### PR TITLE
Add unit test for loading non-sklearn flows, fixes #218

### DIFF
--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -677,10 +677,18 @@ def _create_run_from_xml(xml):
                          'description XML' % run_id)
 
     if 'predictions' not in files:
-        # JvR: actually, I am not sure whether this error should be raised.
-        # a run can consist without predictions. But for now let's keep it
-        raise ValueError('No prediction files for run %d in run '
-                         'description XML' % run_id)
+        task = openml.tasks.get_task(task_id)
+        if task.task_type_id == 8:
+            raise NotImplementedError(
+                'Subgroup discovery tasks are not yet supported.'
+            )
+        else:
+            # JvR: actually, I am not sure whether this error should be raised.
+            # a run can consist without predictions. But for now let's keep it
+            # Matthias: yes, it should stay as long as we do not really handle
+            # this stuff
+            raise ValueError('No prediction files for run %d in run '
+                             'description XML' % run_id)
 
     tags = openml.utils.extract_xml_tags('oml:tag', run)
 

--- a/tests/test_flows/test_flow.py
+++ b/tests/test_flows/test_flow.py
@@ -348,3 +348,29 @@ class TestFlow(TestBase):
         flow_dict = xmltodict.parse(flow_xml)
         tags = openml.utils.extract_xml_tags('oml:tag', flow_dict['oml:flow'])
         self.assertEqual(tags, ['OpenmlWeka', 'weka'])
+
+    def test_download_non_scikit_learn_flows(self):
+        openml.config.server = self.production_server
+
+        flow = openml.flows.get_flow(6742)
+        self.assertIsInstance(flow, openml.OpenMLFlow)
+        self.assertEqual(flow.flow_id, 6742)
+        self.assertEqual(len(flow.parameters), 19)
+        self.assertEqual(len(flow.components), 1)
+        self.assertIsNone(flow.model)
+
+        subflow_1 = list(flow.components.values())[0]
+        self.assertIsInstance(subflow_1, openml.OpenMLFlow)
+        self.assertEqual(subflow_1.flow_id, 6743)
+        self.assertEqual(len(subflow_1.parameters), 8)
+        self.assertEqual(subflow_1.parameters['U'], '0')
+        self.assertEqual(len(subflow_1.components), 1)
+        self.assertIsNone(subflow_1.model)
+
+        subflow_2 = list(subflow_1.components.values())[0]
+        self.assertIsInstance(subflow_2, openml.OpenMLFlow)
+        self.assertEqual(subflow_2.flow_id, 5888)
+        self.assertEqual(len(subflow_2.parameters), 4)
+        self.assertIsNone(subflow_2.parameters['batch-size'])
+        self.assertEqual(len(subflow_2.components), 0)
+        self.assertIsNone(subflow_2.model)


### PR DESCRIPTION
Issue #218 was actually fixed in #253, however, #253 didn't add a unit test. This PR adds the missing unit test.