### PR TITLE
Lazy download of data splits 

### DIFF
--- a/examples/datasets_tutorial.py
+++ b/examples/datasets_tutorial.py
@@ -45,6 +45,7 @@ datalist.query('NumberOfClasses > 50')
 
 # This is done based on the dataset ID ('did').
 dataset = openml.datasets.get_dataset(68)
+# NOTE: Dataset 68 exists on the test server https://test.openml.org/d/68
 
 # Print a summary
 print("This is dataset '%s', the target feature is '%s'" %
@@ -84,7 +85,7 @@ print(X.info())
 # Whenever you use any functionality that requires the data,
 # such as `get_data`, the data will be downloaded.
 dataset = openml.datasets.get_dataset(68, download_data=False)
-
+# NOTE: Dataset 68 exists on the test server https://test.openml.org/d/68
 
 ############################################################################
 # Exercise 2

--- a/examples/flows_and_runs_tutorial.py
+++ b/examples/flows_and_runs_tutorial.py
@@ -15,6 +15,7 @@ from sklearn import ensemble, neighbors, preprocessing, pipeline, tree
 #
 # Train a scikit-learn model on the data manually.
 
+# NOTE: Dataset 68 exists on the test server https://test.openml.org/d/68
 dataset = openml.datasets.get_dataset(68)
 X, y = dataset.get_data(
     dataset_format='array',

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -307,7 +307,11 @@ def get_task(task_id, download_data=True):
     -------
     task
     """
-    task_id = int(task_id)
+    try:
+        task_id = int(task_id)
+    except (ValueError, TypeError):
+        raise ValueError("Dataset ID is neither an Integer nor can be "
+                         "cast to an Integer.")
 
     with lockutils.external_lock(
             name='task.functions.get_task:%d' % task_id,
@@ -323,8 +327,6 @@ def get_task(task_id, download_data=True):
             # List of class labels availaible in dataset description
             # Including class labels as part of task meta data handles
             #   the case where data download was initially disabled
-            # The other alternative would be to abstract away this check
-            #   as part of download_split()
             if isinstance(task, OpenMLClassificationTask):
                 task.class_labels = \
                     dataset.retrieve_class_labels(task.target_name)

--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -129,6 +129,24 @@ class TestTask(TestBase):
             self.workdir, 'org', 'openml', 'test', "datasets", "1", "dataset.arff"
         )))
 
+    def test_get_task_lazy(self):
+        task = openml.tasks.get_task(2, download_data=False)
+        self.assertIsInstance(task, OpenMLTask)
+        self.assertTrue(os.path.exists(os.path.join(
+            self.workdir, 'org', 'openml', 'test', "tasks", "2", "task.xml",
+        )))
+
+        self.assertFalse(os.path.exists(os.path.join(
+            self.workdir, 'org', 'openml', 'test', "tasks", "2", "datasplits.arff"
+        )))
+        # Not checking datasets/ as other test cases might interfere
+
+        task.download_split()
+        self.assertTrue(os.path.exists(os.path.join(
+            self.workdir, 'org', 'openml', 'test', "tasks", "2", "datasplits.arff"
+        )))
+        # Not checking datasets/ as other test cases might interfere
+
     @mock.patch('openml.tasks.functions.get_dataset')
     def test_removal_upon_download_failure(self, get_dataset):
         class WeirdException(Exception):


### PR DESCRIPTION
#### What does this PR implement/fix? Explain your changes.
Addresses the pending part from #346 . Wherein, the splits and the data are not downloaded when `get_task` is called. Only when a run is executed, the data and the respective splits are downloaded.
A unit test has been added for the lazy fetch of a task.

#### How should this PR be tested?
Calling `get_task` or `get_tasks` with the additional parameter of `download_data=False` downloads only the task.xml file. Which can be verified by monitoring the cache directory. When a task is run, the corresponding datasplits.arff file is downloaded and available in the cache directory.

#### Any other comments?
- Earlier: `task.class_labels` assignment was happening in a nested manner after `task.download_split`
- Now: `task.class_labels`is being assigned even if splits are not being downloaded, by fetching it from dataset's description

