### PR TITLE
Prefer lazy loading in unit tests

### DIFF
--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -20,12 +20,12 @@ class OpenMLDatasetTest(TestBase):
 
         # Load dataset id 2 - dataset 2 is interesting because it contains
         # missing values, categorical features etc.
-        self.dataset = openml.datasets.get_dataset(2)
+        self.dataset = openml.datasets.get_dataset(2, download_data=False)
         # titanic as missing values, categories, and string
-        self.titanic = openml.datasets.get_dataset(40945)
+        self.titanic = openml.datasets.get_dataset(40945, download_data=False)
         # these datasets have some boolean features
-        self.pc4 = openml.datasets.get_dataset(1049)
-        self.jm1 = openml.datasets.get_dataset(1053)
+        self.pc4 = openml.datasets.get_dataset(1049, download_data=False)
+        self.jm1 = openml.datasets.get_dataset(1053, download_data=False)
 
     def test_get_data_future_warning(self):
         warn_msg = 'will change from "array" to "dataframe"'
@@ -197,7 +197,7 @@ class OpenMLDatasetTestOnTestServer(TestBase):
     def setUp(self):
         super(OpenMLDatasetTestOnTestServer, self).setUp()
         # longley, really small dataset
-        self.dataset = openml.datasets.get_dataset(125)
+        self.dataset = openml.datasets.get_dataset(125, download_data=False)
 
     def test_tagging(self):
         tag = "testing_tag_{}_{}".format(self.id(), time())
@@ -219,7 +219,7 @@ class OpenMLDatasetTestSparse(TestBase):
         super(OpenMLDatasetTestSparse, self).setUp()
         openml.config.server = self.production_server
 
-        self.sparse_dataset = openml.datasets.get_dataset(4136)
+        self.sparse_dataset = openml.datasets.get_dataset(4136, download_data=False)
 
     def test_get_sparse_dataset_with_target(self):
         X, y = self.sparse_dataset.get_data(

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -1434,6 +1434,7 @@ class TestRun(TestBase):
 
         runs = openml.runs.list_runs(id=ids, task=tasks, uploader=uploaders_1)
 
+    @unittest.skip("API currently broken: https://github.com/openml/OpenML/issues/948")
     def test_get_runs_list_by_tag(self):
         # TODO: comes from live, no such lists on test
         openml.config.server = self.production_server


### PR DESCRIPTION
Prefer lazy loading for all unit tests that don't explicitly need the arff file.
Incremental progress towards #330.

I don't think it matters much for most unit tests (many call `get_data` after downloading the data regardless), but it helps for some and otherwise hopefully encourages future additions to think about lazily loading data :)

If there are any other suggestions that should be included in the PR I'd like to hear them.