### PR TITLE
Option to return dataframes for listing functions

### DIFF
--- a/examples/datasets_tutorial.py
+++ b/examples/datasets_tutorial.py
@@ -10,8 +10,12 @@ import openml
 import pandas as pd
 
 ############################################################################
-# List datasets
-# =============
+# Exercise 0
+# **********
+#
+# * List datasets
+#   * Use the output_format parameter to select output type
+#   * Default gives 'dict' (other option: 'dataframe')
 
 openml_list = openml.datasets.list_datasets()  # returns a dict
 
@@ -21,9 +25,12 @@ datalist = datalist[[
     'did', 'name', 'NumberOfInstances',
     'NumberOfFeatures', 'NumberOfClasses'
 ]]
-
 print("First 10 of %s datasets..." % len(datalist))
 datalist.head(n=10)
+
+# The same can be done with lesser lines of code
+openml_df = openml.datasets.list_datasets(output_format='dataframe')
+openml_df.head(n=10)
 
 ############################################################################
 # Exercise 1

--- a/examples/datasets_tutorial.py
+++ b/examples/datasets_tutorial.py
@@ -25,6 +25,7 @@ datalist = datalist[[
     'did', 'name', 'NumberOfInstances',
     'NumberOfFeatures', 'NumberOfClasses'
 ]]
+
 print("First 10 of %s datasets..." % len(datalist))
 datalist.head(n=10)
 

--- a/examples/tasks_tutorial.py
+++ b/examples/tasks_tutorial.py
@@ -42,6 +42,10 @@ print(tasks.columns)
 print("First 5 of %s tasks:" % len(tasks))
 pprint(tasks.head())
 
+# The same can be obtained through lesser lines of code
+tasks_df = openml.tasks.list_tasks(task_type_id=1, output_format='dataframe')
+pprint(tasks_df.head())
+
 ############################################################################
 # We can filter the list of tasks to only contain datasets with more than
 # 500 samples, but less than 1000 samples:

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -163,7 +163,7 @@ def _get_cache_directory(dataset: OpenMLDataset) -> str:
     return _create_cache_directory_for_id(DATASETS_CACHE_DIR_NAME, dataset.dataset_id)
 
 
-def list_datasets(offset=None, size=None, status=None, tag=None, **kwargs):
+def list_datasets(offset=None, size=None, status=None, tag=None, output_format='dict', **kwargs):
 
     """
     Return a list of all dataset which are on OpenML.
@@ -180,6 +180,10 @@ def list_datasets(offset=None, size=None, status=None, tag=None, **kwargs):
         default active datasets are returned, but also datasets
         from another status can be requested.
     tag : str, optional
+    output_format: str, optional (default='dict')
+        The parameter decides the format of the output.
+        - If 'dict' the output is a dict of dict
+        - If 'dataframe' the output is a pandas DataFrame
     kwargs : dict, optional
         Legal filter operators (keys in the dict):
         data_name, data_version, number_instances,
@@ -187,21 +191,32 @@ def list_datasets(offset=None, size=None, status=None, tag=None, **kwargs):
 
     Returns
     -------
-    datasets : dict of dicts
-        A mapping from dataset ID to dict.
+    datasets : dict of dicts, or dataframe
+        - If output_format='dict'
+            A mapping from dataset ID to dict.
 
-        Every dataset is represented by a dictionary containing
-        the following information:
-        - dataset id
-        - name
-        - format
-        - status
+            Every dataset is represented by a dictionary containing
+            the following information:
+            - dataset id
+            - name
+            - format
+            - status
+            If qualities are calculated for the dataset, some of
+            these are also returned.
 
-        If qualities are calculated for the dataset, some of
-        these are also returned.
+        - If output_format='dataframe'
+            Each row maps to a dataset
+            Each column contains the following information:
+            - dataset id
+            - name
+            - format
+            - status
+            If qualities are calculated for the dataset, some of
+            these are also included as columns.
     """
 
