### PR TITLE
Fix #334: always create a list of tasks from the tasks API call, even if there is just a single task

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -179,7 +179,7 @@ def list_datasets(offset=None, size=None, tag=None):
 def _list_datasets(api_call):
     # TODO add proper error handling here!
     xml_string = _perform_api_call(api_call)
-    datasets_dict = xmltodict.parse(xml_string)
+    datasets_dict = xmltodict.parse(xml_string, force_list=('oml:dataset',))
 
     # Minimalistic check if the XML is useful
     assert type(datasets_dict['oml:data']['oml:dataset']) == list, \
@@ -416,7 +416,7 @@ def _get_dataset_features(did_cache_dir, dataset_id):
         with io.open(features_file, "w", encoding='utf8') as fh:
             fh.write(features_xml)
 
-    features = xmltodict.parse(features_xml)["oml:data_features"]
+    features = xmltodict.parse(features_xml, force_list=('oml:feature',))["oml:data_features"]
 
     return features
 
@@ -452,7 +452,7 @@ def _get_dataset_qualities(did_cache_dir, dataset_id):
         with io.open(qualities_file, "w", encoding='utf8') as fh:
             fh.write(qualities_xml)
 
-    qualities = xmltodict.parse(qualities_xml)['oml:data_qualities']
+    qualities = xmltodict.parse(qualities_xml, force_list=('oml:quality',))['oml:data_qualities']
 
     return qualities
 

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -61,21 +61,17 @@ def _list_evaluations(api_call):
 
     xml_string = _perform_api_call(api_call)
 
-    evals_dict = xmltodict.parse(xml_string)
+    evals_dict = xmltodict.parse(xml_string, force_list=('oml:evaluation',))
     # Minimalistic check if the XML is useful
     if 'oml:evaluations' not in evals_dict:
         raise ValueError('Error in return XML, does not contain "oml:evaluations": %s'
                          % str(evals_dict))
 
-    if isinstance(evals_dict['oml:evaluations']['oml:evaluation'], list):
-        evals_list = evals_dict['oml:evaluations']['oml:evaluation']
-    elif isinstance(evals_dict['oml:evaluations']['oml:evaluation'], dict):
-        evals_list = [evals_dict['oml:evaluations']['oml:evaluation']]
-    else:
-        raise TypeError()
+    assert type(evals_dict['oml:evaluations']['oml:evaluation']) == list, \
+        type(evals_dict['oml:evaluations'])
 
     evals = dict()
-    for eval_ in evals_list:
+    for eval_ in evals_dict['oml:evaluations']['oml:evaluation']:
         run_id = int(eval_['oml:run_id'])
         array_data = None
         if 'oml:array_data' in eval_:

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -107,7 +107,7 @@ def flow_exists(name, external_version):
 def _list_flows(api_call):
     # TODO add proper error handling here!
     xml_string = _perform_api_call(api_call)
-    flows_dict = xmltodict.parse(xml_string)
+    flows_dict = xmltodict.parse(xml_string, force_list=('oml:flow',))
 
     # Minimalistic check if the XML is useful
     assert type(flows_dict['oml:flows']['oml:flow']) == list, \

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -699,13 +699,16 @@ def _create_run_from_xml(xml):
 
 
 def _create_trace_from_description(xml):
-    result_dict = xmltodict.parse(xml)['oml:trace']
+    result_dict = xmltodict.parse(xml, force_list=('oml:trace_iteration',))['oml:trace']
 
     run_id = result_dict['oml:run_id']
     trace = dict()
 
     if 'oml:trace_iteration' not in result_dict:
         raise ValueError('Run does not contain valid trace. ')
+
+    assert type(result_dict['oml:trace_iteration']) == list, \
+        type(result_dict['oml:trace_iteration'])
 
     for itt in result_dict['oml:trace_iteration']:
         repeat = int(itt['oml:repeat'])

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -854,7 +854,7 @@ def _list_runs(api_call):
 
     xml_string = _perform_api_call(api_call)
 
-    runs_dict = xmltodict.parse(xml_string)
+    runs_dict = xmltodict.parse(xml_string, force_list=('oml:run',))
     # Minimalistic check if the XML is useful
     if 'oml:runs' not in runs_dict:
         raise ValueError('Error in return XML, does not contain "oml:runs": %s'
@@ -869,15 +869,11 @@ def _list_runs(api_call):
                          '"http://openml.org/openml": %s'
                          % str(runs_dict))
 
-    if isinstance(runs_dict['oml:runs']['oml:run'], list):
-        runs_list = runs_dict['oml:runs']['oml:run']
-    elif isinstance(runs_dict['oml:runs']['oml:run'], dict):
-        runs_list = [runs_dict['oml:runs']['oml:run']]
-    else:
-        raise TypeError()
+    assert type(runs_dict['oml:runs']['oml:run']) == list, \
+        type(runs_dict['oml:runs'])
 
     runs = dict()
-    for run_ in runs_list:
+    for run_ in runs_dict['oml:runs']['oml:run']:
         run_id = int(run_['oml:run_id'])
         run = {'run_id': run_id,
                'task_id': int(run_['oml:task_id']),

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -116,7 +116,7 @@ def _list_setups(api_call):
 
     xml_string = openml._api_calls._perform_api_call(api_call)
 
-    setups_dict = xmltodict.parse(xml_string)
+    setups_dict = xmltodict.parse(xml_string, force_list=('oml:setup',))
     # Minimalistic check if the XML is useful
     if 'oml:setups' not in setups_dict:
         raise ValueError('Error in return XML, does not contain "oml:setups": %s'
@@ -131,15 +131,11 @@ def _list_setups(api_call):
                          '"http://openml.org/openml": %s'
                          % str(setups_dict))
 
-    if isinstance(setups_dict['oml:setups']['oml:setup'], list):
-        setups_list = setups_dict['oml:setups']['oml:setup']
-    elif isinstance(setups_dict['oml:setups']['oml:setup'], dict):
-        setups_list = [setups_dict['oml:setups']['oml:setup']]
-    else:
-        raise TypeError()
+    assert type(setups_dict['oml:setups']['oml:setup']) == list, \
+        type(setups_dict['oml:setups'])
 
     setups = dict()
-    for setup_ in setups_list:
+    for setup_ in setups_dict['oml:setups']['oml:setup']:
         # making it a dict to give it the right format
         current = _create_setup_from_xml({'oml:setup_parameters': setup_})
         setups[current.setup_id] = current

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -128,7 +128,7 @@ def list_tasks(task_type_id=None, offset=None, size=None, tag=None):
 
 def _list_tasks(api_call):
     xml_string = _perform_api_call(api_call)
-    tasks_dict = xmltodict.parse(xml_string)
+    tasks_dict = xmltodict.parse(xml_string, force_list=('oml:task',))
     # Minimalistic check if the XML is useful
     if 'oml:tasks' not in tasks_dict:
         raise ValueError('Error in return XML, does not contain "oml:runs": %s'
@@ -142,6 +142,9 @@ def _list_tasks(api_call):
                          '"oml:runs"/@xmlns:oml is not '
                          '"http://openml.org/openml": %s'
                          % str(tasks_dict))
+
+    assert type(tasks_dict['oml:tasks']['oml:task']) == list, \
+        type(tasks_dict['oml:tasks'])
 
     tasks = dict()
     procs = _get_estimation_procedure_list()


### PR DESCRIPTION
Original pull request can be found at https://github.com/openml/openml-python/pull/335. It was discarded due to some unintended mixing-up of different branches :-).