### PR TITLE
Allow list-like objects in Sklearn converter.

### DIFF
--- a/openml/flows/sklearn_converter.py
+++ b/openml/flows/sklearn_converter.py
@@ -39,8 +39,8 @@ def sklearn_to_flow(o, parent_model=None):
     if _is_estimator(o):
         # is the main model or a submodel
         rval = _serialize_model(o)
-    elif inspect.isgeneratorfunction(o) or (isinstance(o, Sequence) and not isinstance(o, str)):
-        # this parameter is a generator, list, range, xrange, or tuple
+    elif inspect.isgeneratorfunction(o) or isinstance(o, (Sequence, np.ndarray)) and not isinstance(o, str):
+        # this parameter is a generator, list, range, xrange, tuple or numpy array
         rval = [sklearn_to_flow(element, parent_model) for element in o]
         if isinstance(o, tuple):
             rval = tuple(rval)

--- a/openml/flows/sklearn_converter.py
+++ b/openml/flows/sklearn_converter.py
@@ -1,6 +1,6 @@
 """Convert scikit-learn estimators into an OpenMLFlows and vice versa."""
 
-from collections import OrderedDict
+from collections import OrderedDict, Sequence
 import copy
 from distutils.version import LooseVersion
 import importlib
@@ -39,8 +39,8 @@ def sklearn_to_flow(o, parent_model=None):
     if _is_estimator(o):
         # is the main model or a submodel
         rval = _serialize_model(o)
-    elif isinstance(o, (list, tuple)):
-        # TODO: explain what type of parameter is here
+    elif inspect.isgeneratorfunction(o) or (isinstance(o, Sequence) and not isinstance(o, str)):
+        # this parameter is a generator, list, range, xrange, or tuple
         rval = [sklearn_to_flow(element, parent_model) for element in o]
         if isinstance(o, tuple):
             rval = tuple(rval)

--- a/openml/flows/sklearn_converter.py
+++ b/openml/flows/sklearn_converter.py
@@ -39,7 +39,7 @@ def sklearn_to_flow(o, parent_model=None):
     if _is_estimator(o):
         # is the main model or a submodel
         rval = _serialize_model(o)
-    elif inspect.isgeneratorfunction(o) or isinstance(o, (Sequence, np.ndarray)) and not isinstance(o, str):
+    elif inspect.isgenerator(o) or isinstance(o, (Sequence, np.ndarray)) and not isinstance(o, str):
         # this parameter is a generator, list, range, xrange, tuple or numpy array
         rval = [sklearn_to_flow(element, parent_model) for element in o]
         if isinstance(o, tuple):

--- a/openml/flows/sklearn_converter.py
+++ b/openml/flows/sklearn_converter.py
@@ -39,14 +39,14 @@ def sklearn_to_flow(o, parent_model=None):
     if _is_estimator(o):
         # is the main model or a submodel
         rval = _serialize_model(o)
-    elif inspect.isgenerator(o) or isinstance(o, (Sequence, np.ndarray)) and not isinstance(o, str):
-        # this parameter is a generator, list, range, xrange, tuple or numpy array
-        rval = [sklearn_to_flow(element, parent_model) for element in o]
-        if isinstance(o, tuple):
-            rval = tuple(rval)
     elif isinstance(o, (bool, int, float, six.string_types)) or o is None:
         # base parameter values
         rval = o
+    elif inspect.isgenerator(o) or isinstance(o, (Sequence, np.ndarray)):
+        # a generator, list, range, tuple or numpy array
+        rval = [sklearn_to_flow(element, parent_model) for element in o]
+        if isinstance(o, tuple):
+            rval = tuple(rval)
     elif isinstance(o, dict):
         # TODO: explain what type of parameter is here
         if not isinstance(o, OrderedDict):

--- a/tests/test_flows/test_sklearn.py
+++ b/tests/test_flows/test_sklearn.py
@@ -652,5 +652,5 @@ class TestSklearn(unittest.TestCase):
             yield "something"
             yield ill_obj
 
-        fixture = "\(.*IllegalObject instance at .*, <type 'instance'>\)"
+        fixture = "\(.*IllegalObject ((instance)|(object)) at .*\)"
         self.assertRaisesRegexp(TypeError, fixture, sklearn_to_flow, yielder())


### PR DESCRIPTION
Rather than checking if an object is a `list` or `tuple`, I think we could also allow generators, ranges and numpy arrays to be iterated over.

The Sequence class covers lists, tuples, ranges and strings. To avoid iterating over strings, the code block is moved below the block that checks for strings. The `np.ndarray` covers the numpy arrays, and `inspect.isgenerator(o)` covers generator objects.