-    return openml.utils._list_all(_list_datasets,
+    return openml.utils._list_all(output_format,
+                                  _list_datasets,
                                   offset=offset,
                                   size=size,
                                   status=status,

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -84,7 +84,7 @@ def _get_cached_datasets():
 
 
 def _get_cached_dataset(
-        dataset_id: int
+    dataset_id: int
 ) -> OpenMLDataset:
     """Get cached dataset for ID.
 
@@ -167,12 +167,12 @@ def _get_cache_directory(dataset: OpenMLDataset) -> str:
 
 
 def list_datasets(
-        offset: int = None,
-        size: int = None,
-        status: str = None,
-        tag: str = None,
-        output_format: str = 'dict',
-        **kwargs: dict
+    offset: int = None,
+    size: int = None,
+    status: str = None,
+    tag: str = None,
+    output_format: str = 'dict',
+    **kwargs: dict
 ) -> Union[Dict, pd.DataFrame]:
 
     """
@@ -224,7 +224,7 @@ def list_datasets(
             If qualities are calculated for the dataset, some of
             these are also included as columns.
     """
-    if output_format != 'dataframe' and output_format != 'dict':
+    if output_format not in ['dataframe', 'dict']:
         raise ValueError("Invalid output format selected. "
                          "Only 'dict' or 'dataframe' applicable.")
 
@@ -376,8 +376,8 @@ def _name_to_id(
 
 
 def get_datasets(
-        dataset_ids: List[Union[str, int]],
-        download_data: bool = True,
+    dataset_ids: List[Union[str, int]],
+    download_data: bool = True,
 ) -> List[OpenMLDataset]:
     """Download datasets.
 
@@ -723,8 +723,8 @@ def create_dataset(name, description, creator, contributor,
 
 
 def status_update(
-        data_id: int,
-        status: str
+    data_id: int,
+    status: str
 ) -> None:
     """
     Updates the status of a dataset to either 'active' or 'deactivated'.
@@ -756,8 +756,8 @@ def status_update(
 
 
 def _get_dataset_description(
-        did_cache_dir: str,
-        dataset_id: int
+    did_cache_dir: str,
+    dataset_id: int
 ) -> dict:
     """Get the dataset description as xml dictionary.
 
@@ -798,8 +798,8 @@ def _get_dataset_description(
 
 
 def _get_dataset_arff(
-        description: Union[Dict, OpenMLDataset],
-        cache_directory: str = None
+    description: Union[Dict, OpenMLDataset],
+    cache_directory: str = None
 ) -> str:
 
     """ Return the path to the local arff file of the dataset. If is not cached, it is downloaded.
@@ -854,8 +854,8 @@ def _get_dataset_arff(
 
 
 def _get_dataset_features(
-        did_cache_dir: str,
-        dataset_id: int
+    did_cache_dir: str,
+    dataset_id: int
 ) -> str:
     """API call to get dataset features (cached)
 
@@ -890,8 +890,8 @@ def _get_dataset_features(
 
 
 def _get_dataset_qualities(
-        did_cache_dir: str,
-        dataset_id: int
+    did_cache_dir: str,
+    dataset_id: int
 ) -> dict:
     """API call to get dataset qualities (cached)
 
@@ -931,10 +931,10 @@ def _get_dataset_qualities(
 
 
 def _create_dataset_from_description(
-        description: Dict[str, str],
-        features: Dict,
-        qualities: List,
-        arff_file: str = None,
+    description: Dict[str, str],
+    features: Dict,
+    qualities: List,
+    arff_file: str = None,
 ) -> OpenMLDataset:
     """Create a dataset object from a description dict.
 
@@ -985,7 +985,7 @@ def _create_dataset_from_description(
 
 
 def _get_online_dataset_arff(
-        dataset_id: int
+    dataset_id: int
 ) -> str:
     """Download the ARFF file for a given dataset id
     from the OpenML website.
@@ -1011,7 +1011,7 @@ def _get_online_dataset_arff(
 
 
 def _get_online_dataset_format(
-        dataset_id: int
+    dataset_id: int
 ) -> str:
     """Get the dataset format for a given dataset id
     from the OpenML website.

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -1,7 +1,6 @@
 import io
 import os
 import re
-import warnings
 from typing import List, Dict, Union, Optional
 
 import numpy as np
@@ -167,12 +166,12 @@ def _get_cache_directory(dataset: OpenMLDataset) -> str:
 
 
 def list_datasets(
-    offset: int = None,
-    size: int = None,
-    status: str = None,
-    tag: str = None,
+    offset: Optional[int] = None,
+    size: Optional[int] = None,
+    status: Optional[str] = None,
+    tag: Optional[str] = None,
     output_format: str = 'dict',
-    **kwargs: dict
+    **kwargs
 ) -> Union[Dict, pd.DataFrame]:
 
     """
@@ -722,10 +721,7 @@ def create_dataset(name, description, creator, contributor,
     )
 
 
-def status_update(
-    data_id: int,
-    status: str
-) -> None:
+def status_update(data_id, status):
     """
     Updates the status of a dataset to either 'active' or 'deactivated'.
     Please see the OpenML API documentation for a description of the status
@@ -755,10 +751,7 @@ def status_update(
         raise ValueError('Data id/status does not collide')
 
 
-def _get_dataset_description(
-    did_cache_dir: str,
-    dataset_id: int
-) -> dict:
+def _get_dataset_description(did_cache_dir, dataset_id):
     """Get the dataset description as xml dictionary.
 
     This function is NOT thread/multiprocessing safe.
@@ -797,11 +790,8 @@ def _get_dataset_description(
     return description
 
 
-def _get_dataset_arff(
-    description: Union[Dict, OpenMLDataset],
-    cache_directory: str = None
-) -> str:
-
+def _get_dataset_arff(description: Union[Dict, OpenMLDataset],
+                      cache_directory: str = None) -> str:
     """ Return the path to the local arff file of the dataset. If is not cached, it is downloaded.
 
     Checks if the file is in the cache, if yes, return the path to the file.
@@ -853,10 +843,7 @@ def _get_dataset_arff(
     return output_file_path
 
 
-def _get_dataset_features(
-    did_cache_dir: str,
-    dataset_id: int
-) -> str:
+def _get_dataset_features(did_cache_dir, dataset_id):
     """API call to get dataset features (cached)
 
     Features are feature descriptions for each column.
@@ -889,10 +876,7 @@ def _get_dataset_features(
     return _load_features_from_file(features_file)
 
 
-def _get_dataset_qualities(
-    did_cache_dir: str,
-    dataset_id: int
-) -> dict:
+def _get_dataset_qualities(did_cache_dir, dataset_id):
     """API call to get dataset qualities (cached)
 
     Features are metafeatures (number of features, number of classes, ...)
@@ -931,10 +915,10 @@ def _get_dataset_qualities(
 
 
 def _create_dataset_from_description(
-    description: Dict[str, str],
-    features: Dict,
-    qualities: List,
-    arff_file: str = None,
+        description: Dict[str, str],
+        features: Dict,
+        qualities: List,
+        arff_file: str = None,
 ) -> OpenMLDataset:
     """Create a dataset object from a description dict.
 
@@ -984,9 +968,7 @@ def _create_dataset_from_description(
     )
 
 
-def _get_online_dataset_arff(
-    dataset_id: int
-) -> str:
+def _get_online_dataset_arff(dataset_id):
     """Download the ARFF file for a given dataset id
     from the OpenML website.
 
@@ -1010,9 +992,7 @@ def _get_online_dataset_arff(
     )
 
 
-def _get_online_dataset_format(
-    dataset_id: int
-) -> str:
+def _get_online_dataset_format(dataset_id):
     """Get the dataset format for a given dataset id
     from the OpenML website.
 

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -9,17 +9,17 @@ from ..evaluations import OpenMLEvaluation
 
 
 def list_evaluations(
-        function: str,
-        offset: int = None,
-        size: int = None,
-        id: list = None,
-        task: list = None,
-        setup: list = None,
-        flow: list = None,
-        uploader: list = None,
-        tag: str = None,
-        per_fold: bool = None,
-        output_format: str = 'dict'
+    function: str,
+    offset: int = None,
+    size: int = None,
+    id: list = None,
+    task: list = None,
+    setup: list = None,
+    flow: list = None,
+    uploader: list = None,
+    tag: str = None,
+    per_fold: bool = None,
+    output_format: str = 'dict'
 ) -> Union[dict, pd.DataFrame]:
     """
     List all run-evaluation pairs matching all of the given filters.
@@ -57,6 +57,10 @@ def list_evaluations(
     -------
     dict or dataframe
     """
+    if output_format not in ['dataframe', 'dict', 'object']:
+        raise ValueError("Invalid output format selected. "
+                         "Only 'object', 'dataframe', or 'dict' applicable.")
+
     if per_fold is not None:
         per_fold = str(per_fold).lower()
 
@@ -75,14 +79,14 @@ def list_evaluations(
 
 
 def _list_evaluations(
-        function: str,
-        id: list = None,
-        task: list = None,
-        setup: list = None,
-        flow: list = None,
-        uploader: list = None,
-        output_format: str = 'dict',
-        **kwargs: dict
+    function: str,
+    id: list = None,
+    task: list = None,
+    setup: list = None,
+    flow: list = None,
+    uploader: list = None,
+    output_format: str = 'dict',
+    **kwargs: dict
 ) -> Union[dict, pd.DataFrame]:
     """
     Perform API call ``/evaluation/function{function}/{filters}``
@@ -151,10 +155,7 @@ def __list_evaluations(api_call, output_format='dict'):
     assert type(evals_dict['oml:evaluations']['oml:evaluation']) == list, \
         type(evals_dict['oml:evaluations'])
 
-    # For output_format = 'dict'
     evals = dict()
-    # if output_format == 'dataframe':
-    #     evals = []
     for eval_ in evals_dict['oml:evaluations']['oml:evaluation']:
         run_id = int(eval_['oml:run_id'])
         value = None
@@ -178,18 +179,8 @@ def __list_evaluations(api_call, output_format='dict'):
                                              eval_['oml:function'],
                                              eval_['oml:upload_time'],
                                              value, values, array_data)
-        # elif output_format == 'dataframe':
-        #     evals.append([int(eval_['oml:run_id']),
-        #                   int(eval_['oml:task_id']),
-        #                   int(eval_['oml:setup_id']),
-        #                   int(eval_['oml:flow_id']),
-        #                   eval_['oml:flow_name'],
-        #                   eval_['oml:data_id'],
-        #                   eval_['oml:data_name'],
-        #                   eval_['oml:function'],
-        #                   eval_['oml:upload_time'],
-        #                   value, values, array_data])
-        elif output_format == 'dict' or output_format == 'dataframe':
+        else:
+            # for output_format in ['dict', 'dataframe']
             evals[run_id] = {'run_id': int(eval_['oml:run_id']),
                              'task_id': int(eval_['oml:task_id']),
                              'setup_id': int(eval_['oml:setup_id']),
@@ -202,15 +193,8 @@ def __list_evaluations(api_call, output_format='dict'):
                              'value': value,
                              'values': values,
                              'array_data': array_data}
-        else:
-            raise ValueError("Invalid output format selected. "
-                             "Only 'object', 'dataframe', or 'dict' applicable.")
 
     if output_format == 'dataframe':
-        # column_names = ['run_id', 'task_id', 'setup_id', 'flow_id',
-        #                 'flow_name', 'data_id', 'data_name', 'function',
-        #                 'upload_time', 'value', 'values', 'array_data']
         evals = pd.DataFrame.from_dict(evals, orient='index')
-        # evals.columns = column_names
 
     return evals

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -1,7 +1,7 @@
 import json
 import xmltodict
 import pandas as pd
-from typing import Union
+from typing import Union, List
 
 import openml.utils
 import openml._api_calls
@@ -12,11 +12,11 @@ def list_evaluations(
     function: str,
     offset: int = None,
     size: int = None,
-    id: list = None,
-    task: list = None,
-    setup: list = None,
-    flow: list = None,
-    uploader: list = None,
+    id: List = None,
+    task: List = None,
+    setup: List = None,
+    flow: List = None,
+    uploader: List = None,
     tag: str = None,
     per_fold: bool = None,
     output_format: str = 'dict'
@@ -80,11 +80,11 @@ def list_evaluations(
 
 def _list_evaluations(
     function: str,
-    id: list = None,
-    task: list = None,
-    setup: list = None,
-    flow: list = None,
-    uploader: list = None,
+    id: List = None,
+    task: List = None,
+    setup: List = None,
+    flow: List = None,
+    uploader: List = None,
     output_format: str = 'dict',
     **kwargs: dict
 ) -> Union[dict, pd.DataFrame]:

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -1,7 +1,7 @@
 import json
 import xmltodict
 import pandas as pd
-from typing import Union, List
+from typing import Union, List, Optional, Dict
 
 import openml.utils
 import openml._api_calls
@@ -10,17 +10,17 @@ from ..evaluations import OpenMLEvaluation
 
 def list_evaluations(
     function: str,
-    offset: int = None,
-    size: int = None,
-    id: List = None,
-    task: List = None,
-    setup: List = None,
-    flow: List = None,
-    uploader: List = None,
-    tag: str = None,
-    per_fold: bool = None,
-    output_format: str = 'dict'
-) -> Union[dict, pd.DataFrame]:
+    offset: Optional[int] = None,
+    size: Optional[int] = None,
+    id: Optional[List] = None,
+    task: Optional[List] = None,
+    setup: Optional[List] = None,
+    flow: Optional[List] = None,
+    uploader: Optional[List] = None,
+    tag: Optional[str] = None,
+    per_fold: Optional[bool] = None,
+    output_format: str = 'object'
+) -> Union[Dict, pd.DataFrame]:
     """
     List all run-evaluation pairs matching all of the given filters.
     (Supports large amount of results)
@@ -48,8 +48,9 @@ def list_evaluations(
 
     per_fold : bool, optional
 
-    output_format: str, optional (default='dict')
+    output_format: str, optional (default='object')
         The parameter decides the format of the output.
+        - If 'object' the output is a dict of OpenMLEvaluation objects
         - If 'dict' the output is a dict of dict
         - If 'dataframe' the output is a pandas DataFrame
 
@@ -61,8 +62,9 @@ def list_evaluations(
         raise ValueError("Invalid output format selected. "
                          "Only 'object', 'dataframe', or 'dict' applicable.")
 
+    per_fold_str = None
     if per_fold is not None:
-        per_fold = str(per_fold).lower()
+        per_fold_str = str(per_fold).lower()
 
     return openml.utils._list_all(output_format=output_format,
                                   listing_call=_list_evaluations,
@@ -75,19 +77,19 @@ def list_evaluations(
                                   flow=flow,
                                   uploader=uploader,
                                   tag=tag,
-                                  per_fold=per_fold)
+                                  per_fold=per_fold_str)
 
 
 def _list_evaluations(
     function: str,
-    id: List = None,
-    task: List = None,
-    setup: List = None,
-    flow: List = None,
-    uploader: List = None,
-    output_format: str = 'dict',
-    **kwargs: dict
-) -> Union[dict, pd.DataFrame]:
+    id: Optional[List] = None,
+    task: Optional[List] = None,
+    setup: Optional[List] = None,
+    flow: Optional[List] = None,
+    uploader: Optional[List] = None,
+    output_format: str = 'object',
+    **kwargs
+) -> Union[Dict, pd.DataFrame]:
     """
     Perform API call ``/evaluation/function{function}/{filters}``
 
@@ -143,7 +145,7 @@ def _list_evaluations(
     return __list_evaluations(api_call, output_format=output_format)
 
 
-def __list_evaluations(api_call, output_format='dict'):
+def __list_evaluations(api_call, output_format='object'):
     """Helper function to parse API calls which are lists of runs"""
     xml_string = openml._api_calls._perform_api_call(api_call, 'get')
     evals_dict = xmltodict.parse(xml_string, force_list=('oml:evaluation',))

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -8,7 +8,7 @@ from ..evaluations import OpenMLEvaluation
 
 def list_evaluations(function, offset=None, size=None, id=None, task=None,
                      setup=None, flow=None, uploader=None, tag=None,
-                     per_fold=None):
+                     per_fold=None, output_format='dict'):
     """
     List all run-evaluation pairs matching all of the given filters.
     (Supports large amount of results)
@@ -36,17 +36,22 @@ def list_evaluations(function, offset=None, size=None, id=None, task=None,
 
     per_fold : bool, optional
 
+    output_format: str, optional (default='dict')
+        The parameter decides the format of the output.
+        - If 'dict' the output is a dict of dict
+        - If 'dataframe' the output is a pandas DataFrame
+
     Returns
     -------
-    dict
+    dict or dataframe
     """
     if per_fold is not None:
         per_fold = str(per_fold).lower()
 
-    return openml.utils._list_all(_list_evaluations, function, offset=offset,
-                                  size=size, id=id, task=task, setup=setup,
-                                  flow=flow, uploader=uploader, tag=tag,
-                                  per_fold=per_fold)
+    return openml.utils._list_all(output_format, _list_evaluations, function,
+                                  offset=offset, size=size, id=id, task=task,
+                                  setup=setup, flow=flow, uploader=uploader,
+                                  tag=tag, per_fold=per_fold)
 
 
 def _list_evaluations(function, id=None, task=None,

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -127,7 +127,8 @@ def _get_flow_description(flow_id: int) -> OpenMLFlow:
         return _create_flow_from_xml(flow_xml)
 
 
-def list_flows(offset: int = None, size: int = None, tag: str = None, **kwargs) \
+def list_flows(offset: int = None, size: int = None, tag: str = None,
+               output_format: str = 'dict', **kwargs) \
         -> Dict[int, Dict]:
 
     """
@@ -142,25 +143,40 @@ def list_flows(offset: int = None, size: int = None, tag: str = None, **kwargs) 
         the maximum number of flows to return
     tag : str, optional
         the tag to include
+    output_format: str, optional (default='dict')
+        The parameter decides the format of the output.
+        - If 'dict' the output is a dict of dict
+        - If 'dataframe' the output is a pandas DataFrame
     kwargs: dict, optional
         Legal filter operators: uploader.
 
     Returns
     -------
-    flows : dict
-        A mapping from flow_id to a dict giving a brief overview of the
-        respective flow.
+    flows : dict of dicts, or dataframe
+        - If output_format='dict'
+            A mapping from flow_id to a dict giving a brief overview of the
+            respective flow.
+            Every flow is represented by a dictionary containing
+            the following information:
+            - flow id
+            - full name
+            - name
+            - version
+            - external version
+            - uploader
 
-        Every flow is represented by a dictionary containing
-        the following information:
-        - flow id
-        - full name
-        - name
-        - version
-        - external version
-        - uploader
+        - If output_format='dataframe'
+            Each row maps to a dataset
+            Each column contains the following information:
+            - flow id
+            - full name
+            - name
+            - version
+            - external version
+            - uploader
     """
-    return openml.utils._list_all(_list_flows,
+    return openml.utils._list_all(output_format,
+                                  _list_flows,
                                   offset=offset,
                                   size=size,
                                   tag=tag,

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -5,7 +5,7 @@ import io
 import re
 import xmltodict
 import pandas as pd
-from typing import Union, Dict
+from typing import Union, Dict, Optional
 
 from ..exceptions import OpenMLCacheException
 import openml._api_calls
@@ -129,12 +129,12 @@ def _get_flow_description(flow_id: int) -> OpenMLFlow:
 
 
 def list_flows(
-    offset: int = None,
-    size: int = None,
-    tag: str = None,
+    offset: Optional[int] = None,
+    size: Optional[int] = None,
+    tag: Optional[str] = None,
     output_format: str = 'dict',
-    **kwargs: dict
-) -> Dict[int, Dict]:
+    **kwargs
+) -> Union[Dict, pd.DataFrame]:
 
     """
     Return a list of all flows which are on OpenML.
@@ -192,7 +192,7 @@ def list_flows(
                                   **kwargs)
 
 
-def _list_flows(output_format='dict', **kwargs) -> Dict[int, Dict]:
+def _list_flows(output_format='dict', **kwargs) -> Union[Dict, pd.DataFrame]:
     """
     Perform the api call that return a list of all flows.
 
@@ -262,7 +262,7 @@ def flow_exists(name: str, external_version: str) -> Union[int, bool]:
 def __list_flows(
     api_call: str,
     output_format: str = 'dict'
-) -> Union[dict, pd.DataFrame]:
+) -> Union[Dict, pd.DataFrame]:
 
     xml_string = openml._api_calls._perform_api_call(api_call, 'get')
     flows_dict = xmltodict.parse(xml_string, force_list=('oml:flow',))

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -129,11 +129,11 @@ def _get_flow_description(flow_id: int) -> OpenMLFlow:
 
 
 def list_flows(
-        offset: int = None,
-        size: int = None,
-        tag: str = None,
-        output_format: str = 'dict',
-        **kwargs: dict
+    offset: int = None,
+    size: int = None,
+    tag: str = None,
+    output_format: str = 'dict',
+    **kwargs: dict
 ) -> Dict[int, Dict]:
 
     """
@@ -180,7 +180,7 @@ def list_flows(
             - external version
             - uploader
     """
-    if output_format != 'dataframe' and output_format != 'dict':
+    if output_format not in ['dataframe', 'dict']:
         raise ValueError("Invalid output format selected. "
                          "Only 'dict' or 'dataframe' applicable.")
 
@@ -260,8 +260,8 @@ def flow_exists(name: str, external_version: str) -> Union[int, bool]:
 
 
 def __list_flows(
-        api_call: str,
-        output_format: str = 'dict'
+    api_call: str,
+    output_format: str = 'dict'
 ) -> Union[dict, pd.DataFrame]:
 
     xml_string = openml._api_calls._perform_api_call(api_call, 'get')

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import io
 import itertools
 import os
-from typing import Any, List, Optional, Set, Tuple, Union, TYPE_CHECKING  # noqa F401
+from typing import Any, List, Dict, Optional, Set, Tuple, Union, TYPE_CHECKING  # noqa F401
 import warnings
 
 import sklearn.metrics
@@ -394,11 +394,6 @@ def _run_task_get_arffcontent(
     # is the same as the fold-based measures, and disregarded in that case
     user_defined_measures_per_sample = OrderedDict()  # type: 'OrderedDict[str, OrderedDict]'
 
-    # sys.version_info returns a tuple, the following line compares the entry
-    # of tuples
-    # https://docs.python.org/3.6/reference/expressions.html#value-comparisons
-    can_measure_runtime = sys.version_info[:2] >= (3, 3) and \
-        _check_n_jobs(model)
     # TODO use different iterator to only provide a single iterator (less
     # methods, less maintenance, less confusion)
     num_reps, num_folds, num_samples = task.get_split_dimensions()
@@ -768,18 +763,18 @@ def _get_cached_run(run_id):
 
 
 def list_runs(
-    offset: int = None,
-    size: int = None,
-    id: List = None,
-    task: List = None,
-    setup: List = None,
-    flow: List = None,
-    uploader: List = None,
-    tag: str = None,
+    offset: Optional[int] = None,
+    size: Optional[int] = None,
+    id: Optional[List] = None,
+    task: Optional[List] = None,
+    setup: Optional[List] = None,
+    flow: Optional[List] = None,
+    uploader: Optional[List] = None,
+    tag: Optional[str] = None,
     display_errors: bool = False,
     output_format: str = 'dict',
-    **kwargs: dict
-) -> Union[dict, pd.DataFrame]:
+    **kwargs
+) -> Union[Dict, pd.DataFrame]:
     """
     List all runs matching all of the given filters.
     (Supports large amount of results)
@@ -849,15 +844,15 @@ def list_runs(
 
 
 def _list_runs(
-    id: List = None,
-    task: List = None,
-    setup: List = None,
-    flow: List = None,
-    uploader: List = None,
+    id: Optional[List] = None,
+    task: Optional[List] = None,
+    setup: Optional[List] = None,
+    flow: Optional[List] = None,
+    uploader: Optional[List] = None,
     display_errors: bool = False,
     output_format: str = 'dict',
     **kwargs
-) -> Union[dict, pd.DataFrame]:
+) -> Union[Dict, pd.DataFrame]:
     """
     Perform API call `/run/list/{filters}'
     <https://www.openml.org/api_docs/#!/run/get_run_list_filters>`

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -770,11 +770,11 @@ def _get_cached_run(run_id):
 def list_runs(
     offset: int = None,
     size: int = None,
-    id: list = None,
-    task: list = None,
-    setup: list = None,
-    flow: list = None,
-    uploader: list = None,
+    id: List = None,
+    task: List = None,
+    setup: List = None,
+    flow: List = None,
+    uploader: List = None,
     tag: str = None,
     display_errors: bool = False,
     output_format: str = 'dict',
@@ -849,11 +849,11 @@ def list_runs(
 
 
 def _list_runs(
-    id: list = None,
-    task: list = None,
-    setup: list = None,
-    flow: list = None,
-    uploader: list = None,
+    id: List = None,
+    task: List = None,
+    setup: List = None,
+    flow: List = None,
+    uploader: List = None,
     display_errors: bool = False,
     output_format: str = 'dict',
     **kwargs

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -768,17 +768,17 @@ def _get_cached_run(run_id):
 
 
 def list_runs(
-        offset: int = None,
-        size: int = None,
-        id: list = None,
-        task: list = None,
-        setup: list = None,
-        flow: list = None,
-        uploader: list = None,
-        tag: str = None,
-        display_errors: bool = False,
-        output_format: str = 'dict',
-        **kwargs: dict
+    offset: int = None,
+    size: int = None,
+    id: list = None,
+    task: list = None,
+    setup: list = None,
+    flow: list = None,
+    uploader: list = None,
+    tag: str = None,
+    display_errors: bool = False,
+    output_format: str = 'dict',
+    **kwargs: dict
 ) -> Union[dict, pd.DataFrame]:
     """
     List all runs matching all of the given filters.
@@ -819,7 +819,7 @@ def list_runs(
     -------
     dict of dicts, or dataframe
     """
-    if output_format != 'dataframe' and output_format != 'dict':
+    if output_format not in ['dataframe', 'dict']:
         raise ValueError("Invalid output format selected. "
                          "Only 'dict' or 'dataframe' applicable.")
 
@@ -849,14 +849,14 @@ def list_runs(
 
 
 def _list_runs(
-        id: list = None,
-        task: list = None,
-        setup: list = None,
-        flow: list = None,
-        uploader: list = None,
-        display_errors: bool = False,
-        output_format: str = 'dict',
-        **kwargs
+    id: list = None,
+    task: list = None,
+    setup: list = None,
+    flow: list = None,
+    uploader: list = None,
+    display_errors: bool = False,
+    output_format: str = 'dict',
+    **kwargs
 ) -> Union[dict, pd.DataFrame]:
     """
     Perform API call `/run/list/{filters}'

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -763,7 +763,7 @@ def _get_cached_run(run_id):
 
 def list_runs(offset=None, size=None, id=None, task=None, setup=None,
               flow=None, uploader=None, tag=None, display_errors=False,
-              **kwargs):
+              output_format='dict', **kwargs):
     """
     List all runs matching all of the given filters.
     (Supports large amount of results)
@@ -791,6 +791,11 @@ def list_runs(offset=None, size=None, id=None, task=None, setup=None,
         Whether to list runs which have an error (for example a missing
         prediction file).
 
+    output_format: str, optional (default='dict')
+        The parameter decides the format of the output.
+        - If 'dict' the output is a dict of dict
+        - If 'dataframe' the output is a pandas DataFrame
+
     kwargs : dict, optional
         Legal filter operators: task_type.
 
@@ -812,9 +817,9 @@ def list_runs(offset=None, size=None, id=None, task=None, setup=None,
         raise TypeError('uploader must be of type list.')
 
     return openml.utils._list_all(
-        _list_runs, offset=offset, size=size, id=id, task=task, setup=setup,
-        flow=flow, uploader=uploader, tag=tag, display_errors=display_errors,
-        **kwargs)
+        output_format, _list_runs, offset=offset, size=size, id=id, task=task,
+        setup=setup, flow=flow, uploader=uploader, tag=tag,
+        display_errors=display_errors, **kwargs)
 
 
 def _list_runs(id=None, task=None, setup=None,

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -108,7 +108,8 @@ def get_setup(setup_id):
     return _create_setup_from_xml(result_dict)
 
 
-def list_setups(offset=None, size=None, flow=None, tag=None, setup=None):
+def list_setups(offset=None, size=None, flow=None, tag=None, setup=None,
+                output_format: str = 'dict'):
     """
     List all setups matching all of the given filters.
 
@@ -119,14 +120,18 @@ def list_setups(offset=None, size=None, flow=None, tag=None, setup=None):
     flow : int, optional
     tag : str, optional
     setup : list(int), optional
+    output_format: str, optional (default='dict')
+        The parameter decides the format of the output.
+        - If 'dict' the output is a dict of dict
+        - If 'dataframe' the output is a pandas DataFrame
 
     Returns
     -------
-    dict
+    dict or dataframe
         """
     batch_size = 1000  # batch size for setups is lower
-    return openml.utils._list_all(_list_setups, offset=offset, size=size,
-                                  flow=flow, tag=tag,
+    return openml.utils._list_all(output_format, _list_setups, offset=offset,
+                                  size=size, flow=flow, tag=tag,
                                   setup=setup, batch_size=batch_size)
 
 

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -74,7 +74,7 @@ def _get_cached_setup(setup_id, output_format='object'):
             "Setup file for setup id %d not cached" % setup_id)
 
 
-def get_setup(setup_id, output_format='object'):
+def get_setup(setup_id):
     """
      Downloads the setup (configuration) description from OpenML
      and returns a structured object
@@ -83,8 +83,6 @@ def get_setup(setup_id, output_format='object'):
     ----------
     setup_id : int
         The Openml setup_id
-    output_format : str, optional (default='object')
-        Describes type of output {'dict', 'dataframe', 'object'}
 
     Returns
     -------
@@ -99,7 +97,7 @@ def get_setup(setup_id, output_format='object'):
         os.makedirs(setup_dir)
 
     try:
-        return _get_cached_setup(setup_id, output_format=output_format)
+        return _get_cached_setup(setup_id, output_format=object')
     except (openml.exceptions.OpenMLCacheException):
         url_suffix = '/setup/%d' % setup_id
         setup_xml = openml._api_calls._perform_api_call(url_suffix, 'get')
@@ -107,7 +105,7 @@ def get_setup(setup_id, output_format='object'):
             fh.write(setup_xml)
 
     result_dict = xmltodict.parse(setup_xml)
-    return _create_setup_from_xml(result_dict, output_format=output_format)
+    return _create_setup_from_xml(result_dict, output_format=object')
 
 
 def list_setups(

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -111,12 +111,12 @@ def get_setup(setup_id: int) -> OpenMLSetup:
 
 
 def list_setups(
-        offset: int = None,
-        size: int = None,
-        flow: int = None,
-        tag: str = None,
-        setup: list = None,
-        output_format: str = 'dict'
+    offset: int = None,
+    size: int = None,
+    flow: int = None,
+    tag: str = None,
+    setup: list = None,
+    output_format: str = 'dict'
 ) -> Union[dict, pd.DataFrame]:
     """
     List all setups matching all of the given filters.
@@ -137,7 +137,7 @@ def list_setups(
     -------
     dict or dataframe
     """
-    if (output_format != 'dataframe' and output_format != 'dict' and output_format != 'object'):
+    if output_format not in ['dataframe', 'dict', 'object']:
         raise ValueError("Invalid output format selected. "
                          "Only 'dict', 'object', or 'dataframe' applicable.")
 
@@ -294,27 +294,14 @@ def _create_setup_from_xml(result_dict, output_format='object'):
             raise ValueError('Expected None, list or dict, received '
                              'something else: %s' % str(type(xml_parameters)))
 
-    if output_format == 'dataframe' or output_format == 'dict':
+    if output_format in ['dataframe', 'dict']:
         return_dict = {'setup_id': setup_id, 'flow_id': flow_id}
         return_dict['parameters'] = parameters
-        # if parameters is not None:
-        #     for key in parameters:
-        #         return_dict[key] = parameters[key]
-        # return_dict.append(parameters)
         return(return_dict)
     return OpenMLSetup(setup_id, flow_id, parameters)
 
 
 def _create_setup_parameter_from_xml(result_dict, output_format='object'):
-    # if output_format == 'dataframe' or output_format == 'dict':
-    #     return({'input:id': int(result_dict['oml:id']),
-    #             'flow_id': int(result_dict['oml:flow_id']),
-    #             'flow_name': result_dict['oml:flow_name'],
-    #             'full_name': result_dict['oml:full_name'],
-    #             'parameter_name': result_dict['oml:parameter_name'],
-    #             'data_type': result_dict['oml:data_type'],
-    #             'default_value': result_dict['oml:default_value'],
-    #             'value': result_dict['oml:value']})
     return OpenMLParameter(input_id=int(result_dict['oml:id']),
                            flow_id=int(result_dict['oml:flow_id']),
                            flow_name=result_dict['oml:flow_name'],

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -58,7 +58,7 @@ def setup_exists(flow) -> int:
         return False
 
 
-def _get_cached_setup(setup_id, output_format='object'):
+def _get_cached_setup(setup_id):
     """Load a run from the cache."""
     cache_dir = config.get_cache_directory()
     setup_cache_dir = os.path.join(cache_dir, "setups", str(setup_id))
@@ -66,7 +66,7 @@ def _get_cached_setup(setup_id, output_format='object'):
         setup_file = os.path.join(setup_cache_dir, "description.xml")
         with io.open(setup_file, encoding='utf8') as fh:
             setup_xml = xmltodict.parse(fh.read())
-            setup = _create_setup_from_xml(setup_xml, output_format=output_format)
+            setup = _create_setup_from_xml(setup_xml, output_format='object')
         return setup
 
     except (OSError, IOError):
@@ -97,7 +97,7 @@ def get_setup(setup_id):
         os.makedirs(setup_dir)
 
     try:
-        return _get_cached_setup(setup_id, output_format=object')
+        return _get_cached_setup(setup_id)
     except (openml.exceptions.OpenMLCacheException):
         url_suffix = '/setup/%d' % setup_id
         setup_xml = openml._api_calls._perform_api_call(url_suffix, 'get')
@@ -105,7 +105,7 @@ def get_setup(setup_id):
             fh.write(setup_xml)
 
     result_dict = xmltodict.parse(setup_xml)
-    return _create_setup_from_xml(result_dict, output_format=object')
+    return _create_setup_from_xml(result_dict, output_format='object')
 
 
 def list_setups(

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import xmltodict
 import pandas as pd
-from typing import Union
+from typing import Union, List
 
 import openml
 from .. import config
@@ -115,7 +115,7 @@ def list_setups(
     size: int = None,
     flow: int = None,
     tag: str = None,
-    setup: list = None,
+    setup: List = None,
     output_format: str = 'dict'
 ) -> Union[dict, pd.DataFrame]:
     """

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -223,7 +223,7 @@ def __list_setups(api_call, output_format='object'):
     return setups
 
 
-def initialize_model(setup_id: int, output_format: str = 'object') -> Any:
+def initialize_model(setup_id: int) -> Any:
     """
     Initialized a model based on a setup_id (i.e., using the exact
     same parameter settings)
@@ -237,7 +237,7 @@ def initialize_model(setup_id: int, output_format: str = 'object') -> Any:
     -------
     model
     """
-    setup = get_setup(setup_id, output_format=output_format)
+    setup = get_setup(setup_id)
     flow = openml.flows.get_flow(setup.flow_id)
 
     # instead of using scikit-learns or any other library's "set_params" function, we override the

--- a/openml/study/functions.py
+++ b/openml/study/functions.py
@@ -3,7 +3,7 @@ import warnings
 
 import dateutil.parser
 import xmltodict
-from typing import Union
+from typing import Union, List
 import pandas as pd
 
 from openml.study import OpenMLStudy, OpenMLBenchmarkSuite
@@ -466,7 +466,7 @@ def list_studies(
     offset: int = None,
     size: int = None,
     status: str = None,
-    uploader: list = None,
+    uploader: List = None,
     benchmark_suite: str = None,
     output_format: str = 'dict'
 ) -> Union[dict, pd.DataFrame]:

--- a/openml/study/functions.py
+++ b/openml/study/functions.py
@@ -463,12 +463,12 @@ def list_suites(
 
 
 def list_studies(
-        offset: int = None,
-        size: int = None,
-        status: str = None,
-        uploader: list = None,
-        benchmark_suite: str = None,
-        output_format: str = 'dict'
+    offset: int = None,
+    size: int = None,
+    status: str = None,
+    uploader: list = None,
+    benchmark_suite: str = None,
+    output_format: str = 'dict'
 ) -> Union[dict, pd.DataFrame]:
     """
     Return a list of all studies which are on OpenML.
@@ -518,7 +518,7 @@ def list_studies(
             If qualities are calculated for the dataset, some of
             these are also returned.
     """
-    if (output_format != 'dataframe' and output_format != 'dict'):
+    if output_format not in ['dataframe', 'dict']:
         raise ValueError("Invalid output format selected. "
                          "Only 'dict' or 'dataframe' applicable.")
 

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -2,6 +2,13 @@ from collections import OrderedDict
 import io
 import re
 import os
+import warnings
+
+# Currently, importing oslo raises a lot of warning that it will stop working
+# under python3.8; remove this once they disappear
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from oslo_concurrency import lockutils
 import xmltodict
 
 from ..exceptions import OpenMLCacheException
@@ -120,9 +127,10 @@ def _get_estimation_procedure_list():
     return procs
 
 
-def list_tasks(task_type_id=None, offset=None, size=None, tag=None, **kwargs):
-    """Return a number of tasks having the given tag and task_type_id
-
+def list_tasks(task_type_id=None, offset=None, size=None, tag=None,
+               output_format='dict', **kwargs):
+    """
+    Return a number of tasks having the given tag and task_type_id
     Parameters
     ----------
     Filter task_type_id is separated from the other filters because
@@ -145,11 +153,14 @@ def list_tasks(task_type_id=None, offset=None, size=None, tag=None, **kwargs):
         the maximum number of tasks to show
     tag : str, optional
         the tag to include
+    output_format: str, optional (default='dict')
+        The parameter decides the format of the output.
+        - If 'dict' the output is a dict of dict
+        - If 'dataframe' the output is a pandas DataFrame
     kwargs: dict, optional
         Legal filter operators: data_tag, status, data_id, data_name,
         number_instances, number_features,
         number_classes, number_missing_values.
-
     Returns
     -------
     dict
@@ -158,13 +169,14 @@ def list_tasks(task_type_id=None, offset=None, size=None, tag=None, **kwargs):
         task id, dataset id, task_type and status. If qualities are calculated
         for the associated dataset, some of these are also returned.
     """
-    return openml.utils._list_all(_list_tasks, task_type_id=task_type_id,
-                                  offset=offset, size=size, tag=tag, **kwargs)
+    return openml.utils._list_all(output_format, _list_tasks,
+                                  task_type_id=task_type_id, offset=offset,
+                                  size=size, tag=tag, **kwargs)
 
 
 def _list_tasks(task_type_id=None, **kwargs):
-    """Perform the api call to return a number of tasks having the given filters.
-
+    """
+    Perform the api call to return a number of tasks having the given filters.
     Parameters
     ----------
     Filter task_type_id is separated from the other filters because

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -2,15 +2,8 @@ from collections import OrderedDict
 import io
 import re
 import os
-import warnings
-from typing import Union
+from typing import Union, Dict, Optional
 import pandas as pd
-
-# Currently, importing oslo raises a lot of warning that it will stop working
-# under python3.8; remove this once they disappear
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from oslo_concurrency import lockutils
 import xmltodict
 
 from ..exceptions import OpenMLCacheException
@@ -130,13 +123,13 @@ def _get_estimation_procedure_list():
 
 
 def list_tasks(
-    task_type_id: int = None,
-    offset: int = None,
-    size: int = None,
-    tag: str = None,
+    task_type_id: Optional[int] = None,
+    offset: Optional[int] = None,
+    size: Optional[int] = None,
+    tag: Optional[str] = None,
     output_format: str = 'dict',
     **kwargs
-) -> Union[dict, pd.DataFrame]:
+) -> Union[Dict, pd.DataFrame]:
     """
     Return a number of tasks having the given tag and task_type_id
     Parameters
@@ -169,6 +162,7 @@ def list_tasks(
         Legal filter operators: data_tag, status, data_id, data_name,
         number_instances, number_features,
         number_classes, number_missing_values.
+
     Returns
     -------
     dict
@@ -224,7 +218,7 @@ def _list_tasks(task_type_id=None, output_format='dict', **kwargs):
 
     Returns
     -------
-    dict
+    dict or dataframe
     """
     api_call = "task/list"
     if task_type_id is not None:

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -130,12 +130,12 @@ def _get_estimation_procedure_list():
 
 
 def list_tasks(
-        task_type_id: int = None,
-        offset: int = None,
-        size: int = None,
-        tag: str = None,
-        output_format: str = 'dict',
-        **kwargs
+    task_type_id: int = None,
+    offset: int = None,
+    size: int = None,
+    tag: str = None,
+    output_format: str = 'dict',
+    **kwargs
 ) -> Union[dict, pd.DataFrame]:
     """
     Return a number of tasks having the given tag and task_type_id
@@ -182,7 +182,7 @@ def list_tasks(
         as columns: task id, dataset id, task_type and status. If qualities are
         calculated for the associated dataset, some of these are also returned.
     """
-    if output_format != 'dataframe' and output_format != 'dict':
+    if output_format not in ['dataframe', 'dict']:
         raise ValueError("Invalid output format selected. "
                          "Only 'dict' or 'dataframe' applicable.")
     return openml.utils._list_all(output_format=output_format,

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -151,12 +151,12 @@ def _delete_entity(entity_type, entity_id):
         return False
 
 
-def _list_all(output_format, listing_call, *args, **filters):
+def _list_all(listing_call, output_format='dict', *args, **filters):
     """Helper to handle paged listing requests.
 
     Example usage:
 
-    ``evaluations = _list_all(list_evaluations, "predictive_accuracy", task=mytask)``
+    ``evaluations = list_all(list_evaluations, "predictive_accuracy", task=mytask)``
 
     Parameters
     ----------

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -242,42 +242,7 @@ def _list_all(output_format, listing_call, *args, **filters):
             if BATCH_SIZE_ORIG > LIMIT - len(result):
                 batch_size = LIMIT - len(result)
 
-    # Checking and converting to dataframe
-    # if output_format is not None and output_format == 'dataframe':
-    #     result = _unwrap_object_to_dict(result)
-    #     result = pd.DataFrame.from_dict(result, orient='index')
     return result
-
-
-def _unwrap_object_to_dict(result_dict):
-    """Converts a dict to object mapping to dict of dict
-
-    If the elements of the dict keys are class objects, it converts
-    the objects into dicts to create a dict of dict.
-    Else, it returns the dict as is.
-
-    Parameters
-    ----------
-    result_dict: dict
-
-    Returns
-    -------
-    dict
-    """
-    # Checking first entry of dict
-    val = next(iter(result_dict.values()))
-    # Checking if dict contains class object
-    if not hasattr(val, '__dict__'):
-        return result_dict
-    # Extracting class name
-    obj_type = str(type(next(iter(result_dict.values()))))
-    obj_type = obj_type.split('.')[-1].split('\'')[0]
-    for key in result_dict:
-        obj = result_dict[key]
-        result_dict[key] = vars(obj)
-        # Retaining the original object as a dataframe entry
-        result_dict[key].update({obj_type: obj})
-    return result_dict
 
 
 def _create_cache_directory(key):

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -153,6 +153,11 @@ class TestOpenMLDataset(TestBase):
         self.assertGreaterEqual(len(datasets), 100)
         self._check_datasets(datasets)
 
+    def test_list_datasets_output_format(self):
+        datasets = openml.datasets.list_datasets(output_format='dataframe')
+        self.assertIsInstance(datasets, pd.DataFrame)
+        self.assertGreaterEqual(len(datasets), 100)
+
     def test_list_datasets_by_tag(self):
         datasets = openml.datasets.list_datasets(tag='study_14')
         self.assertGreaterEqual(len(datasets), 100)

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -4,6 +4,7 @@ import unittest
 
 from distutils.version import LooseVersion
 import sklearn
+import pandas as pd
 
 import openml
 from openml.testing import TestBase
@@ -34,6 +35,14 @@ class TestFlowFunctions(TestBase):
         self.assertGreaterEqual(len(flows), 1500)
         for fid in flows:
             self._check_flow(flows[fid])
+
+    def test_list_flows_output_format(self):
+        openml.config.server = self.production_server
+        # We can only perform a smoke test here because we test on dynamic
+        # data from the internet...
+        flows = openml.flows.list_flows(output_format='dataframe')
+        self.assertIsInstance(flows, pd.DataFrame)
+        self.assertGreaterEqual(len(flows), 1500)
 
     def test_list_flows_empty(self):
         openml.config.server = self.production_server

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -14,6 +14,7 @@ import openml._api_calls
 import sklearn
 import unittest
 import warnings
+import pandas as pd
 
 import openml.extensions.sklearn
 from openml.testing import TestBase
@@ -1112,6 +1113,10 @@ class TestRun(TestBase):
             raise ValueError('UnitTest Outdated, got somehow results')
 
         self.assertIsInstance(runs, dict)
+
+    def test_list_runs_output_format(self):
+        runs = openml.runs.list_runs(size=1000, output_format='dataframe')
+        self.assertIsInstance(runs, pd.DataFrame)
 
     def test_get_runs_list_by_task(self):
         # TODO: comes from live, no such lists on test

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -141,11 +141,18 @@ class TestSetupFunctions(TestBase):
         flow_id = 5873
         setups = openml.setups.list_setups(flow=flow_id, output_format='object')
         self.assertIsInstance(setups, Dict)
-        self.assertIsInstance(setups[30948], openml.setups.setup.OpenMLSetup)
+        self.assertIsInstance(isinstance(setups[list(setups.keys())[1]],
+                                         openml.setups.setup.OpenMLSetup))
+        self.assertGreater(len(setups), 0)
 
         setups = openml.setups.list_setups(flow=flow_id, output_format='dataframe')
         self.assertIsInstance(setups, pd.DataFrame)
-        self.assertEqual(len(setups), 2)
+        self.assertGreater(len(setups), 0)
+
+        setups = openml.setups.list_setups(flow=flow_id, output_format='dict')
+        self.assertIsInstance(setups, Dict)
+        self.assertIsInstance(isinstance(setups[list(setups.keys())[1]], Dict))
+        self.assertGreater(len(setups), 0)
 
     def test_setuplist_offset(self):
         # TODO: remove after pull on live for better testing

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -6,6 +6,8 @@ import openml
 import openml.exceptions
 import openml.extensions.sklearn
 from openml.testing import TestBase
+from typing import Dict
+import pandas as pd
 
 import sklearn.tree
 import sklearn.naive_bayes
@@ -134,6 +136,16 @@ class TestSetupFunctions(TestBase):
             raise ValueError('UnitTest Outdated, got somehow results')
 
         self.assertIsInstance(setups, dict)
+
+    def test_list_setups_output_format(self):
+        flow_id = 5873
+        setups = openml.setups.list_setups(flow=flow_id, output_format='object')
+        self.assertIsInstance(setups, Dict)
+        self.assertIsInstance(setups[30948], openml.setups.setup.OpenMLSetup)
+
+        setups = openml.setups.list_setups(flow=flow_id, output_format='dataframe')
+        self.assertIsInstance(setups, pd.DataFrame)
+        self.assertEqual(len(setups), 2)
 
     def test_setuplist_offset(self):
         # TODO: remove after pull on live for better testing

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -141,8 +141,8 @@ class TestSetupFunctions(TestBase):
         flow_id = 18
         setups = openml.setups.list_setups(flow=flow_id, output_format='object')
         self.assertIsInstance(setups, Dict)
-        self.assertIsInstance(isinstance(setups[list(setups.keys())[0]],
-                                         openml.setups.setup.OpenMLSetup))
+        self.assertIsInstance(setups[list(setups.keys())[0]],
+                              openml.setups.setup.OpenMLSetup)
         self.assertGreater(len(setups), 0)
 
         setups = openml.setups.list_setups(flow=flow_id, output_format='dataframe')
@@ -151,7 +151,7 @@ class TestSetupFunctions(TestBase):
 
         setups = openml.setups.list_setups(flow=flow_id, output_format='dict')
         self.assertIsInstance(setups, Dict)
-        self.assertIsInstance(isinstance(setups[list(setups.keys())[0]], Dict))
+        self.assertIsInstance(setups[list(setups.keys())[0]], Dict)
         self.assertGreater(len(setups), 0)
 
     def test_setuplist_offset(self):

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -138,10 +138,10 @@ class TestSetupFunctions(TestBase):
         self.assertIsInstance(setups, dict)
 
     def test_list_setups_output_format(self):
-        flow_id = 5873
+        flow_id = 18
         setups = openml.setups.list_setups(flow=flow_id, output_format='object')
         self.assertIsInstance(setups, Dict)
-        self.assertIsInstance(isinstance(setups[list(setups.keys())[1]],
+        self.assertIsInstance(isinstance(setups[list(setups.keys())[0]],
                                          openml.setups.setup.OpenMLSetup))
         self.assertGreater(len(setups), 0)
 
@@ -151,7 +151,7 @@ class TestSetupFunctions(TestBase):
 
         setups = openml.setups.list_setups(flow=flow_id, output_format='dict')
         self.assertIsInstance(setups, Dict)
-        self.assertIsInstance(isinstance(setups[list(setups.keys())[1]], Dict))
+        self.assertIsInstance(isinstance(setups[list(setups.keys())[0]], Dict))
         self.assertGreater(len(setups), 0)
 
     def test_setuplist_offset(self):

--- a/tests/test_study/test_study_functions.py
+++ b/tests/test_study/test_study_functions.py
@@ -1,6 +1,7 @@
 import openml
 import openml.study
 from openml.testing import TestBase
+import pandas as pd
 
 
 class TestStudyFunctions(TestBase):
@@ -197,4 +198,10 @@ class TestStudyFunctions(TestBase):
     def test_study_list(self):
         study_list = openml.study.list_studies(status='in_preparation')
         # might fail if server is recently resetted
+        self.assertGreater(len(study_list), 2)
+
+    def test_study_list_output_format(self):
+        study_list = openml.study.list_studies(status='in_preparation',
+                                               output_format='dataframe')
+        self.assertIsInstance(study_list, pd.DataFrame)
         self.assertGreater(len(study_list), 2)

--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -6,6 +6,7 @@ from openml import OpenMLSplit, OpenMLTask
 from openml.exceptions import OpenMLCacheException
 import openml
 import unittest
+import pandas as pd
 
 
 class TestTask(TestBase):
@@ -63,6 +64,12 @@ class TestTask(TestBase):
         for tid in tasks:
             self.assertEqual(ttid, tasks[tid]["ttid"])
             self._check_task(tasks[tid])
+
+    def test_list_tasks_output_format(self):
+        ttid = 3
+        tasks = openml.tasks.list_tasks(task_type_id=ttid, output_format='dataframe')
+        self.assertIsInstance(tasks, pd.DataFrame)
+        self.assertGreater(len(tasks), 100)
 
     def test_list_tasks_empty(self):
         tasks = openml.tasks.list_tasks(tag='NoOneWillEverUseThisTag')

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -19,7 +19,7 @@ class OpenMLTaskTest(TestBase):
         return openml._api_calls._read_url(url, request_method=request_method)
 
     def test_list_all(self):
-        openml.utils._list_all(openml.tasks.functions._list_tasks)
+        openml.utils._list_all(listing_call=openml.tasks.functions._list_tasks)
 
     @mock.patch('openml._api_calls._perform_api_call',
                 side_effect=mocked_perform_api_call)


### PR DESCRIPTION
#### What does this PR implement/fix? Explain your changes.
Addresses #364.
An optional parameter has been added to the `get_X` functions called `output_format`. Which is by default `dict` so that nothing breaks. When `output_format='dataframe'` the output is a pandas data frame.

#### How should this PR be tested?
The following commands should suffice in demonstrating the change:
`openml.datasets.list_datasets(size=10)`
`openml.datasets.list_datasets(size=10, output_format='dataframe')`
`openml.tasks.list_tasks(task_type_id=1, size = 10)`
`openml.tasks.list_tasks(task_type_id=1, size = 10, output_format='dataframe')`
`openml.evaluations.list_evaluations('predictive_accuracy', size = 10)`
`openml.evaluations.list_evaluations('predictive_accuracy', size = 10, output_format='object')`
`openml.evaluations.list_evaluations('predictive_accuracy', size = 10, output_format='dataframe')`
`openml.flows.list_flows(size=10)`
`openml.flows.list_flows(size=10, output_format='dataframe')`
`openml.runs.list_runs(size=10)`
`openml.runs.list_runs(size=10, output_format='dataframe')`
`openml.setups.list_setups(size=10)`
`openml.setups.list_setups(size=10, output_format='object')`
`openml.setups.list_setups(size=10, output_format='dataframe')`

#### Any other comments?
- For design parity, all the __list_X functions have been edited to produce the desired output format. In effect, every list function has an added parameter called `output_format` including the `_list_all` in utils.py.
- The defaults have been kept as 'dict' and 'object' where applicable to ensure nothing breaks.
- Examples which had listing as an example, has been updated.
- A small unit test is added for all the listing calls that already being tested