### PR TITLE
Fix612 lazy download dataset

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,8 @@ install:
   - rmdir C:\\cygwin /s /q
 
   # Update previous packages and install the build and runtime dependencies of the project.
-  # XXX: setuptools>23 is currently broken on Win+py3 with numpy
-  # (https://github.com/pypa/setuptools/issues/728)
-  - conda update --all --yes setuptools=23
+  - conda update conda --yes
+  - conda update --all --yes
 
   # Install the build and runtime dependencies of the project.
   - "cd C:\\projects\\openml-python"

--- a/examples/datasets_tutorial.py
+++ b/examples/datasets_tutorial.py
@@ -78,6 +78,15 @@ print(X.head())
 print(X.info())
 
 ############################################################################
+# Sometimes you only need access to a dataset's metadata.
+# In those cases, you can download the dataset without downloading the
+# data file. The dataset object can be used as normal.
+# Whenever you use any functionality that requires the data,
+# such as `get_data`, the data will be downloaded.
+dataset = openml.datasets.get_dataset(68, download_data=False)
+
+
+############################################################################
 # Exercise 2
 # **********
 # * Explore the data visually.

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -401,6 +401,12 @@ class OpenMLDataset(object):
         return pd.Series(col, index=series.index, dtype='category',
                          name=series.name)
 
