### PR TITLE
#563 Fixing run print bug with blank flow_name

### DIFF
--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -56,7 +56,7 @@ class OpenMLRun(object):
 
     def __str__(self):
         flow_name = self.flow_name
-        if len(flow_name) > 26:
+        if flow_name is not None and len(flow_name) > 26:
             # long enough to show sklearn.pipeline.Pipeline
             flow_name = flow_name[:26] + "..."
         return "[run id: {}, task id: {}, flow id: {}, flow name: {}]".format(


### PR DESCRIPTION
#### Reference Issue

Fixes #536 

#### What does this PR implement/fix? Explain your changes.

This fixes a bug where you can't print a run that has `flow_name = None`.

#### How should this PR be tested?

```python

from sklearn import ensemble
from openml import tasks, flows, runs
import openml

task = tasks.get_task(3954)
clf = ensemble.RandomForestClassifier()
flow = flows.sklearn_to_flow(clf)
run = runs.run_flow_on_task(task, flow)
print(run)  #should print w/o error
```

