### PR TITLE
Fix typos in documentation and example

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -30,7 +30,7 @@ in python, `scikit-learn <http://scikit-learn.org/stable/index.html>`_.
 Thereby it will automatically be compatible with many machine learning
 libraries written in Python.
 
-We aim to keep the package as leight-weight as possible and we will try to
+We aim to keep the package as light-weight as possible and we will try to
 keep the number of potential installation dependencies as low as possible.
 Therefore, the connection to other machine learning libraries such as
 *pytorch*, *keras* or *tensorflow* should not be done directly inside this
@@ -43,7 +43,7 @@ Open issues and potential todos
 
 We collect open issues and feature requests in an `issue tracker on github <https://github.com/openml/openml-python/issues>`_.
 The issue tracker contains issues marked as *Good first issue*, which shows
-issues which are good for beginers. We also maintain a somewhat up-to-date
+issues which are good for beginners. We also maintain a somewhat up-to-date
 `roadmap <https://github.com/openml/openml-python/issues/410>`_ which
 contains longer-term goals.
 

--- a/examples/create_upload_tutorial.py
+++ b/examples/create_upload_tutorial.py
@@ -210,7 +210,7 @@ df['play'] = df['play'].astype('category')
 print(df.info())
 
 ############################################################################
-# We enforce the column 'outlook', 'winday', and 'play' to be a categorical
+# We enforce the column 'outlook', 'windy', and 'play' to be a categorical
 # dtype while the column 'rnd_str' is kept as a string column. Then, we can
 # call :func:`create_dataset` by passing the dataframe and fixing the parameter
 # ``attributes`` to ``'auto'``.


### PR DESCRIPTION
I noticed a few typos while reading the documentation while preparing for #570, so I fixed them.
Seeing as it is probably best to wait with working on #570 until develop branch passes unit tests, and these changes are separate from that issue anyway, I thought it might be better to open a separate PR.

There were some other PRs for minor documentation improvements (e.g. #561), so I thought this was appropriate.

There is nothing to test as all changes are in documentation (either code comment or rst).
