### PR TITLE
Fix unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 doc/generated
 examples/.ipynb_checkpoints
 # Byte-compiled / optimized / DLL files

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -231,26 +231,28 @@ def _run_exists(task_id, setup_id):
     Parameters
     ----------
     task_id: int
+
     setup_id: int
 
     Returns
     -------
-        List of run ids iff these already exists on the server, False otherwise
+        Set run ids for runs where flow setup_id was run on task_id. Empty
+        set if it wasn't run yet.
     """
     if setup_id <= 0:
         # openml setups are in range 1-inf
-        return False
+        return set()
 
     try:
         result = list_runs(task=[task_id], setup=[setup_id])
         if len(result) > 0:
             return set(result.keys())
         else:
-            return False
+            return set()
     except OpenMLServerException as exception:
         # error code 512 implies no results. This means the run does not exist yet
         assert(exception.code == 512)
-        return False
+        return set()
 
 
 def _get_seeded_model(model, seed=None):

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -47,7 +47,6 @@ def setup_exists(flow, model=None):
     description = xmltodict.unparse(_to_dict(flow.flow_id,
                                              openml_param_settings),
                                     pretty=True)
-    print(description)
     file_elements = {'description': ('description.arff', description)}
 
     result = openml._api_calls._perform_api_call('/setup/exists/',

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -47,6 +47,7 @@ def setup_exists(flow, model=None):
     description = xmltodict.unparse(_to_dict(flow.flow_id,
                                              openml_param_settings),
                                     pretty=True)
+    print(description)
     file_elements = {'description': ('description.arff', description)}
 
     result = openml._api_calls._perform_api_call('/setup/exists/',

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -527,10 +527,13 @@ class TestRun(TestBase):
             flow = openml.flows.sklearn_to_flow(clf)
             flow_exists = openml.flows.flow_exists(flow.name, flow.external_version)
             self.assertIsInstance(flow_exists, int)
+            self.assertGreater(flow_exists, 0)
             downloaded_flow = openml.flows.get_flow(flow_exists)
             setup_exists = openml.setups.setup_exists(downloaded_flow)
             self.assertIsInstance(setup_exists, int)
+            self.assertGreater(setup_exists, 0)
             run_ids = _run_exists(task.task_id, setup_exists)
+            self.assertGreater(len(run_ids), 0)
             run_id = random.choice(list(run_ids))
 
         # now the actual unit test ...

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -1,0 +1,18 @@
+from openml.testing import TestBase
+import openml
+
+
+class OpenMLTaskTest(TestBase):
+    _multiprocess_can_split_ = True
+
+    def test_list_all(self):
+        list_datasets = openml.datasets.functions._list_datasets
+        datasets = openml.utils.list_all(list_datasets)
+
+        self.assertGreaterEqual(len(datasets), 100)
+        for did in datasets:
+            self._check_dataset(datasets[did])
+
+        # TODO implement these tests
+        # datasets = openml.utils.list_all(list_datasets, limit=50)
+        # self.assertEqual(len(datasets), 50)


### PR DESCRIPTION
This PR fixes a few unit tests and adds one which I forgot to check in quite a while ago. Most importantly, the return values to retrieve all runs for a combination of task/setup is now consistent. Furthermore, I think cleaning the test server from lots of runs was really important.