### PR TITLE
 runs.run_task now works if the target feature the attribute name 'class' is capitalized.

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -249,6 +249,8 @@ class OpenMLDataset(object):
         dataAttributes = dict(arffData['attributes'])
         if('class' in dataAttributes):
             return dataAttributes['class']
+        elif('Class' in dataAttributes):
+            return dataAttributes['Class']
         else:
             return None
 


### PR DESCRIPTION
The [python example](http://www.openml.org/guide#!python) did work with [task 10](http://www.openml.org/t/10), which had target 'class', but not with [task 14951](http://www.openml.org/t/14951) which had target 'Class'.

This is a quick fix which makes it work, but there still probably should eventually be a way which does not involve re-opening the arff file to read the data and/or a way to mark the attribute as class without needing for exact string matching.