### PR TITLE
Issue #621 - better error messages on listing queries.  Adding check …

### DIFF
--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -713,6 +713,17 @@ def list_runs(offset=None, size=None, id=None, task=None, setup=None,
         List of found runs.
     """
 
+    if id is not None and (not isinstance(id, list)):
+        raise TypeError('id must be of type list.')
+    if task is not None and (not isinstance(task, list)):
+        raise TypeError('task must be of type list.')
+    if setup is not None and (not isinstance(setup, list)):
+        raise TypeError('setup must be of type list.')
+    if flow is not None and (not isinstance(flow, list)):
+        raise TypeError('flow must be of type list.')
+    if uploader is not None and (not isinstance(uploader, list)):
+        raise TypeError('uploader must be of type list.')
+
     return openml.utils._list_all(
         _list_runs, offset=offset, size=size, id=id, task=task, setup=setup,
         flow=flow, uploader=uploader, tag=tag, display_errors=display_errors,


### PR DESCRIPTION
…for list type and return error message, take 2.

<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #621 (take 2)

#### What does this PR implement/fix? Explain your changes.
When calling list_runs, if a parameter is expected to be a list, a TypeError is thrown with proper notification.  Suggested improvements have been implemented (TypeError instead of generic Exception, elimination of redundant return statements, using isinstance instead of Type).

#### How should this PR be tested?
import openml as oml
runs = oml.runs.list_runs(task=2)
(should provide a descriptive error message).

#### Any other comments?

