### PR TITLE
Fix/#392

### DIFF
--- a/examples/OpenML_Tutorial.ipynb
+++ b/examples/OpenML_Tutorial.ipynb
@@ -23,12 +23,18 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
-    "# Install OpenML (developer version)\n",
-    "# 'pip install openml' coming up (october 2017) \n",
-    "pip install git+https://github.com/openml/openml-python.git@develop"
+    "# Installation\n",
+    "\n",
+    "* Up to now: `pip install git+https://github.com/openml/openml-python.git@develop`\n",
+    "* In the future: `pip install openml`\n",
+    "* Check out the installation guide: [https://openml.github.io/openml-python/stable/#installation](https://openml.github.io/openml-python/stable/#installation)"
    ]
   },
   {
@@ -1547,7 +1553,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -13,7 +13,7 @@ import xmltodict
 
 from .data_feature import OpenMLDataFeature
 from ..exceptions import PyOpenMLError
-from .._api_calls import _perform_api_call
+import openml._api_calls
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +135,7 @@ class OpenMLDataset(object):
             Tag to attach to the dataset.
         """
         data = {'data_id': self.dataset_id, 'tag': tag}
-        _perform_api_call("/data/tag", data=data)
+        openml._api_calls._perform_api_call("/data/tag", data=data)
 
     def remove_tag(self, tag):
         """Removes a tag from this dataset on the server.
@@ -146,7 +146,7 @@ class OpenMLDataset(object):
             Tag to attach to the dataset.
         """
         data = {'data_id': self.dataset_id, 'tag': tag}
-        _perform_api_call("/data/untag", data=data)
+        openml._api_calls._perform_api_call("/data/untag", data=data)
 
     def __eq__(self, other):
         if type(other) != OpenMLDataset:
@@ -432,8 +432,11 @@ class OpenMLDataset(object):
         if self.data_file is not None:
             file_dictionary['dataset'] = self.data_file
 
-        return_value = _perform_api_call("/data/", file_dictionary=file_dictionary,
-                                         file_elements=file_elements)
+        return_value = openml._api_calls._perform_api_call(
+            "/data/",
+            file_dictionary=file_dictionary,
+            file_elements=file_elements,
+        )
 
         self.dataset_id = int(xmltodict.parse(return_value)['oml:upload_data_set']['oml:id'])
         return self

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -9,11 +9,12 @@ from oslo_concurrency import lockutils
 import xmltodict
 
 import openml.utils
+import openml._api_calls
 from .dataset import OpenMLDataset
 from ..exceptions import OpenMLCacheException, OpenMLServerNoResult, \
     OpenMLHashException
 from .. import config
-from .._api_calls import _perform_api_call, _read_url
+from .._api_calls import _read_url
 
 
 ############################################################################
@@ -206,7 +207,7 @@ def _list_datasets(**kwargs):
 
 def __list_datasets(api_call):
 
-    xml_string = _perform_api_call(api_call)
+    xml_string = openml._api_calls._perform_api_call(api_call)
     datasets_dict = xmltodict.parse(xml_string, force_list=('oml:dataset',))
 
     # Minimalistic check if the XML is useful
@@ -357,7 +358,7 @@ def _get_dataset_description(did_cache_dir, dataset_id):
     try:
         return _get_cached_dataset_description(dataset_id)
     except (OpenMLCacheException):
-        dataset_xml = _perform_api_call("data/%d" % dataset_id)
+        dataset_xml = openml._api_calls._perform_api_call("data/%d" % dataset_id)
 
         with io.open(description_file, "w", encoding='utf8') as fh:
             fh.write(dataset_xml)
@@ -450,7 +451,7 @@ def _get_dataset_features(did_cache_dir, dataset_id):
         with io.open(features_file, encoding='utf8') as fh:
             features_xml = fh.read()
     except (OSError, IOError):
-        features_xml = _perform_api_call("data/features/%d" % dataset_id)
+        features_xml = openml._api_calls._perform_api_call("data/features/%d" % dataset_id)
 
         with io.open(features_file, "w", encoding='utf8') as fh:
             fh.write(features_xml)
@@ -486,7 +487,7 @@ def _get_dataset_qualities(did_cache_dir, dataset_id):
         with io.open(qualities_file, encoding='utf8') as fh:
             qualities_xml = fh.read()
     except (OSError, IOError):
-        qualities_xml = _perform_api_call("data/qualities/%d" % dataset_id)
+        qualities_xml = openml._api_calls._perform_api_call("data/qualities/%d" % dataset_id)
 
         with io.open(qualities_file, "w", encoding='utf8') as fh:
             fh.write(qualities_xml)

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -2,7 +2,7 @@ import xmltodict
 
 from openml.exceptions import OpenMLServerNoResult
 import openml.utils
-from .._api_calls import _perform_api_call
+import openml._api_calls
 from ..evaluations import OpenMLEvaluation
 
 
@@ -93,7 +93,7 @@ def _list_evaluations(function, id=None, task=None,
 
 def __list_evaluations(api_call):
     """Helper function to parse API calls which are lists of runs"""
-    xml_string = _perform_api_call(api_call)
+    xml_string = openml._api_calls._perform_api_call(api_call)
     evals_dict = xmltodict.parse(xml_string, force_list=('oml:evaluation',))
     # Minimalistic check if the XML is useful
     if 'oml:evaluations' not in evals_dict:

--- a/openml/exceptions.py
+++ b/openml/exceptions.py
@@ -25,6 +25,10 @@ class OpenMLServerException(OpenMLServerError):
         self.url = url
         super(OpenMLServerException, self).__init__(message)
 
+    def __str__(self):
+        return '%s returned code %s: %s' % (
+            self.url, self.code, self.message,
+        )
 
 class OpenMLServerNoResult(OpenMLServerException):
     """exception for when the result of the server is empty. """

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import six
 import xmltodict
 
-from .._api_calls import _perform_api_call
+import openml._api_calls
 from ..utils import extract_xml_tags
 
 
@@ -341,7 +341,10 @@ class OpenMLFlow(object):
         xml_description = self._to_xml()
 
         file_elements = {'description': xml_description}
-        return_value = _perform_api_call("flow/", file_elements=file_elements)
+        return_value = openml._api_calls._perform_api_call(
+            "flow/",
+            file_elements=file_elements,
+        )
         flow_id = int(xmltodict.parse(return_value)['oml:upload_flow']['oml:id'])
         flow = openml.flows.functions.get_flow(flow_id)
         _copy_server_fields(flow, self)
@@ -364,7 +367,7 @@ class OpenMLFlow(object):
             Tag to attach to the flow.
         """
         data = {'flow_id': self.flow_id, 'tag': tag}
-        _perform_api_call("/flow/tag", data=data)
+        openml._api_calls._perform_api_call("/flow/tag", data=data)
 
     def remove_tag(self, tag):
         """Removes a tag from this flow on the server.
@@ -375,7 +378,7 @@ class OpenMLFlow(object):
             Tag to attach to the flow.
         """
         data = {'flow_id': self.flow_id, 'tag': tag}
-        _perform_api_call("/flow/untag", data=data)
+        openml._api_calls._perform_api_call("/flow/untag", data=data)
 
 
 def _copy_server_fields(source_flow, target_flow):

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -3,8 +3,7 @@ import dateutil.parser
 import xmltodict
 import six
 
-from openml._api_calls import _perform_api_call
-from openml.exceptions import OpenMLServerNoResult
+import openml._api_calls
 from . import OpenMLFlow
 import openml.utils
 
@@ -23,7 +22,7 @@ def get_flow(flow_id):
     except:
         raise ValueError("Flow ID must be an int, got %s." % str(flow_id))
 
-    flow_xml = _perform_api_call("flow/%d" % flow_id)
+    flow_xml = openml._api_calls._perform_api_call("flow/%d" % flow_id)
 
     flow_dict = xmltodict.parse(flow_xml)
     flow = OpenMLFlow._from_dict(flow_dict)
@@ -114,9 +113,10 @@ def flow_exists(name, external_version):
     if not (isinstance(name, six.string_types) and len(external_version) > 0):
         raise ValueError('Argument \'version\' should be a non-empty string')
 
-    xml_response = _perform_api_call(
-        "flow/exists", data={'name': name, 'external_version':
-                             external_version})
+    xml_response = openml._api_calls._perform_api_call(
+        "flow/exists",
+        data={'name': name, 'external_version': external_version},
+    )
 
     result_dict = xmltodict.parse(xml_response)
     flow_id = int(result_dict['oml:flow_exists']['oml:id'])
@@ -128,7 +128,7 @@ def flow_exists(name, external_version):
 
 def __list_flows(api_call):
 
-    xml_string = _perform_api_call(api_call)
+    xml_string = openml._api_calls._perform_api_call(api_call)
     flows_dict = xmltodict.parse(xml_string, force_list=('oml:flow',))
 
     # Minimalistic check if the XML is useful

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -14,13 +14,13 @@ import sklearn.metrics
 
 import openml
 import openml.utils
+import openml._api_calls
 from ..exceptions import PyOpenMLError, OpenMLServerNoResult
 from .. import config
 from ..flows import sklearn_to_flow, get_flow, flow_exists, _check_n_jobs, \
     _copy_server_fields
 from ..setups import setup_exists, initialize_model
 from ..exceptions import OpenMLCacheException, OpenMLServerException
-from .._api_calls import _perform_api_call
 from .run import OpenMLRun, _get_version_information
 from .trace import OpenMLRunTrace, OpenMLTraceIteration
 
@@ -150,7 +150,7 @@ def get_run_trace(run_id):
      openml.runs.OpenMLTrace
     """
 
-    trace_xml = _perform_api_call('run/trace/%d' % run_id)
+    trace_xml = openml._api_calls._perform_api_call('run/trace/%d' % run_id)
     run_trace = _create_trace_from_description(trace_xml)
     return run_trace
 
@@ -653,7 +653,7 @@ def get_run(run_id):
         return _get_cached_run(run_id)
 
     except (OpenMLCacheException):
-        run_xml = _perform_api_call("run/%d" % run_id)
+        run_xml = openml._api_calls._perform_api_call("run/%d" % run_id)
         with io.open(run_file, "w", encoding='utf8') as fh:
             fh.write(run_xml)
 
@@ -992,7 +992,7 @@ def _list_runs(id=None, task=None, setup=None,
 
 def __list_runs(api_call):
     """Helper function to parse API calls which are lists of runs"""
-    xml_string = _perform_api_call(api_call)
+    xml_string = openml._api_calls._perform_api_call(api_call)
     runs_dict = xmltodict.parse(xml_string, force_list=('oml:run',))
     # Minimalistic check if the XML is useful
     if 'oml:runs' not in runs_dict:

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -8,8 +8,9 @@ import arff
 import xmltodict
 
 import openml
+import openml._api_calls
 from ..tasks import get_task
-from .._api_calls import _perform_api_call, _file_id_to_url
+from .._api_calls import _file_id_to_url
 from ..exceptions import PyOpenMLError
 
 
@@ -234,7 +235,7 @@ class OpenMLRun(object):
             trace_arff = arff.dumps(self._generate_trace_arff_dict())
             file_elements['trace'] = ("trace.arff", trace_arff)
 
-        return_value = _perform_api_call("/run/", file_elements=file_elements)
+        return_value = openml._api_calls._perform_api_call("/run/", file_elements=file_elements)
         run_id = int(xmltodict.parse(return_value)['oml:upload_run']['oml:run_id'])
         self.run_id = run_id
         return self
@@ -370,7 +371,7 @@ class OpenMLRun(object):
             Tag to attach to the run.
         """
         data = {'run_id': self.run_id, 'tag': tag}
-        _perform_api_call("/run/tag", data=data)
+        openml._api_calls._perform_api_call("/run/tag", data=data)
 
     def remove_tag(self, tag):
         """Removes a tag from this run on the server.
@@ -381,7 +382,7 @@ class OpenMLRun(object):
             Tag to attach to the run.
         """
         data = {'run_id': self.run_id, 'tag': tag}
-        _perform_api_call("/run/untag", data=data)
+        openml._api_calls._perform_api_call("/run/untag", data=data)
 
 
 ################################################################################

--- a/openml/study/functions.py
+++ b/openml/study/functions.py
@@ -1,7 +1,7 @@
 import xmltodict
 
 from openml.study import OpenMLStudy
-from .._api_calls import _perform_api_call
+import openml._api_calls
 
 
 def _multitag_to_list(result_dict, tag):
@@ -22,7 +22,7 @@ def get_study(study_id, type=None):
     call_suffix = "study/%s" %str(study_id)
     if type is not None:
         call_suffix += "/" + type
-    xml_string = _perform_api_call(call_suffix)
+    xml_string = openml._api_calls._perform_api_call(call_suffix)
     result_dict = xmltodict.parse(xml_string)['oml:study']
     id = int(result_dict['oml:id'])
     name = result_dict['oml:name']

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -11,8 +11,8 @@ from ..exceptions import OpenMLCacheException, OpenMLServerNoResult
 from ..datasets import get_dataset
 from .task import OpenMLTask, _create_task_cache_dir
 from .. import config
-from .._api_calls import _perform_api_call
 import openml.utils
+import openml._api_calls
 
 def _get_cached_tasks():
     tasks = OrderedDict()
@@ -60,7 +60,7 @@ def _get_estimation_procedure_list():
         name, type, repeats, folds, stratified.
     """
 
-    xml_string = _perform_api_call("estimationprocedure/list")
+    xml_string = openml._api_calls._perform_api_call("estimationprocedure/list")
     procs_dict = xmltodict.parse(xml_string)
     # Minimalistic check if the XML is useful
     if 'oml:estimationprocedures' not in procs_dict:
@@ -175,7 +175,7 @@ def _list_tasks(task_type_id=None, **kwargs):
 
 def __list_tasks(api_call):
 
-    xml_string = _perform_api_call(api_call)
+    xml_string = openml._api_calls._perform_api_call(api_call)
     tasks_dict = xmltodict.parse(xml_string, force_list=('oml:task', 'oml:input'))
     # Minimalistic check if the XML is useful
     if 'oml:tasks' not in tasks_dict:
@@ -301,7 +301,7 @@ def _get_task_description(task_id):
         return _get_cached_task(task_id)
     except OpenMLCacheException:
         xml_file = os.path.join(_create_task_cache_dir(task_id), "task.xml")
-        task_xml = _perform_api_call("task/%d" % task_id)
+        task_xml = openml._api_calls._perform_api_call("task/%d" % task_id)
 
         with io.open(xml_file, "w", encoding='utf8') as fh:
             fh.write(task_xml)

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -4,7 +4,8 @@ import os
 from .. import config
 from .. import datasets
 from .split import OpenMLSplit
-from .._api_calls import _read_url, _perform_api_call
+from .._api_calls import _read_url
+import openml._api_calls
 
 
 class OpenMLTask(object):
@@ -101,7 +102,7 @@ class OpenMLTask(object):
             Tag to attach to the task.
         """
         data = {'task_id': self.task_id, 'tag': tag}
-        _perform_api_call("/task/tag", data=data)
+        openml._api_calls._perform_api_call("/task/tag", data=data)
 
     def remove_tag(self, tag):
         """Removes a tag from this task on the server.
@@ -112,7 +113,7 @@ class OpenMLTask(object):
             Tag to attach to the task.
         """
         data = {'task_id': self.task_id, 'tag': tag}
-        _perform_api_call("/task/untag", data=data)
+        openml._api_calls._perform_api_call("/task/untag", data=data)
 
 
 def _create_task_cache_dir(task_id):

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -1,6 +1,6 @@
 import xmltodict
 import six
-from ._api_calls import _perform_api_call
+import openml._api_calls
 
 from openml.exceptions import OpenMLServerException
 
@@ -79,7 +79,7 @@ def _tag_entity(entity_type, entity_id, tag, untag=False):
 
 
     post_variables = {'%s_id'%entity_type: entity_id, 'tag': tag}
-    result_xml = _perform_api_call(uri, post_variables)
+    result_xml = openml._api_calls._perform_api_call(uri, post_variables)
 
     result = xmltodict.parse(result_xml, force_list={'oml:tag'})[main_tag]
 

--- a/tests/test_examples/test_OpenMLDemo.py
+++ b/tests/test_examples/test_OpenMLDemo.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import sys
 
+import matplotlib
+matplotlib.use('AGG')
 import nbformat
 from nbconvert.exporters import export
 from nbconvert.exporters.python import PythonExporter

--- a/tests/test_examples/test_OpenMLDemo.py
+++ b/tests/test_examples/test_OpenMLDemo.py
@@ -2,10 +2,14 @@ import os
 import shutil
 import sys
 
+from IPython import get_ipython
 import nbformat
+from nbconvert.exporters import export
+from nbconvert.exporters.python import PythonExporter
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
 
+import openml.config
 from openml.testing import TestBase
 
 
@@ -29,29 +33,25 @@ class OpenMLDemoTest(TestBase):
         except:
             pass
 
-    def _test_notebook(self, notebook_name):
+    def _tst_notebook(self, notebook_name):
 
         notebook_filename = os.path.abspath(os.path.join(
             self.this_file_directory, '..', '..', 'examples', notebook_name))
-        notebook_filename_out = os.path.join(
-            self.notebook_output_directory, notebook_name)
 
         with open(notebook_filename) as f:
             nb = nbformat.read(f, as_version=4)
-            nb.metadata.get('kernelspec', {})['name'] = self.kernel_name
-            ep = ExecutePreprocessor(kernel_name=self.kernel_name)
-            ep.timeout = 60
 
-            try:
-                ep.preprocess(nb, {'metadata': {'path': self.this_file_directory}})
-            except CellExecutionError as e:
-                msg = 'Error executing the notebook "%s". ' % notebook_filename
-                msg += 'See notebook "%s" for the traceback.\n\n' % notebook_filename_out
-                msg += e.traceback
-                self.fail(msg)
-            finally:
-                with open(notebook_filename_out, mode='wt') as f:
-                    nbformat.write(nb, f)
+        python_nb, metadata = export(PythonExporter, nb)
+
+        # Remove magic lines manually
+        python_nb = '\n'.join([
+            line for line in python_nb.split('\n')
+            if 'get_ipython().run_line_magic(' not in line
+        ])
+        print(type(python_nb), python_nb)
+
+        exec(python_nb)
 
     def test_tutorial(self):
-        self._test_notebook('OpenML_Tutorial.ipynb')
+        openml.config.server = self.production_server
+        self._tst_notebook('OpenML_Tutorial.ipynb')

--- a/tests/test_flows/test_flow.py
+++ b/tests/test_flows/test_flow.py
@@ -197,7 +197,7 @@ class TestFlow(TestBase):
         flow.publish()
 
     @mock.patch('openml.flows.functions.get_flow')
-    @mock.patch('openml.flows.flow._perform_api_call')
+    @mock.patch('openml._api_calls._perform_api_call')
     def test_publish_error(self, api_call_mock, get_flow_mock):
         model = sklearn.ensemble.RandomForestClassifier()
         flow = openml.flows.sklearn_to_flow(model)


### PR DESCRIPTION
Do not upload runs to the production server any more when running unit tests. Mocks out the calls to the api and simply claims the run was uploaded with an ID of 1.