### PR TITLE
Change option to check for parameter names instead of not checking parameters at all

### DIFF
--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -105,7 +105,7 @@ class OpenMLFlow(object):
         keys_parameters = set(parameters.keys())
         keys_parameters_meta_info = set(parameters_meta_info.keys())
         if len(keys_parameters.difference(keys_parameters_meta_info)) > 0:
-            raise ValueError('Parameter %s only in parameters, but not in'
+            raise ValueError('Parameter %s only in parameters, but not in '
                              'parameters_meta_info.' %
                              str(keys_parameters.difference(
                                  keys_parameters_meta_info)))

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -146,7 +146,7 @@ def _check_flow_for_server_id(flow):
 
 
 def assert_flows_equal(flow1, flow2, ignore_parameters_on_older_children=None,
-                       ignore_parameters=False):
+                       ignore_parameter_values=False):
     """Check equality of two flows.
 
     Two flows are equal if their all keys which are not set by the server
@@ -162,7 +162,7 @@ def assert_flows_equal(flow1, flow2, ignore_parameters_on_older_children=None,
         If set to ``OpenMLFlow.upload_date``, ignores parameters in a child
         flow if it's upload date predates the upload date of the parent flow.
 
-    ignore_parameters : bool
+    ignore_parameter_values : bool
         Whether to ignore parameter values when comparing flows.
     """
     if not isinstance(flow1, OpenMLFlow):
@@ -197,7 +197,7 @@ def assert_flows_equal(flow1, flow2, ignore_parameters_on_older_children=None,
                                      'argument2, but not in argument1.' % name)
                 assert_flows_equal(attr1[name], attr2[name],
                                    ignore_parameters_on_older_children,
-                                   ignore_parameters)
+                                   ignore_parameter_values)
 
         else:
             if key == 'parameters':
@@ -208,7 +208,14 @@ def assert_flows_equal(flow1, flow2, ignore_parameters_on_older_children=None,
                         ignore_parameters_on_older_children)
                     if upload_date_current_flow < upload_date_parent_flow:
                         continue
-                elif ignore_parameters:
+                elif ignore_parameter_values:
+                    parameters_flow_1 = set(flow1.parameters.keys())
+                    parameters_flow_2 = set(flow2.parameters.keys())
+                    symmetric_difference = parameters_flow_1 ^ parameters_flow_2
+                    if len(symmetric_difference) > 0:
+                        raise ValueError('Flow %s: parameter set of flow '
+                                         'differs from the parameters stored '
+                                         'on the server.' % flow1.name)
                     continue
 
             if attr1 != attr2:

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -127,7 +127,7 @@ def _publish_flow_if_necessary(flow):
                 server_flow = get_flow(flow_id)
                 openml.flows.flow._copy_server_fields(server_flow, flow)
                 openml.flows.assert_flows_equal(flow, server_flow,
-                                                ignore_parameters=True)
+                                                ignore_parameter_values=True)
             else:
                 raise e
 

--- a/tests/test_flows/test_flow.py
+++ b/tests/test_flows/test_flow.py
@@ -205,7 +205,8 @@ class TestFlow(TestBase):
                   "New flow ID is 1. Please check manually and remove " \
                   "the flow if necessary! Error is:\n" \
                   "'Flow sklearn.ensemble.forest.RandomForestClassifier: values for attribute 'name' differ: " \
-                  "'sklearn.ensemble.forest.RandomForestClassifier' vs 'sklearn.ensemble.forest.RandomForestClassifie'.'"
+                  "'sklearn.ensemble.forest.RandomForestClassifier'" \
+                  "\nvs\n'sklearn.ensemble.forest.RandomForestClassifie'.'"
 
         self.assertEqual(context_manager.exception.args[0], fixture)
         self.assertEqual(api_call_mock.call_count, 2)

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -112,7 +112,7 @@ class TestFlowFunctions(unittest.TestCase):
                           openml.flows.functions.assert_flows_equal,
                           parent_flow, new_flow)
 
-    def test_are_flows_equal_ignore_parameters(self):
+    def test_are_flows_equal_ignore_parameter_values(self):
         paramaters = OrderedDict((('a', 5), ('b', 6)))
         parameters_meta_info = OrderedDict((('a', None), ('b', None)))
 
@@ -137,7 +137,7 @@ class TestFlowFunctions(unittest.TestCase):
         new_flow.parameters['a'] = 7
         self.assertRaisesRegexp(ValueError, "values for attribute 'parameters' "
                                             "differ: 'OrderedDict\(\[\('a', "
-                                            "5\), \('b', 6\)\]\)' vs "
+                                            "5\), \('b', 6\)\]\)'\nvs\n"
                                             "'OrderedDict\(\[\('a', 7\), "
                                             "\('b', 6\)\]\)'",
                                 openml.flows.functions.assert_flows_equal,
@@ -148,7 +148,7 @@ class TestFlowFunctions(unittest.TestCase):
         del new_flow.parameters['a']
         self.assertRaisesRegexp(ValueError, "values for attribute 'parameters' "
                                             "differ: 'OrderedDict\(\[\('a', "
-                                            "5\), \('b', 6\)\]\)' vs "
+                                            "5\), \('b', 6\)\]\)'\nvs\n"
                                             "'OrderedDict\(\[\('b', 6\)\]\)'",
                                 openml.flows.functions.assert_flows_equal,
                                 flow, new_flow)
@@ -157,3 +157,39 @@ class TestFlowFunctions(unittest.TestCase):
                                             "on the server.",
                                 openml.flows.functions.assert_flows_equal,
                                 flow, new_flow, ignore_parameter_values=True)
