### PR TITLE
Fixes a bug that prevents openml from finding the config file

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -24,7 +24,7 @@ _defaults = {
     'connection_n_retries': 2,
 }
 
-config_file = os.path.expanduser(os.path.join('~', '.openml' 'config'))
+config_file = os.path.expanduser(os.path.join('~', '.openml', 'config'))
 
 # Default values are actually added here in the _setup() function which is
 # called at the end of this module

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -1,0 +1,11 @@
+import os
+
+import openml.config
+import openml.testing
+
+
+class TestConfig(openml.testing.TestBase):
+
+    def test_config_loading(self):
+        self.assertTrue(os.path.exists(openml.config.config_file))
+        self.assertTrue(os.path.isdir(os.path.expanduser('~/.openml')))


### PR DESCRIPTION
This is a pretty serious issue that breaks the current release.

#### What does this PR implement/fix? Explain your changes.
There was a comma missing in config.py which prevented openml from finding the config file. Uploads failed with a 102 'Authentication required' error.

#### How should this PR be tested?
Uploading anything to openml, with the API key only available in the config file, should not return an error anymore.


