### PR TITLE
pushed to fix serializing

### DIFF
--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -391,11 +391,11 @@ def _run_task_get_arffcontent(model, task, add_local_measures):
     # this information is multiple times overwritten, but due to the ordering
     # of tne loops, eventually it contains the information based on the full
     # dataset size
-    user_defined_measures_per_fold = dict()
+    user_defined_measures_per_fold = collections.OrderedDict()
     # stores sample-based evaluation measures (sublevel of fold-based)
     # will also be filled on a non sample-based task, but the information
     # is the same as the fold-based measures, and disregarded in that case
-    user_defined_measures_per_sample = dict()
+    user_defined_measures_per_sample = collections.OrderedDict()
 
     # sys.version_info returns a tuple, the following line compares the entry of tuples
     # https://docs.python.org/3.6/reference/expressions.html#value-comparisons
@@ -418,16 +418,17 @@ def _run_task_get_arffcontent(model, task, add_local_measures):
 
                 for measure in user_defined_measures_fold:
                     # instantiate the dicts. Can not use default dicts, due to pickle
+                    # ordered dicts important for maintaining consistency in unit tests
                     if measure not in user_defined_measures_per_fold:
-                        user_defined_measures_per_fold[measure] = dict()
+                        user_defined_measures_per_fold[measure] = collections.OrderedDict()
                     if measure not in user_defined_measures_per_sample:
-                        user_defined_measures_per_sample[measure] = dict()
+                        user_defined_measures_per_sample[measure] = collections.OrderedDict()
                     if rep_no not in user_defined_measures_per_fold[measure]:
-                        user_defined_measures_per_fold[measure][rep_no] = dict()
+                        user_defined_measures_per_fold[measure][rep_no] = collections.OrderedDict()
                     if rep_no not in user_defined_measures_per_sample[measure]:
-                        user_defined_measures_per_sample[measure][rep_no] = dict()
+                        user_defined_measures_per_sample[measure][rep_no] = collections.OrderedDict()
                     if fold_no not in user_defined_measures_per_sample[measure][rep_no]:
-                        user_defined_measures_per_sample[measure][rep_no][fold_no] = dict()
+                        user_defined_measures_per_sample[measure][rep_no][fold_no] = collections.OrderedDict()
 
                     user_defined_measures_per_fold[measure][rep_no][fold_no] = user_defined_measures_fold[measure]
                     user_defined_measures_per_sample[measure][rep_no][fold_no][sample_no] = user_defined_measures_fold[measure]

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -391,11 +391,11 @@ def _run_task_get_arffcontent(model, task, add_local_measures):
     # this information is multiple times overwritten, but due to the ordering
     # of tne loops, eventually it contains the information based on the full
     # dataset size
-    user_defined_measures_per_fold = collections.defaultdict(lambda: collections.defaultdict(dict))
+    user_defined_measures_per_fold = dict()
     # stores sample-based evaluation measures (sublevel of fold-based)
     # will also be filled on a non sample-based task, but the information
     # is the same as the fold-based measures, and disregarded in that case
-    user_defined_measures_per_sample = collections.defaultdict(lambda: collections.defaultdict(lambda: collections.defaultdict(dict)))
+    user_defined_measures_per_sample = dict()
 
     # sys.version_info returns a tuple, the following line compares the entry of tuples
     # https://docs.python.org/3.6/reference/expressions.html#value-comparisons
@@ -417,6 +417,18 @@ def _run_task_get_arffcontent(model, task, add_local_measures):
                 arff_tracecontent.extend(arff_tracecontent_fold)
 
                 for measure in user_defined_measures_fold:
+                    # instantiate the dicts. Can not use default dicts, due to pickle
+                    if measure not in user_defined_measures_per_fold:
+                        user_defined_measures_per_fold[measure] = dict()
+                    if measure not in user_defined_measures_per_sample:
+                        user_defined_measures_per_sample[measure] = dict()
+                    if rep_no not in user_defined_measures_per_fold[measure]:
+                        user_defined_measures_per_fold[measure][rep_no] = dict()
+                    if rep_no not in user_defined_measures_per_sample[measure]:
+                        user_defined_measures_per_sample[measure][rep_no] = dict()
+                    if fold_no not in user_defined_measures_per_sample[measure][rep_no]:
+                        user_defined_measures_per_sample[measure][rep_no][fold_no] = dict()
+
                     user_defined_measures_per_fold[measure][rep_no][fold_no] = user_defined_measures_fold[measure]
                     user_defined_measures_per_sample[measure][rep_no][fold_no][sample_no] = user_defined_measures_fold[measure]
 

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -88,33 +88,21 @@ class OpenMLRun(object):
         if not os.path.isdir(folder):
             raise ValueError('Could not find folder')
 
-        description_path = os.path.join(folder, 'description.xml')
-        predictions_path = os.path.join(folder, 'predictions.arff')
-        trace_path = os.path.join(folder, 'trace.arff')
+        run_path = os.path.join(folder, 'OpenMLRun.pkl')
         model_path = os.path.join(folder, 'model.pkl')
 