+
+    def test_are_flows_equal_ignore_if_older(self):
+        paramaters = OrderedDict((('a', 5), ('b', 6)))
+        parameters_meta_info = OrderedDict((('a', None), ('b', None)))
+
+        flow = openml.flows.OpenMLFlow(name='Test',
+                                       description='Test flow',
+                                       model=None,
+                                       components=OrderedDict(),
+                                       parameters=paramaters,
+                                       parameters_meta_info=parameters_meta_info,
+                                       external_version='1',
+                                       tags=['abc', 'def'],
+                                       language='English',
+                                       dependencies='abc',
+                                       class_name='Test',
+                                       custom_name='Test',
+                                       upload_date='2017-01-31T12-01-01')
+
+        openml.flows.functions.assert_flows_equal(flow, flow,
+                                                  ignore_parameter_values_on_older_children='2017-01-31T12-01-01')
+        openml.flows.functions.assert_flows_equal(flow, flow,
+                                                  ignore_parameter_values_on_older_children=None)
+        new_flow = copy.deepcopy(flow)
+        new_flow.parameters['a'] = 7
+        self.assertRaises(ValueError, openml.flows.functions.assert_flows_equal,
+                          flow, new_flow, ignore_parameter_values_on_older_children='2017-01-31T12-01-01')
+        self.assertRaises(ValueError, openml.flows.functions.assert_flows_equal,
+                          flow, new_flow, ignore_parameter_values_on_older_children=None)
+
+        new_flow.upload_date = '2016-01-31T12-01-01'
+        self.assertRaises(ValueError, openml.flows.functions.assert_flows_equal,
+                          flow, new_flow,
+                          ignore_parameter_values_on_older_children='2017-01-31T12-01-01')
+        openml.flows.functions.assert_flows_equal(flow, flow,
+                                                  ignore_parameter_values_on_older_children=None)

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -111,3 +111,49 @@ class TestFlowFunctions(unittest.TestCase):
         self.assertRaises(ValueError,
                           openml.flows.functions.assert_flows_equal,
                           parent_flow, new_flow)
+
+    def test_are_flows_equal_ignore_parameters(self):
+        paramaters = OrderedDict((('a', 5), ('b', 6)))
+        parameters_meta_info = OrderedDict((('a', None), ('b', None)))
+
+        flow = openml.flows.OpenMLFlow(name='Test',
+                                       description='Test flow',
+                                       model=None,
+                                       components=OrderedDict(),
+                                       parameters=paramaters,
+                                       parameters_meta_info=parameters_meta_info,
+                                       external_version='1',
+                                       tags=['abc', 'def'],
+                                       language='English',
+                                       dependencies='abc',
+                                       class_name='Test',
+                                       custom_name='Test')
+
+        openml.flows.functions.assert_flows_equal(flow, flow)
+        openml.flows.functions.assert_flows_equal(flow, flow,
+                                                  ignore_parameter_values=True)
+
+        new_flow = copy.deepcopy(flow)
+        new_flow.parameters['a'] = 7
+        self.assertRaisesRegexp(ValueError, "values for attribute 'parameters' "
+                                            "differ: 'OrderedDict\(\[\('a', "
+                                            "5\), \('b', 6\)\]\)' vs "
+                                            "'OrderedDict\(\[\('a', 7\), "
+                                            "\('b', 6\)\]\)'",
+                                openml.flows.functions.assert_flows_equal,
+                                flow, new_flow)
+        openml.flows.functions.assert_flows_equal(flow, new_flow,
+                                                  ignore_parameter_values=True)
+
+        del new_flow.parameters['a']
+        self.assertRaisesRegexp(ValueError, "values for attribute 'parameters' "
+                                            "differ: 'OrderedDict\(\[\('a', "
+                                            "5\), \('b', 6\)\]\)' vs "
+                                            "'OrderedDict\(\[\('b', 6\)\]\)'",
+                                openml.flows.functions.assert_flows_equal,
+                                flow, new_flow)
+        self.assertRaisesRegexp(ValueError, "Flow Test: parameter set of flow "
+                                            "differs from the parameters stored "
+                                            "on the server.",
+                                openml.flows.functions.assert_flows_equal,
+                                flow, new_flow, ignore_parameter_values=True)

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -67,7 +67,7 @@ class TestRun(TestBase):
         try:
             model_prime = openml.runs.initialize_model_from_trace(run_id, 0, 0)
         except openml.exceptions.OpenMLServerException as e:
-            e.additional += '; run_id: ' + str(run_id)
+            e.additional = str(e.additional) + '; run_id: ' + str(run_id)
             raise e
         
         run_prime = openml.runs.run_model_on_task(task, model_prime,

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -67,7 +67,7 @@ class TestRun(TestBase):
         try:
             model_prime = openml.runs.initialize_model_from_trace(run_id, 0, 0)
         except openml.exceptions.OpenMLServerException as e:
-            e.additional += '; run_id: ' + run_id
+            e.additional += '; run_id: ' + str(run_id)
             raise e
         
         run_prime = openml.runs.run_model_on_task(task, model_prime,


### PR DESCRIPTION
Changes the flag `ignore_parameters` to `ignore_parameter_values` and change the behavior such that parameter names are compared instead of not comparing the parameters at all. Important to check that a flow is stored correctly on the server (while the hyperparameters are allowed to differ).