### PR TITLE
Fix check_datasets_active and corresponding unit test

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -278,7 +278,7 @@ def _load_features_from_file(features_file: str) -> Dict:
                                    force_list=('oml:feature', 'oml:nominal_value'))
         return xml_dict["oml:data_features"]
 
-      
+
 def check_datasets_active(dataset_ids: List[int]) -> Dict[int, bool]:
     """ Check if the dataset ids provided are active.
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -284,7 +284,7 @@ def check_datasets_active(dataset_ids: List[int]) -> Dict[int, bool]:
     """
     dataset_list = list_datasets(status='all')
     active = {}
-    
+
     for did in dataset_ids:
         dataset = dataset_list.get(did, None)
         if dataset is None:

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -284,16 +284,13 @@ def check_datasets_active(dataset_ids: List[int]) -> Dict[int, bool]:
     """
     dataset_list = list_datasets(status='all')
     active = {}
-
-    for dataset in dataset_list.values():
-        active[dataset['did']] = dataset['status'] == 'active'
-
+    
     for did in dataset_ids:
-        if did not in active:
-            raise ValueError('Could not find dataset {} in '
-                             'OpenML dataset list.'.format(did))
-
-    active = {did: active[did] for did in dataset_ids}
+        dataset = dataset_list.get(did, None)
+        if dataset is None:
+            raise ValueError('Could not find dataset {} in OpenML dataset list.'.format(did))
+        else:
+            active[did] = (dataset['status'] == 'active')
 
     return active
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -3,6 +3,7 @@ import io
 import os
 import re
 import warnings
+from typing import Dict, List
 
 import numpy as np
 import arff
@@ -268,24 +269,23 @@ def __list_datasets(api_call):
     return datasets
 
 
-def check_datasets_active(dataset_ids):
-    """Check if the dataset ids provided are active.
+def check_datasets_active(dataset_ids: List[int]) -> Dict[int, bool]:
+    """ Check if the dataset ids provided are active.
 
     Parameters
     ----------
-    dataset_ids : iterable
-        Integers representing dataset ids.
+    dataset_ids : List[int]
+        A list of integers representing dataset ids.
 
     Returns
     -------
     dict
         A dictionary with items {did: bool}
     """
-    dataset_list = list_datasets()
-    dataset_ids = sorted(dataset_ids)
+    dataset_list = list_datasets(status='all')
     active = {}
 
-    for dataset in dataset_list:
+    for dataset in dataset_list.values():
         active[dataset['did']] = dataset['status'] == 'active'
 
     for did in dataset_ids:

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1,4 +1,3 @@
-import unittest
 import os
 import random
 from itertools import product

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -206,10 +206,11 @@ class TestOpenMLDataset(TestBase):
 
         self.assertIsInstance(datasets, dict)
 
-    @unittest.skip('See https://github.com/openml/openml-python/issues/149')
     def test_check_datasets_active(self):
-        active = openml.datasets.check_datasets_active([1, 17])
-        self.assertTrue(active[1])
+        # Have to test on live because there is no deactivated dataset on the test server.
+        openml.config.server = self.production_server
+        active = openml.datasets.check_datasets_active([2, 17])
+        self.assertTrue(active[2])
         self.assertFalse(active[17])
         self.assertRaisesRegex(
             ValueError,
@@ -217,6 +218,7 @@ class TestOpenMLDataset(TestBase):
             openml.datasets.check_datasets_active,
             [79],
         )
+        openml.config.server = self.test_server
 
     def test_get_datasets(self):
         dids = [1, 2]


### PR DESCRIPTION
This solves an issue hinted at in #149. While retrieving deactivated datasets worked perfectly well, the `check_datasets_active` method was seemingly not updated for some latest changes, and its unit test was outdated too ([it was disabled](https://github.com/openml/openml-python/blob/master/tests/test_datasets/test_dataset_functions.py#L214)).

This PR:
 - Fixes a bug in `check_datasets_active` where deactivated datasets would never be found due to not specifying `status='all'` in the `list_datasets` call (presumably because the default behavior was changed at some point).
 - Correctly points the unit test to the production server, as there is no deactivated dataset on the test server.
 - Updated the dataset id that is supposed to refer to an active dataset from 1 to 2 in the unit test (since d/1 is now deactivated).
 - reactivates the fixed unit test
 - refactored the flow of `check_datasets_active` a little for legibility and to avoid "excessive" looping/evaluations (minor but still nice :) )