-        if not os.path.isfile(description_path):
-            raise ValueError('Could not find description.xml')
-        if not os.path.isfile(predictions_path):
-            raise ValueError('Could not find predictions.arff')
+        if not os.path.isfile(run_path):
+            raise ValueError('Could not find OpenMLRun.pkl')
         if not os.path.isfile(model_path):
             raise ValueError('Could not find model.pkl')
 
-        with open(description_path, 'r') as fp:
-            run = openml.runs.functions._create_run_from_xml(fp.read(), from_server=False)
-
-        with open(predictions_path, 'r') as fp:
-            predictions = arff.load(fp)
-            run.data_content = predictions['data']
+        with open(run_path, 'r') as fp:
+            run = pickle.load(fp)
+        if not isinstance(run, OpenMLRun):
+            raise ValueError('obtained run not instance of OpenMLRun')
 
         with open(model_path, 'rb') as fp:
             run.model = pickle.load(fp)
-
-        if os.path.isfile(trace_path):
-            with open(trace_path, 'r') as fp:
-                trace = arff.load(fp)
-                run.trace_attributes = trace['attributes']
-                run.trace_content = trace['data']
 
         return run
 
@@ -143,20 +131,10 @@ class OpenMLRun(object):
         if not os.listdir(output_directory) == []:
             raise ValueError('Output directory should be empty')
 
-        run_xml = self._create_description_xml()
-        predictions_arff = arff.dumps(self._generate_arff_dict())
-
-        with open(os.path.join(output_directory, 'description.xml'), 'w') as f:
-            f.write(run_xml)
-        with open(os.path.join(output_directory, 'predictions.arff'), 'w') as f:
-            f.write(predictions_arff)
+        with open(os.path.join(output_directory, 'OpenMLRun.pkl'), 'wb') as fp:
+            pickle.dump(self, fp)
         with open(os.path.join(output_directory, 'model.pkl'), 'wb') as f:
             pickle.dump(self.model, f)
-
-        if self.trace_content is not None:
-            trace_arff = arff.dumps(self._generate_trace_arff_dict())
-            with open(os.path.join(output_directory, 'trace.arff'), 'w') as f:
-                f.write(trace_arff)
 
     def _generate_arff_dict(self):
         """Generates the arff dictionary for uploading predictions to the server.

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -96,7 +96,7 @@ class OpenMLRun(object):
         if not os.path.isfile(model_path):
             raise ValueError('Could not find model.pkl')
 
-        with open(run_path, 'r') as fp:
+        with open(run_path, 'rb') as fp:
             run = pickle.load(fp)
         if not isinstance(run, OpenMLRun):
             raise ValueError('obtained run not instance of OpenMLRun')

--- a/tests/test_runs/test_run.py
+++ b/tests/test_runs/test_run.py
@@ -1,6 +1,7 @@
 import numpy as np
 import random
 import os
+import unittest
 from time import time
 
 from sklearn.tree import DecisionTreeClassifier
@@ -91,10 +92,12 @@ class TestRun(TestBase):
         np.testing.assert_array_equal(string_part, string_part_prime)
 
         if run.trace_content is not None:
-            numeric_part = np.array(np.array(run.trace_content)[:, 0:-2], dtype=float)
-            numeric_part_prime = np.array(np.array(run_prime.trace_content)[:, 0:-2], dtype=float)
-            string_part = np.array(run.trace_content)[:, -2:]
-            string_part_prime = np.array(run_prime.trace_content)[:, -2:]
+            # 0 - 4 is the range of numeric part (repeat, fold, iteration, score)
+            # the rest is boolean selected and hyperparameters
+            numeric_part = np.array(np.array(run.trace_content)[:, 0:4], dtype=float)
+            numeric_part_prime = np.array(np.array(run_prime.trace_content)[:, 0:4], dtype=float)
+            string_part = np.array(run.trace_content)[:, 4:]
+            string_part_prime = np.array(run_prime.trace_content)[:, 4:]
             # JvR: Python 2.7 requires an almost equal check, rather than an equals check
             np.testing.assert_array_almost_equal(numeric_part, numeric_part_prime)
             np.testing.assert_array_equal(string_part, string_part_prime)
@@ -114,7 +117,8 @@ class TestRun(TestBase):
         run_prime.publish()
 
     def test_to_from_filesystem_search(self):
-        model = GridSearchCV(estimator=DecisionTreeClassifier(), param_grid={"max_depth": [1, 2, 3, 4, 5]})
+        model = GridSearchCV(estimator=DecisionTreeClassifier(),
+                             param_grid={'max_depth': [1, 2, 3], 'criterion': ['gini', 'entropy']})
 
         task = openml.tasks.get_task(119)
         run = openml.runs.run_model_on_task(task, model, add_local_measures=False)


### PR DESCRIPTION
Apparently, the previous serialization / deserialization breaks when using a random search with a non numeric hyperparameter in the grid. 

This is due to the serialization / deserialization in liac arff, which keeps on adding escape characters. As such, serializing once is OK, but deserializing and reserializing is a problem. 

Although I liked the previous approach (very clear and verbose) we can not rely on this, and I have created a new PR (with more extensive tests)