### PR TITLE
Fix636

### DIFF
--- a/openml/flows/sklearn_converter.py
+++ b/openml/flows/sklearn_converter.py
@@ -502,13 +502,12 @@ def _extract_information_from_model(model):
         rval = sklearn_to_flow(v, model)
 
         def flatten_all(list_):
-            flattened = []
+            """ Flattens arbitrary depth lists of lists. """
             for el in list_:
                 if isinstance(el, (list, tuple)):
-                    flattened += flatten_all(el)
+                    yield from flatten_all(el)
                 else:
-                    flattened.append(el)
-            return flattened
+                    yield el
 
         if isinstance(rval, (list, tuple)):
             nested_list_of_simple_types = all([isinstance(el, (bool, str, int, float))

--- a/openml/flows/sklearn_converter.py
+++ b/openml/flows/sklearn_converter.py
@@ -527,6 +527,7 @@ def _extract_information_from_model(model):
             and all([isinstance(rval_i, type(rval[0])) for rval_i in rval])
         )
 
+        # Check that all list elements are of simple types.
         nested_list_of_simple_types = (
             is_non_empty_list_of_lists_with_same_type
             and all([isinstance(el, SIMPLE_TYPES) for el in flatten_all(rval)])

--- a/openml/flows/sklearn_converter.py
+++ b/openml/flows/sklearn_converter.py
@@ -35,12 +35,13 @@ DEPENDENCIES_PATTERN = re.compile(
 )
 
 
+SIMPLE_NUMPY_TYPES = [nptype for type_cat, nptypes in np.sctypes.items()
+                      for nptype in nptypes if type_cat != 'others']
+SIMPLE_TYPES = tuple([bool, int, float, str] + SIMPLE_NUMPY_TYPES)
+
+
 def sklearn_to_flow(o, parent_model=None):
     # TODO: assert that only on first recursion lvl `parent_model` can be None
-    simple_numpy_types = [nptype for type_cat, nptypes in np.sctypes.items()
-                          for nptype in nptypes
-                          if type_cat != 'others']
-    simple_types = tuple([bool, int, float, str] + simple_numpy_types)
     if _is_estimator(o):
         # is the main model or a submodel
         rval = _serialize_model(o)
@@ -49,8 +50,8 @@ def sklearn_to_flow(o, parent_model=None):
         rval = [sklearn_to_flow(element, parent_model) for element in o]
         if isinstance(o, tuple):
             rval = tuple(rval)
-    elif isinstance(o, simple_types) or o is None:
-        if isinstance(o, tuple(simple_numpy_types)):
+    elif isinstance(o, SIMPLE_TYPES) or o is None:
+        if isinstance(o, tuple(SIMPLE_NUMPY_TYPES)):
             o = o.item()
         # base parameter values
         rval = o
@@ -507,28 +508,34 @@ def _extract_information_from_model(model):
         rval = sklearn_to_flow(v, model)
 
         def flatten_all(list_):
-            """ Flattens arbitrary depth lists of lists. """
+            """ Flattens arbitrary depth lists of lists (e.g. [[1,2],[3,[1]]] -> [1,2,3,1]). """
             for el in list_:
                 if isinstance(el, (list, tuple)):
                     yield from flatten_all(el)
                 else:
                     yield el
 
-        if isinstance(rval, (list, tuple)):
-            nested_list_of_simple_types = all([isinstance(el, (bool, str, int, float))
-                                               for el in flatten_all(rval)])
-        else:
-            nested_list_of_simple_types = False
-
-        if (isinstance(rval, (list, tuple))
+        # In case rval is a list of lists (or tuples), we need to identify two situations:
+        # - sklearn pipeline steps, feature union or base classifiers in voting classifier.
+        #   They look like e.g. [("imputer", Imputer()), ("classifier", SVC())]
+        # - a list of lists with simple types (e.g. int or str), such as for an OrdinalEncoder
+        #   where all possible values for each feature are described: [[0,1,2], [1,2,5]]
+        is_non_empty_list_of_lists_with_same_type = (
+            isinstance(rval, (list, tuple))
             and len(rval) > 0
             and isinstance(rval[0], (list, tuple))
-            and all([isinstance(rval[i], type(rval[0]))
-                     for i in range(len(rval))])
-                and not nested_list_of_simple_types):
+            and all([isinstance(rval_i, type(rval[0])) for rval_i in rval])
+        )
 
-            # Steps in a pipeline or feature union, or base classifiers in
-            # voting classifier
+        nested_list_of_simple_types = (
+            is_non_empty_list_of_lists_with_same_type
+            and all([isinstance(el, SIMPLE_TYPES) for el in flatten_all(rval)])
+        )
+
+        if is_non_empty_list_of_lists_with_same_type and not nested_list_of_simple_types:
+            # If a list of lists is identified that include 'non-simple' types (e.g. objects),
+            # we assume they are steps in a pipeline, feature union, or base classifiers in
+            # a voting classifier.
             parameter_value = list()
             reserved_keywords = set(model.get_params(deep=False).keys())
 

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -233,4 +233,5 @@ class TestFlowFunctions(TestBase):
         from sklearn.preprocessing import OrdinalEncoder
         ordinal_encoder = OrdinalEncoder(categories=[[0, 1], [0, 1]])
         flow = openml.flows.sklearn_to_flow(ordinal_encoder)
+        self._add_sentinel_to_flow_name(flow)
         flow.publish()

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -221,3 +221,9 @@ class TestFlowFunctions(TestBase):
         self.assertRaises(ValueError, assert_flows_equal, flow, new_flow,
                           ignore_parameter_values_on_older_children=flow_upload_date)
         assert_flows_equal(flow, flow, ignore_parameter_values_on_older_children=None)
+
+    def test_sklearn_to_flow_list_of_lists(self):
+        from sklearn.preprocessing import OrdinalEncoder
+        ordinal_encoder = OrdinalEncoder(categories=[[0, 1], [0, 1]])
+        flow = openml.flows.sklearn_to_flow(ordinal_encoder)
+        flow.publish()

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -1,5 +1,9 @@
 from collections import OrderedDict
 import copy
+import unittest
+
+from distutils.version import LooseVersion
+import sklearn
 
 import openml
 from openml.testing import TestBase
@@ -222,6 +226,9 @@ class TestFlowFunctions(TestBase):
                           ignore_parameter_values_on_older_children=flow_upload_date)
         assert_flows_equal(flow, flow, ignore_parameter_values_on_older_children=None)
 
+    @unittest.skipIf(LooseVersion(sklearn.__version__) < "0.20",
+                     reason="OrdinalEncoder introduced in 0.20. "
+                            "No known models with list of lists parameters in older versions.")
     def test_sklearn_to_flow_list_of_lists(self):
         from sklearn.preprocessing import OrdinalEncoder
         ordinal_encoder = OrdinalEncoder(categories=[[0, 1], [0, 1]])

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -232,6 +232,15 @@ class TestFlowFunctions(TestBase):
     def test_sklearn_to_flow_list_of_lists(self):
         from sklearn.preprocessing import OrdinalEncoder
         ordinal_encoder = OrdinalEncoder(categories=[[0, 1], [0, 1]])
+
+        # Test serialization works
         flow = openml.flows.sklearn_to_flow(ordinal_encoder)
+
+        # Test flow is accepted by server
         self._add_sentinel_to_flow_name(flow)
         flow.publish()
+
+        # Test deserialization works
+        server_flow = openml.flows.get_flow(flow.flow_id, reinstantiate=True)
+        self.assertEqual(server_flow.parameters['categories'], '[[0, 1], [0, 1]]')
+        self.assertEqual(server_flow.model.categories, flow.model.categories)


### PR DESCRIPTION
Fixes an issue where a list of lists with simple types could not be serialized (because it was expected to be FeatureUnion, Pipeline or VotingClassifier), as described in #636.

Example flow generated: https://www.openml.org/f/9556
It deserializes correctly with
```
flow = openml.flows.get_flow(9556)
model = openml.flows.flow_to_sklearn(flow)
```