### PR TITLE
Fix circle-ci builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,14 +25,11 @@ dependencies:
     - pip install --upgrade pip
     - pip install --upgrade numpy
     - pip install --upgrade scipy
-    - pip install git+https://github.com/mfeurer/liac-arff.git
     # install documentation building dependencies
     - pip install --upgrade matplotlib setuptools nose coverage sphinx pillow sphinx-gallery sphinx_bootstrap_theme cython numpydoc scikit-learn nbformat nbconvert
     # Installing required packages for `make -C doc check command` to work.
     - sudo -E apt-get -yq update
     - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
-    # finally install the requirements of the package to allow autodoc
-    - pip install -r requirements.txt
 
   # The --user is needed to let sphinx see the source and the binaries
   # The pipefail is requested to propagate exit code

--- a/circle.yml
+++ b/circle.yml
@@ -55,8 +55,3 @@ general:
   artifacts:
     - "doc/_build/html"
     - "~/log.txt"
-  # Restric the build to the branch master only
-  branches:
-    only:
-       - master
-       - develop


### PR DESCRIPTION
I think this is the last step prior to our first pypi release. We removed the requirements.txt file in PR #438 and therefore need to update the circle-ci build file. Furthermore, this PR enables building of the docs (not deployment) for all branches pushed to github.