### PR TITLE
add create_dataset to api docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -30,6 +30,7 @@ Top-level Classes
    :template: function.rst
 
     check_datasets_active
+    create_dataset
     get_dataset
     get_datasets
     list_datasets


### PR DESCRIPTION
adds create_dataset to the API docs from which it was missing.