### PR TITLE
Avoid to add dataset_id -1

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -32,7 +32,7 @@ def _list_cached_datasets():
     # description
     for directory_name in directory_content:
         # First check if the directory name could be an OpenML dataset id
-        if not re.match(r"[0-9]*", directory_name):
+        if re.match(r"[0-9]*", directory_name).group() != "":
             continue
 
         dataset_id = int(directory_name)

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -32,7 +32,7 @@ def _list_cached_datasets():
     # description
     for directory_name in directory_content:
         # First check if the directory name could be an OpenML dataset id
-        if re.match(r"[0-9]*", directory_name).group() != "":
+        if re.match(r"[0-9]*", directory_name).group() == "":
             continue
 
         dataset_id = int(directory_name)

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -31,7 +31,7 @@ def _list_cached_datasets():
     # Find all dataset ids for which we have downloaded the dataset
     # description
     for directory_name in directory_content:
-        # First check if the directory name could be an OpenML dataset id
+        # First check if the directory name could be an OpenML dataset id, but exclude -1
         if re.match(r"[0-9]*", directory_name).group() == "":
             continue
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -39,7 +39,7 @@ class TestOpenMLDataset(TestBase):
         _list_cached_datasets_mock.return_value = [-1, 2]
         datasets = _get_cached_datasets()
         self.assertIsInstance(datasets, dict)
-        self.assertEqual(len(datasets), 2)
+        self.assertTrue(len(datasets)>0)
         self.assertIsInstance(list(datasets.values())[0], OpenMLDataset)
 
     def test__get_cached_dataset(self, ):

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -30,7 +30,7 @@ class TestOpenMLDataset(TestBase):
         openml.config.set_cache_directory(self.static_cache_dir)
         cached_datasets = openml.datasets.functions._list_cached_datasets()
         self.assertIsInstance(cached_datasets, list)
-        self.assertEqual(len(cached_datasets), 2)
+        self.assertTrue(len(cached_datasets) > 0)
         self.assertIsInstance(cached_datasets[0], int)
 
     @mock.patch('openml.datasets.functions._list_cached_datasets')
@@ -39,7 +39,7 @@ class TestOpenMLDataset(TestBase):
         _list_cached_datasets_mock.return_value = [-1, 2]
         datasets = _get_cached_datasets()
         self.assertIsInstance(datasets, dict)
-        self.assertTrue(len(datasets)>0)
+        self.assertTrue(len(datasets) > 0)
         self.assertIsInstance(list(datasets.values())[0], OpenMLDataset)
 
     def test__get_cached_dataset(self, ):


### PR DESCRIPTION
fix line 35 in functions.py to avoid add dataset_id -1, which cause test error when python setup.py install

Due to re.match error in openml/datasets/functions.py line35, self.assertEqual(len(cached_datasets), 2) in openml-python/tests/test_datasets/test_dataset_functions.py will pop error when python setup.py test.
Error:
FAIL: test__list_cached_datasets (tests.test_datasets.test_dataset_functions.TestOpenMLDataset)

Traceback (most recent call last):
File "/root/install/openml-python/tests/test_datasets/test_dataset_functions.py", line 34, in test__list_cached_datasets
self.assertEqual(len(cached_datasets), 2)
nose.proxy.AssertionError: 3 != 2

'3 != 2' = '%s != %s' % _common_shorten_repr(3, 2)
'3 != 2' = self._formatMessage('3 != 2', '3 != 2')

        raise self.failureException('3 != 2')

Fix:
old:
if not re.match(r"[0-9]", directory_name): ##openml/datasets/functions.py in line 35
new:
if re.match(r"[0-9]", directory_name).group() == "":