+    def _download_data(self) -> None:
+        """ Download ARFF data file to standard cache directory. Set `self.data_file`. """
+        # import required here to avoid circular import.
+        from .functions import _get_dataset_arff
+        self.data_file = _get_dataset_arff(self)
+
     def get_data(self, target: str=None,
                  include_row_id: bool=False,
                  include_ignore_attributes: bool=False,
@@ -450,9 +456,7 @@ class OpenMLDataset(object):
 
         if self.data_pickle_file is None:
             if self.data_file is None:
-                # import required hero to avoid circular import.
-                from .functions import _get_dataset_arff
-                self.data_file = _get_dataset_arff(self)
+                self._download_data()
             self.data_pickle_file = self._data_arff_to_pickle(self.data_file)
 
         path = self.data_pickle_file
@@ -570,6 +574,9 @@ class OpenMLDataset(object):
 
         # TODO improve performance, currently reads the whole file
         # Should make a method that only reads the attributes
+        if self.data_file is None:
+            self._download_data()
+
         arffFileName = self.data_file
 
         if self.format.lower() == 'arff':

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -175,6 +175,7 @@ class OpenMLDataset(object):
         data_pickle_file = data_file.replace('.arff', '.pkl.py3')
         if os.path.exists(data_pickle_file):
             logger.debug("Data pickle file already exists.")
+            return data_pickle_file
         else:
             try:
                 data = self._get_arff(self.format)

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -157,7 +157,7 @@ class OpenMLDataset(object):
                 feature = OpenMLDataFeature(int(xmlfeature['oml:index']),
                                             xmlfeature['oml:name'],
                                             xmlfeature['oml:data_type'],
-                                            None,
+                                            xmlfeature.get('oml:nominal_value'),
                                             int(nr_missing))
                 if idx != feature.index:
                     raise ValueError('Data features not provided '
@@ -572,29 +572,10 @@ class OpenMLDataset(object):
         -------
         list
         """
-
-        # TODO improve performance, currently reads the whole file
-        # Should make a method that only reads the attributes
-        if self.data_file is None:
-            self._download_data()
-
-        arffFileName = self.data_file
-
-        if self.format.lower() == 'arff':
-            return_type = arff.DENSE
-        elif self.format.lower() == 'sparse_arff':
-            return_type = arff.COO
-        else:
-            raise ValueError('Unknown data format %s' % self.format)
-
-        with io.open(arffFileName, encoding='utf8') as fh:
-            arffData = arff.ArffDecoder().decode(fh, return_type=return_type)
-
-        dataAttributes = dict(arffData['attributes'])
-        if target_name in dataAttributes:
-            return dataAttributes[target_name]
-        else:
-            return None
+        for feature in self.features.values():
+            if (feature.name == target_name) and (feature.data_type == 'nominal'):
+                return feature.nominal_values
+        return None
 
     def get_features_by_type(self, data_type, exclude=None,
                              exclude_ignore_attributes=True,

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -167,96 +167,103 @@ class OpenMLDataset(object):
         self.qualities = _check_qualities(qualities)
 
         if data_file is not None:
-            self.data_pickle_file = data_file.replace('.arff', '.pkl.py3')
+            self.data_pickle_file = self.data_arff_to_pickle(data_file)
+        else:
+            self.data_pickle_file = None
 
-            if os.path.exists(self.data_pickle_file):
-                logger.debug("Data pickle file already exists.")
-            else:
-                try:
-                    data = self._get_arff(self.format)
-                except OSError as e:
-                    logger.critical("Please check that the data file %s is "
-                                    "there and can be read.", self.data_file)
-                    raise e
+    def data_arff_to_pickle(self, data_file):
+        data_pickle_file = data_file.replace('.arff', '.pkl.py3')
+        if os.path.exists(data_pickle_file):
+            logger.debug("Data pickle file already exists.")
+        else:
+            try:
+                data = self._get_arff(self.format)
+            except OSError as e:
+                logger.critical("Please check that the data file %s is "
+                                "there and can be read.", data_file)
+                raise e
 
-                ARFF_DTYPES_TO_PD_DTYPE = {
-                    'INTEGER': 'integer',
-                    'REAL': 'floating',
-                    'NUMERIC': 'floating',
-                    'STRING': 'string'
-                }
-                attribute_dtype = {}
-                attribute_names = []
-                categories_names = {}
-                categorical = []
-                for name, type_ in data['attributes']:
-                    # if the feature is nominal and the a sparse matrix is
-                    # requested, the categories need to be numeric
-                    if (isinstance(type_, list)
-                            and self.format.lower() == 'sparse_arff'):
-                        try:
-                            np.array(type_, dtype=np.float32)
-                        except ValueError:
-                            raise ValueError(
-                                "Categorical data needs to be numeric when "
-                                "using sparse ARFF."
-                            )
-                    # string can only be supported with pandas DataFrame
-                    elif (type_ == 'STRING'
-                          and self.format.lower() == 'sparse_arff'):
+            ARFF_DTYPES_TO_PD_DTYPE = {
+                'INTEGER': 'integer',
+                'REAL': 'floating',
+                'NUMERIC': 'floating',
+                'STRING': 'string'
+            }
+            attribute_dtype = {}
+            attribute_names = []
+            categories_names = {}
+            categorical = []
+            for name, type_ in data['attributes']:
+                # if the feature is nominal and the a sparse matrix is
+                # requested, the categories need to be numeric
+                if (isinstance(type_, list)
+                        and self.format.lower() == 'sparse_arff'):
+                    try:
+                        np.array(type_, dtype=np.float32)
+                    except ValueError:
                         raise ValueError(
-                            "Dataset containing strings is not supported "
-                            "with sparse ARFF."
+                            "Categorical data needs to be numeric when "
+                            "using sparse ARFF."
                         )
+                # string can only be supported with pandas DataFrame
+                elif (type_ == 'STRING'
+                      and self.format.lower() == 'sparse_arff'):
+                    raise ValueError(
+                        "Dataset containing strings is not supported "
+                        "with sparse ARFF."
+                    )
 
-                    # infer the dtype from the ARFF header
-                    if isinstance(type_, list):
-                        categorical.append(True)
-                        categories_names[name] = type_
-                        if len(type_) == 2:
-                            type_norm = [cat.lower().capitalize()
-                                         for cat in type_]
-                            if set(['True', 'False']) == set(type_norm):
-                                categories_names[name] = [
-                                    True if cat == 'True' else False
-                                    for cat in type_norm
-                                ]
-                                attribute_dtype[name] = 'boolean'
-                            else:
-                                attribute_dtype[name] = 'categorical'
+                # infer the dtype from the ARFF header
+                if isinstance(type_, list):
+                    categorical.append(True)
+                    categories_names[name] = type_
+                    if len(type_) == 2:
+                        type_norm = [cat.lower().capitalize()
+                                     for cat in type_]
+                        if set(['True', 'False']) == set(type_norm):
+                            categories_names[name] = [
+                                True if cat == 'True' else False
+                                for cat in type_norm
+                            ]
+                            attribute_dtype[name] = 'boolean'
                         else:
                             attribute_dtype[name] = 'categorical'
                     else:
-                        categorical.append(False)
-                        attribute_dtype[name] = ARFF_DTYPES_TO_PD_DTYPE[type_]
-                    attribute_names.append(name)
+                        attribute_dtype[name] = 'categorical'
+                else:
+                    categorical.append(False)
+                    attribute_dtype[name] = ARFF_DTYPES_TO_PD_DTYPE[type_]
+                attribute_names.append(name)
 
-                if self.format.lower() == 'sparse_arff':
-                    X = data['data']
-                    X_shape = (max(X[1]) + 1, max(X[2]) + 1)
-                    X = scipy.sparse.coo_matrix(
-                        (X[0], (X[1], X[2])), shape=X_shape, dtype=np.float32)
-                    X = X.tocsr()
+            if self.format.lower() == 'sparse_arff':
+                X = data['data']
+                X_shape = (max(X[1]) + 1, max(X[2]) + 1)
+                X = scipy.sparse.coo_matrix(
+                    (X[0], (X[1], X[2])), shape=X_shape, dtype=np.float32)
+                X = X.tocsr()
 
-                elif self.format.lower() == 'arff':
-                    X = pd.DataFrame(data['data'], columns=attribute_names)
+            elif self.format.lower() == 'arff':
+                X = pd.DataFrame(data['data'], columns=attribute_names)
 
-                    col = []
-                    for column_name in X.columns:
-                        if attribute_dtype[column_name] in ('categorical',
-                                                            'boolean'):
-                            col.append(self._unpack_categories(
-                                X[column_name], categories_names[column_name]))
-                        else:
-                            col.append(X[column_name])
-                    X = pd.concat(col, axis=1)
+                col = []
+                for column_name in X.columns:
+                    if attribute_dtype[column_name] in ('categorical',
+                                                        'boolean'):
+                        col.append(self._unpack_categories(
+                            X[column_name], categories_names[column_name]))
+                    else:
+                        col.append(X[column_name])
+                X = pd.concat(col, axis=1)
 
-                # Pickle the dataframe or the sparse matrix.
-                with open(self.data_pickle_file, "wb") as fh:
-                    pickle.dump((X, categorical, attribute_names), fh, -1)
-                logger.debug("Saved dataset %d: %s to file %s" %
-                             (int(self.dataset_id or -1), self.name,
-                              self.data_pickle_file))
+            # Pickle the dataframe or the sparse matrix.
+            with open(data_pickle_file, "wb") as fh:
+                pickle.dump((X, categorical, attribute_names), fh, -1)
+            logger.debug("Saved dataset {did}: {name} to file {path}"
+                         .format(did=int(self.dataset_id or -1),
+                                 name=self.name,
+                                 path=data_pickle_file)
+                         )
+            return data_pickle_file
 
     def push_tag(self, tag):
         """Annotates this data set with a tag on the server.
@@ -394,13 +401,13 @@ class OpenMLDataset(object):
         return pd.Series(col, index=series.index, dtype='category',
                          name=series.name)
 
-    def get_data(self, target=None,
-                 include_row_id=False,
-                 include_ignore_attributes=False,
-                 return_categorical_indicator=False,
-                 return_attribute_names=False,
-                 dataset_format=None):
-        """Returns dataset content as dataframes or sparse matrices.
+    def get_data(self, target: str=None,
+                 include_row_id: bool=False,
+                 include_ignore_attributes: bool=False,
+                 return_categorical_indicator: bool=False,
+                 return_attribute_names: bool=False,
+                 dataset_format: str=None):
+        """ Returns dataset content as dataframes or sparse matrices.
 
         Parameters
         ----------
@@ -416,10 +423,10 @@ class OpenMLDataset(object):
             categorical.
         return_attribute_names : boolean (default=False)
             Whether to return attribute names.
-        dataset_format : string
-            The format of returned dataset. If ``array``, the returned dataset
-            will be a NumPy array or a SciPy sparse matrix. If ``dataframe``,
-            the returned dataset will be a Pandas DataFrame or SparseDataFrame.
+        dataset_format : string, optional
+            The format of returned dataset.
+            If ``array``, the returned dataset will be a NumPy array or a SciPy sparse matrix.
+            If ``dataframe``, the returned dataset will be a Pandas DataFrame or SparseDataFrame.
 
         Returns
         -------
@@ -428,12 +435,11 @@ class OpenMLDataset(object):
         y : ndarray or series, shape (n_samples,)
             Target column(s). Only returned if target is not None.
         categorical_indicator : boolean ndarray
-            Mask that indicate categorical features. Only returned if
-            return_categorical_indicator is True.
+            Mask that indicate categorical features.
+            Only returned if return_categorical_indicator is True.
         return_attribute_names : list of strings
-            List of attribute names. Returned only if return_attribute_names is
-            True.
-
+            List of attribute names.
+            Only returned if return_attribute_names is True.
         """
         if dataset_format is None:
             warn('The default of "dataset_format" will change from "array" to'

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -167,11 +167,11 @@ class OpenMLDataset(object):
         self.qualities = _check_qualities(qualities)
 
         if data_file is not None:
-            self.data_pickle_file = self.data_arff_to_pickle(data_file)
+            self.data_pickle_file = self._data_arff_to_pickle(data_file)
         else:
             self.data_pickle_file = None
 
-    def data_arff_to_pickle(self, data_file):
+    def _data_arff_to_pickle(self, data_file):
         data_pickle_file = data_file.replace('.arff', '.pkl.py3')
         if os.path.exists(data_pickle_file):
             logger.debug("Data pickle file already exists.")
@@ -447,6 +447,13 @@ class OpenMLDataset(object):
             dataset_format = 'array'
 
         rval = []
+
+        if self.data_pickle_file is None:
+            if self.data_file is None:
+                # import required hero to avoid circular import.
+                from .functions import _get_dataset_arff
+                self.data_file = _get_dataset_arff(self)
+            self.data_pickle_file = self._data_arff_to_pickle(self.data_file)
 
         path = self.data_pickle_file
         if not os.path.exists(path):

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -407,12 +407,12 @@ class OpenMLDataset(object):
         from .functions import _get_dataset_arff
         self.data_file = _get_dataset_arff(self)
 
-    def get_data(self, target: str=None,
-                 include_row_id: bool=False,
-                 include_ignore_attributes: bool=False,
-                 return_categorical_indicator: bool=False,
-                 return_attribute_names: bool=False,
-                 dataset_format: str=None):
+    def get_data(self, target: str = None,
+                 include_row_id: bool = False,
+                 include_ignore_attributes: bool = False,
+                 return_categorical_indicator: bool = False,
+                 return_attribute_names: bool = False,
+                 dataset_format: str = None):
         """ Returns dataset content as dataframes or sparse matrices.
 
         Parameters

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -1,4 +1,3 @@
-import hashlib
 import io
 import os
 import re
@@ -306,7 +305,7 @@ def check_datasets_active(dataset_ids):
 
 def get_datasets(
         dataset_ids: List[Union[str, int]],
-        download_data: bool=True,
+        download_data: bool = True,
 ) -> List[OpenMLDataset]:
     """Download datasets.
 
@@ -706,7 +705,8 @@ def _get_dataset_description(did_cache_dir, dataset_id):
     return description
 
 
-def _get_dataset_arff(description: Union[Dict, OpenMLDataset], cache_directory: str=None) -> str:
+def _get_dataset_arff(description: Union[Dict, OpenMLDataset],
+                      cache_directory: str = None) -> str:
     """ Return the path to the local arff file of the dataset. If is not cached, it is downloaded.
 
     Checks if the file is in the cache, if yes, return the path to the file.
@@ -840,7 +840,7 @@ def _create_dataset_from_description(
         description: Dict[str, str],
         features: Dict,
         qualities: List,
-        arff_file: str=None,
+        arff_file: str = None,
 ) -> OpenMLDataset:
     """Create a dataset object from a description dict.
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -168,6 +168,11 @@ def _get_cached_dataset_arff(dataset_id):
                                    "cached" % dataset_id)
 
 
+def _get_cache_directory(dataset: OpenMLDataset) -> str:
+    """ Return the cache directory of the OpenMLDataset """
+    return _create_cache_directory_for_id(DATASETS_CACHE_DIR_NAME, dataset.dataset_id)
+
+
 def list_datasets(offset=None, size=None, status=None, tag=None, **kwargs):
 
     """
@@ -724,33 +729,18 @@ def _get_dataset_arff(did_cache_dir, description):
     """
     output_file_path = os.path.join(did_cache_dir, "dataset.arff")
     md5_checksum_fixture = description.get("oml:md5_checksum")
-    did = description.get("oml:id")
-
-    # This means the file is still there; whether it is useful is up to
-    # the user and not checked by the program.
-    try:
-        with io.open(output_file_path, encoding='utf8'):
-            pass
-        return output_file_path
-    except (OSError, IOError):
-        pass
-
     url = description['oml:url']
-    arff_string = openml._api_calls._read_url(url, request_method='get')
-    md5 = hashlib.md5()
-    md5.update(arff_string.encode('utf-8'))
-    md5_checksum = md5.hexdigest()
-    if md5_checksum != md5_checksum_fixture:
-        raise OpenMLHashException(
-            'Checksum %s of downloaded dataset %d is unequal to the checksum '
-            '%s sent by the server.' % (
-                md5_checksum, int(did), md5_checksum_fixture
-            )
-        )
 
-    with io.open(output_file_path, "w", encoding='utf8') as fh:
-        fh.write(arff_string)
-    del arff_string
+    try:
+        openml.utils._download_text_file(
+            source=url,
+            output_path=output_file_path,
+            md5_checksum=md5_checksum_fixture
+        )
+    except OpenMLHashException as e:
+        additional_info = " Raised when downloading dataset {}.".format(description.get('oml:id'))
+        e.args = (e.args[0] + additional_info,)
+        raise
 
     return output_file_path
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -792,7 +792,7 @@ def _get_dataset_features(did_cache_dir, dataset_id):
         with io.open(features_file, "w", encoding='utf8') as fh:
             fh.write(features_xml)
 
-    xml_as_dict = xmltodict.parse(features_xml, force_list=('oml:feature',))
+    xml_as_dict = xmltodict.parse(features_xml, force_list=('oml:feature','oml:nominal_value'))
     features = xml_as_dict["oml:data_features"]
 
     return features

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -315,7 +315,7 @@ def get_datasets(
     Parameters
     ----------
     dataset_ids : iterable
-        Integers representing dataset ids.
+        Integers or strings representing dataset ids.
     download_data : bool, optional
         If True, also download the data file. Beware that some datasets are large and it might
         make the operation noticeably slower. Metadata is also still retrieved.
@@ -333,7 +333,7 @@ def get_datasets(
     return datasets
 
 
-def get_dataset(dataset_id: int, download_data: bool = True) -> OpenMLDataset:
+def get_dataset(dataset_id: Union[int, str], download_data: bool = True) -> OpenMLDataset:
     """ Download the OpenML dataset representation, optionally also download actual data file.
 
     This function is thread/multiprocessing safe.
@@ -342,7 +342,7 @@ def get_dataset(dataset_id: int, download_data: bool = True) -> OpenMLDataset:
 
     Parameters
     ----------
-    dataset_id : int
+    dataset_id : int or str
         Dataset ID of the dataset to download
     download_data : bool, optional (default=True)
         If True, also download the data file. Beware that some datasets are large and it might

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -1,8 +1,10 @@
 import os
+import hashlib
 import xmltodict
 import shutil
 
 import openml._api_calls
+import openml.exceptions
 from . import config
 
 
@@ -284,3 +286,53 @@ def _create_lockfiles_dir():
     except OSError:
         pass
     return dir
+
+
+def _download_text_file(source: str,
+                        output_path: str,
+                        md5_checksum: str=None,
+                        exists_ok: bool=True,
+                        encoding: str='utf8',
+                        ) -> None:
+    """ Download the text file at `source` and store it in `output_path`.
+
+    By default, do nothing if a file already exists in `output_path`.
+    The downloaded file can be checked against an expected md5 checksum.
+
+    Parameters
+    ----------
+    source : str
+        url of the file to be downloaded
+    output_path : str
+        full path, including filename, of where the file should be stored.
+    md5_checksum : str, optional (default=None)
+        If not None, should be a string of hexidecimal digits of the expected digest value.
+    exists_ok : bool, optional (default=True)
+        If False, raise an FileExistsError if there already exists a file at `output_path`.
+    encoding : str, optional (default='utf8')
+        The encoding with which the file should be stored.
+    """
+    try:
+        with open(output_path, encoding=encoding):
+            if exists_ok:
+                return
+            else:
+                raise FileExistsError
+    except FileNotFoundError:
+        pass
+
+    downloaded_file = openml._api_calls._read_url(source, request_method='get')
+
+    if md5_checksum is not None:
+        md5 = hashlib.md5()
+        md5.update(downloaded_file.encode('utf-8'))
+        md5_checksum_download = md5.hexdigest()
+        if md5_checksum != md5_checksum_download:
+            raise openml.exceptions.OpenMLHashException(
+                'Checksum {} of downloaded file is unequal to the expected checksum {}.'
+                .format(md5_checksum_download, md5_checksum))
+
+    with open(output_path, "w", encoding=encoding) as fh:
+        fh.write(downloaded_file)
+
+    del downloaded_file

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -290,9 +290,9 @@ def _create_lockfiles_dir():
 
 def _download_text_file(source: str,
                         output_path: str,
-                        md5_checksum: str=None,
-                        exists_ok: bool=True,
-                        encoding: str='utf8',
+                        md5_checksum: str = None,
+                        exists_ok: bool = True,
+                        encoding: str = 'utf8',
                         ) -> None:
     """ Download the text file at `source` and store it in `output_path`.
 

--- a/tests/files/org/openml/test/datasets/2/features.xml
+++ b/tests/files/org/openml/test/datasets/2/features.xml
@@ -3,7 +3,16 @@
     <oml:index>0</oml:index>
     <oml:name>family</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>GB</oml:nominal_value>
+          <oml:nominal_value>GK</oml:nominal_value>
+          <oml:nominal_value>GS</oml:nominal_value>
+          <oml:nominal_value>TN</oml:nominal_value>
+          <oml:nominal_value>ZA</oml:nominal_value>
+          <oml:nominal_value>ZF</oml:nominal_value>
+          <oml:nominal_value>ZH</oml:nominal_value>
+          <oml:nominal_value>ZM</oml:nominal_value>
+          <oml:nominal_value>ZS</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>772</oml:number_of_missing_values>
@@ -12,7 +21,10 @@
     <oml:index>1</oml:index>
     <oml:name>product-type</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>C</oml:nominal_value>
+          <oml:nominal_value>H</oml:nominal_value>
+          <oml:nominal_value>G</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -21,7 +33,15 @@
     <oml:index>2</oml:index>
     <oml:name>steel</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>R</oml:nominal_value>
+          <oml:nominal_value>A</oml:nominal_value>
+          <oml:nominal_value>U</oml:nominal_value>
+          <oml:nominal_value>K</oml:nominal_value>
+          <oml:nominal_value>M</oml:nominal_value>
+          <oml:nominal_value>S</oml:nominal_value>
+          <oml:nominal_value>W</oml:nominal_value>
+          <oml:nominal_value>V</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>86</oml:number_of_missing_values>
@@ -30,7 +50,7 @@
     <oml:index>3</oml:index>
     <oml:name>carbon</oml:name>
     <oml:data_type>numeric</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -39,7 +59,7 @@
     <oml:index>4</oml:index>
     <oml:name>hardness</oml:name>
     <oml:data_type>numeric</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -48,7 +68,8 @@
     <oml:index>5</oml:index>
     <oml:name>temper_rolling</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>T</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>761</oml:number_of_missing_values>
@@ -57,7 +78,10 @@
     <oml:index>6</oml:index>
     <oml:name>condition</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>S</oml:nominal_value>
+          <oml:nominal_value>A</oml:nominal_value>
+          <oml:nominal_value>X</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>303</oml:number_of_missing_values>
@@ -66,7 +90,12 @@
     <oml:index>7</oml:index>
     <oml:name>formability</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>1</oml:nominal_value>
+          <oml:nominal_value>2</oml:nominal_value>
+          <oml:nominal_value>3</oml:nominal_value>
+          <oml:nominal_value>4</oml:nominal_value>
+          <oml:nominal_value>5</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>318</oml:number_of_missing_values>
@@ -75,7 +104,7 @@
     <oml:index>8</oml:index>
     <oml:name>strength</oml:name>
     <oml:data_type>numeric</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -84,7 +113,8 @@
     <oml:index>9</oml:index>
     <oml:name>non-ageing</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>N</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>793</oml:number_of_missing_values>
@@ -93,7 +123,9 @@
     <oml:index>10</oml:index>
     <oml:name>surface-finish</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>P</oml:nominal_value>
+          <oml:nominal_value>M</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>889</oml:number_of_missing_values>
@@ -102,7 +134,11 @@
     <oml:index>11</oml:index>
     <oml:name>surface-quality</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>D</oml:nominal_value>
+          <oml:nominal_value>E</oml:nominal_value>
+          <oml:nominal_value>F</oml:nominal_value>
+          <oml:nominal_value>G</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>244</oml:number_of_missing_values>
@@ -111,7 +147,12 @@
     <oml:index>12</oml:index>
     <oml:name>enamelability</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>1</oml:nominal_value>
+          <oml:nominal_value>2</oml:nominal_value>
+          <oml:nominal_value>3</oml:nominal_value>
+          <oml:nominal_value>4</oml:nominal_value>
+          <oml:nominal_value>5</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>882</oml:number_of_missing_values>
@@ -120,7 +161,8 @@
     <oml:index>13</oml:index>
     <oml:name>bc</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>897</oml:number_of_missing_values>
@@ -129,7 +171,8 @@
     <oml:index>14</oml:index>
     <oml:name>bf</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>769</oml:number_of_missing_values>
@@ -138,7 +181,8 @@
     <oml:index>15</oml:index>
     <oml:name>bt</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>824</oml:number_of_missing_values>
@@ -147,7 +191,9 @@
     <oml:index>16</oml:index>
     <oml:name>bw%2Fme</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>B</oml:nominal_value>
+          <oml:nominal_value>M</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>687</oml:number_of_missing_values>
@@ -156,7 +202,8 @@
     <oml:index>17</oml:index>
     <oml:name>bl</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>749</oml:number_of_missing_values>
@@ -165,7 +212,8 @@
     <oml:index>18</oml:index>
     <oml:name>m</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>898</oml:number_of_missing_values>
@@ -174,7 +222,8 @@
     <oml:index>19</oml:index>
     <oml:name>chrom</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>C</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>872</oml:number_of_missing_values>
@@ -183,7 +232,8 @@
     <oml:index>20</oml:index>
     <oml:name>phos</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>P</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>891</oml:number_of_missing_values>
@@ -192,7 +242,8 @@
     <oml:index>21</oml:index>
     <oml:name>cbond</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>824</oml:number_of_missing_values>
@@ -201,7 +252,8 @@
     <oml:index>22</oml:index>
     <oml:name>marvi</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>898</oml:number_of_missing_values>
@@ -210,7 +262,8 @@
     <oml:index>23</oml:index>
     <oml:name>exptl</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>896</oml:number_of_missing_values>
@@ -219,7 +272,8 @@
     <oml:index>24</oml:index>
     <oml:name>ferro</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>868</oml:number_of_missing_values>
@@ -228,7 +282,8 @@
     <oml:index>25</oml:index>
     <oml:name>corr</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>898</oml:number_of_missing_values>
@@ -237,7 +292,11 @@
     <oml:index>26</oml:index>
     <oml:name>blue%2Fbright%2Fvarn%2Fclean</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>B</oml:nominal_value>
+          <oml:nominal_value>R</oml:nominal_value>
+          <oml:nominal_value>V</oml:nominal_value>
+          <oml:nominal_value>C</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>892</oml:number_of_missing_values>
@@ -246,7 +305,8 @@
     <oml:index>27</oml:index>
     <oml:name>lustre</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>847</oml:number_of_missing_values>
@@ -255,7 +315,8 @@
     <oml:index>28</oml:index>
     <oml:name>jurofm</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>898</oml:number_of_missing_values>
@@ -264,7 +325,8 @@
     <oml:index>29</oml:index>
     <oml:name>s</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>898</oml:number_of_missing_values>
@@ -273,7 +335,8 @@
     <oml:index>30</oml:index>
     <oml:name>p</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>898</oml:number_of_missing_values>
@@ -282,7 +345,9 @@
     <oml:index>31</oml:index>
     <oml:name>shape</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>COIL</oml:nominal_value>
+          <oml:nominal_value>SHEET</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -291,7 +356,7 @@
     <oml:index>32</oml:index>
     <oml:name>thick</oml:name>
     <oml:data_type>numeric</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -300,7 +365,7 @@
     <oml:index>33</oml:index>
     <oml:name>width</oml:name>
     <oml:data_type>numeric</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -309,7 +374,7 @@
     <oml:index>34</oml:index>
     <oml:name>len</oml:name>
     <oml:data_type>numeric</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -318,7 +383,9 @@
     <oml:index>35</oml:index>
     <oml:name>oil</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>Y</oml:nominal_value>
+          <oml:nominal_value>N</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>834</oml:number_of_missing_values>
@@ -327,7 +394,11 @@
     <oml:index>36</oml:index>
     <oml:name>bore</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>0</oml:nominal_value>
+          <oml:nominal_value>500</oml:nominal_value>
+          <oml:nominal_value>600</oml:nominal_value>
+          <oml:nominal_value>760</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
@@ -336,7 +407,10 @@
     <oml:index>37</oml:index>
     <oml:name>packing</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>false</oml:is_target>
+          <oml:nominal_value>1</oml:nominal_value>
+          <oml:nominal_value>2</oml:nominal_value>
+          <oml:nominal_value>3</oml:nominal_value>
+        <oml:is_target>false</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>889</oml:number_of_missing_values>
@@ -345,10 +419,15 @@
     <oml:index>38</oml:index>
     <oml:name>class</oml:name>
     <oml:data_type>nominal</oml:data_type>
-    <oml:is_target>true</oml:is_target>
+          <oml:nominal_value>1</oml:nominal_value>
+          <oml:nominal_value>2</oml:nominal_value>
+          <oml:nominal_value>3</oml:nominal_value>
+          <oml:nominal_value>4</oml:nominal_value>
+          <oml:nominal_value>5</oml:nominal_value>
+          <oml:nominal_value>U</oml:nominal_value>
+        <oml:is_target>true</oml:is_target>
     <oml:is_ignore>false</oml:is_ignore>
     <oml:is_row_identifier>false</oml:is_row_identifier>
     <oml:number_of_missing_values>0</oml:number_of_missing_values>
   </oml:feature>
   </oml:data_features>
-

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -335,8 +335,9 @@ class TestOpenMLDataset(TestBase):
         }
         self.assertRaisesRegex(
             OpenMLHashException,
-            'Checksum ad484452702105cbf3d30f8deaba39a9 of downloaded dataset 5 '
-            'is unequal to the checksum abc sent by the server.',
+            'Checksum ad484452702105cbf3d30f8deaba39a9 of downloaded file '
+            'is unequal to the expected checksum abc. '
+            'Raised when downloading dataset 5.',
             _get_dataset_arff,
             self.workdir, description,
         )

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -261,6 +261,14 @@ class TestOpenMLDataset(TestBase):
         self.assertFalse(os.path.exists(os.path.join(
             openml.config.get_cache_directory(), "datasets", "2", "dataset.arff")))
 
+        datasets[0].get_data()
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
+
+        datasets[1].get_data()
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "2", "dataset.arff")))
+
     def test_get_dataset(self):
         dataset = openml.datasets.get_dataset(1)
         self.assertEqual(type(dataset), OpenMLDataset)
@@ -297,6 +305,10 @@ class TestOpenMLDataset(TestBase):
 
         self.assertGreater(len(dataset.features), 1)
         self.assertGreater(len(dataset.qualities), 4)
+
+        dataset.get_data()
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
 
         # Issue324 Properly handle private datasets when trying to access them
         openml.config.server = self.production_server

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -319,11 +319,12 @@ class TestOpenMLDataset(TestBase):
         dataset = openml.datasets.get_dataset(1, download_data=False)
         # We only tests functions as general integrity is tested by test_get_dataset_lazy
 
-        dataset.push_tag('lazy_tag')
+        tag = 'test_lazy_tag_%d' % random.randint(1, 1000000)
+        dataset.push_tag(tag)
         self.assertFalse(os.path.exists(os.path.join(
             openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
 
-        dataset.remove_tag('lazy_tag')
+        dataset.remove_tag(tag)
         self.assertFalse(os.path.exists(os.path.join(
             openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -239,6 +239,28 @@ class TestOpenMLDataset(TestBase):
         self.assertTrue(os.path.exists(os.path.join(
             openml.config.get_cache_directory(), "datasets", "2", "qualities.xml")))
 
+    def test_get_datasets_lazy(self):
+        dids = [1, 2]
+        datasets = openml.datasets.get_datasets(dids, download_data=False)
+        self.assertEqual(len(datasets), 2)
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "description.xml")))
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "2", "description.xml")))
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "features.xml")))
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "2", "features.xml")))
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "qualities.xml")))
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "2", "qualities.xml")))
+
+        self.assertFalse(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
+        self.assertFalse(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "2", "dataset.arff")))
+
     def test_get_dataset(self):
         dataset = openml.datasets.get_dataset(1)
         self.assertEqual(type(dataset), OpenMLDataset)
@@ -251,6 +273,27 @@ class TestOpenMLDataset(TestBase):
             openml.config.get_cache_directory(), "datasets", "1", "features.xml")))
         self.assertTrue(os.path.exists(os.path.join(
             openml.config.get_cache_directory(), "datasets", "1", "qualities.xml")))
+
+        self.assertGreater(len(dataset.features), 1)
+        self.assertGreater(len(dataset.qualities), 4)
+
+        # Issue324 Properly handle private datasets when trying to access them
+        openml.config.server = self.production_server
+        self.assertRaises(OpenMLPrivateDatasetError, openml.datasets.get_dataset, 45)
+
+    def test_get_dataset_lazy(self):
+        dataset = openml.datasets.get_dataset(1, download_data=False)
+        self.assertEqual(type(dataset), OpenMLDataset)
+        self.assertEqual(dataset.name, 'anneal')
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "description.xml")))
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "features.xml")))
+        self.assertTrue(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "qualities.xml")))
+
+        self.assertFalse(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
 
         self.assertGreater(len(dataset.features), 1)
         self.assertGreater(len(dataset.qualities), 4)

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -334,11 +334,11 @@ class TestOpenMLDataset(TestBase):
                    20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 35, 36, 37, 38]
         self.assertEqual(nominal_indices, correct)
 
-        # Due to the current implementation, retrieve_class_labels must download the file
         classes = dataset.retrieve_class_labels()
-        self.assertTrue(os.path.exists(os.path.join(
-            openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
         self.assertEqual(classes, ['1', '2', '3', '4', '5', 'U'])
+        
+        self.assertFalse(os.path.exists(os.path.join(
+            openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
 
     def test_get_dataset_sparse(self):
         dataset = openml.datasets.get_dataset(102)

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -336,7 +336,7 @@ class TestOpenMLDataset(TestBase):
 
         classes = dataset.retrieve_class_labels()
         self.assertEqual(classes, ['1', '2', '3', '4', '5', 'U'])
-        
+
         self.assertFalse(os.path.exists(os.path.join(
             openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")))
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -323,7 +323,7 @@ class TestOpenMLDataset(TestBase):
     def test__getarff_path_dataset_arff(self):
         openml.config.cache_directory = self.static_cache_dir
         description = openml.datasets.functions._get_cached_dataset_description(2)
-        arff_path = _get_dataset_arff(self.workdir, description)
+        arff_path = _get_dataset_arff(description, cache_directory=self.workdir)
         self.assertIsInstance(arff_path, str)
         self.assertTrue(os.path.exists(arff_path))
 
@@ -339,7 +339,7 @@ class TestOpenMLDataset(TestBase):
             'is unequal to the expected checksum abc. '
             'Raised when downloading dataset 5.',
             _get_dataset_arff,
-            self.workdir, description,
+            description,
         )
 
     def test__get_dataset_features(self):


### PR DESCRIPTION
Datasets can now be downloaded without downloading the `arff` file.
Function signature of `get_dataset` changed from
`def get_dataset(dataset_id: Union[int, str]) -> OpenMLDataset:`
to
`def get_dataset(dataset_id: Union[int, str], download_data: bool = True) -> OpenMLDataset:`
I chose to default to `True` so there are no breaking changes to existing code.
If `download_data=False`, only metadata will be downloaded (i.e. *all* data except the arff file).

Whenever a user invokes ~`retrieve_class_labels` or~ `get_data`, both of which require the arff-file, the arff-file is retrieved and processed as if it were downloaded from the server on initialization (e.g. pickled). This happens without warning or error/argument.
As long as only functionality is used which does not require the arff file, no additional data is downloaded.

I took the liberty to refactor `retrieve_class_labels` s.t. it uses the already downloaded feature metadata instead of reading the arff file. This makes it so that `retrieve_class_labels` can 50used without downloading the underlying data, and overall should really speed up the method in cases where a huge arff file was loaded just to check the header 👍 
As part of this I also addressed open issue #507 that was being worked on in #508 (I only realized afterwards). Though it looks like that code was from before @janvanrijn changed the xml so that the nominal values are a list. My solution is able to use this update and with only minor changes address the issue.

Fixes:
 #643 
 #612 
 #507 
 #446
 #346 in part