### PR TITLE
Nominal values attribute fix

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -78,10 +78,16 @@ class OpenMLDataset(object):
         if features is not None:
             self.features = {}
             for idx, xmlfeature in enumerate(features['oml:feature']):
+                # split string of nominal values into type list if feature is nominal
+                # otherwise passing none for nominal values
+                try:
+                    nom_vals = [str(x[1:-1]) for x in xmlfeature['oml:nominal_values'][1:-1].split(',')]
+                except KeyError:
+                    nom_vals = None
                 feature = OpenMLDataFeature(int(xmlfeature['oml:index']),
                                             xmlfeature['oml:name'],
                                             xmlfeature['oml:data_type'],
-                                            xmlfeature['oml:nominal_values'] ######## This must pass nominal values for feature
+                                            nom_vals,
                                             int(xmlfeature.get('oml:number_of_missing_values', 0)))
                 if idx != feature.index:
                     raise ValueError('Data features not provided in right order')

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -81,7 +81,7 @@ class OpenMLDataset(object):
                 feature = OpenMLDataFeature(int(xmlfeature['oml:index']),
                                             xmlfeature['oml:name'],
                                             xmlfeature['oml:data_type'],
-                                            None,  # todo add nominal values (currently not in database)
+                                            xmlfeature['oml:nominal_values'] ######## This must pass nominal values for feature
                                             int(xmlfeature.get('oml:number_of_missing_values', 0)))
                 if idx != feature.index:
                     raise ValueError('Data features not provided in right order')


### PR DESCRIPTION
#### Reference Issue
Fixes #507 
Adds list of nominal values to be passed to `OpenMLDataFeature` constructor in setting the `OpenMLDataset.feature` attribute

#### What does this PR implement/fix? Explain your changes.
Creates `nom_val` variable to store list of nominal variables if feature is nominal, stores `None` otherwise, then `nom_val` is passed to `OpenMLDataFeature` constructor

#### How should this PR be tested?


#### Any other comments?
`xmlfeature['oml:nominal_values']` contains list as string type (e.g. `"['A', 'B', 'C', 'D']"), thus the use of splitting, lambda 
