### PR TITLE
Specify build dependencies through pyproject.toml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,12 @@ install:
 
   # Install the build and runtime dependencies of the project.
   - "cd C:\\projects\\openml-python"
-  - conda install --quiet --yes scikit-learn=0.20.0 nb_conda nb_conda_kernels numpy scipy requests nbformat python-dateutil nbconvert pandas matplotlib seaborn
-  - pip install liac-arff xmltodict oslo.concurrency
+  #- conda install --quiet --yes scikit-learn=0.20.0 nb_conda nb_conda_kernels numpy scipy requests nbformat python-dateutil nbconvert pandas matplotlib seaborn
+  # - pip install liac-arff xmltodict oslo.concurrency
   # Packages for (parallel) unit tests with pytest
-  - pip install pytest pytest-xdist pytest-timeout
-  - "pip install .[test]"
+  # - pip install pytest pytest-xdist pytest-timeout
+  - "pip install .[examples,test]"
+  - conda install --quiet --yes scikit-learn=0.20.0
 
 
 # Not a .NET project, we build scikit-learn in the install step instead

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,10 +34,6 @@ install:
 
   # Install the build and runtime dependencies of the project.
   - "cd C:\\projects\\openml-python"
-  #- conda install --quiet --yes scikit-learn=0.20.0 nb_conda nb_conda_kernels numpy scipy requests nbformat python-dateutil nbconvert pandas matplotlib seaborn
-  # - pip install liac-arff xmltodict oslo.concurrency
-  # Packages for (parallel) unit tests with pytest
-  # - pip install pytest pytest-xdist pytest-timeout
   - "pip install .[examples,test]"
   - conda install --quiet --yes scikit-learn=0.20.0
 

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -26,7 +26,6 @@ popd
 # provided versions
 conda create -n testenv --yes python=$PYTHON_VERSION pip
 source activate testenv
-pip install scikit-learn==$SKLEARN_VERSION
 
 python --version
 pip install -e '.[test]'
@@ -45,3 +44,7 @@ fi
 if [[ "$RUN_FLAKE8" == "true" ]]; then
     pip install flake8 mypy
 fi
+
+# Install scikit-learn last to make sure the openml package installation works
+# from a clean environment without scikit-learn.
+pip install scikit-learn==$SKLEARN_VERSION

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -26,15 +26,18 @@ popd
 # provided versions
 conda create -n testenv --yes python=$PYTHON_VERSION pip
 source activate testenv
-pip install pytest pytest-xdist pytest-timeout numpy scipy cython scikit-learn==$SKLEARN_VERSION \
-    oslo.concurrency
+pip install scikit-learn==$SKLEARN_VERSION
+
+python --version
+pip install -e '.[test]'
+python -c "import numpy; print('numpy %s' % numpy.__version__)"
+python -c "import scipy; print('scipy %s' % scipy.__version__)"
 
 if [[ "$EXAMPLES" == "true" ]]; then
-    pip install matplotlib jupyter notebook nbconvert nbformat jupyter_client \
-        ipython ipykernel pandas seaborn
+    pip install -e '.[examples]'
 fi
 if [[ "$DOCTEST" == "true" ]]; then
-    pip install pandas sphinx_bootstrap_theme
+    pip install sphinx_bootstrap_theme
 fi
 if [[ "$COVERAGE" == "true" ]]; then
     pip install codecov pytest-cov
@@ -42,8 +45,3 @@ fi
 if [[ "$RUN_FLAKE8" == "true" ]]; then
     pip install flake8 mypy
 fi
-
-python --version
-python -c "import numpy; print('numpy %s' % numpy.__version__)"
-python -c "import scipy; print('scipy %s' % scipy.__version__)"
-pip install -e '.[test]'

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -565,7 +565,7 @@ class OpenMLDataset(object):
         else:
             return rval
 
-    def retrieve_class_labels(self, target_name='class'):
+    def retrieve_class_labels(self, target_name: str ='class') -> Union[None, List[str]]:
         """Reads the datasets arff to determine the class-labels.
 
         If the task has no class labels (for example a regression problem)

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -565,7 +565,7 @@ class OpenMLDataset(object):
         else:
             return rval
 
-    def retrieve_class_labels(self, target_name: str ='class') -> Union[None, List[str]]:
+    def retrieve_class_labels(self, target_name: str = 'class') -> Union[None, List[str]]:
         """Reads the datasets arff to determine the class-labels.
 
         If the task has no class labels (for example a regression problem)

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -390,7 +390,7 @@ class OpenMLFlow(object):
                              (flow_id, message))
         return self
 
-    def get_structure(self, key_item):
+    def get_structure(self, key_item: str) -> Dict[str, List[str]]:
         """
         Returns for each sub-component of the flow the path of identifiers
         that should be traversed to reach this component. The resulting dict

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -460,7 +460,7 @@ class OpenMLRun(object):
         description_xml = xmltodict.unparse(description, pretty=True)
         return description_xml
 
-    def push_tag(self, tag):
+    def push_tag(self, tag: str) -> None:
         """Annotates this run with a tag on the server.
 
         Parameters
@@ -471,7 +471,7 @@ class OpenMLRun(object):
         data = {'run_id': self.run_id, 'tag': tag}
         openml._api_calls._perform_api_call("/run/tag", 'post', data=data)
 
-    def remove_tag(self, tag):
+    def remove_tag(self, tag: str) -> None:
         """Removes a tag from this run on the server.
 
         Parameters

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -68,7 +68,7 @@ class OpenMLRun(object):
         pp.text(str(self))
 
     @classmethod
-    def from_filesystem(cls, directory, expect_model=True):
+    def from_filesystem(cls, directory: str, expect_model: bool = True) -> 'OpenMLRun':
         """
         The inverse of the to_filesystem method. Instantiates an OpenMLRun
         object based on files stored on the file system.

--- a/openml/runs/trace.py
+++ b/openml/runs/trace.py
@@ -32,7 +32,7 @@ class OpenMLRunTrace(object):
         self.run_id = run_id
         self.trace_iterations = trace_iterations
 
-    def get_selected_iteration(self, fold, repeat):
+    def get_selected_iteration(self, fold: int, repeat: int) -> 'OpenMLTraceIteration':
         """
         Returns the trace iteration that was marked as selected. In
         case multiple are marked as selected (should not happen) the

--- a/openml/runs/trace.py
+++ b/openml/runs/trace.py
@@ -32,7 +32,7 @@ class OpenMLRunTrace(object):
         self.run_id = run_id
         self.trace_iterations = trace_iterations
 
-    def get_selected_iteration(self, fold: int, repeat: int) -> 'OpenMLTraceIteration':
+    def get_selected_iteration(self, fold: int, repeat: int) -> int:
         """
         Returns the trace iteration that was marked as selected. In
         case multiple are marked as selected (should not happen) the
@@ -46,7 +46,7 @@ class OpenMLRunTrace(object):
 
         Returns
         ----------
-        OpenMLTraceIteration
+        int
             The trace iteration from the given fold and repeat that was
             selected as the best iteration by the search procedure
         """

--- a/openml/runs/trace.py
+++ b/openml/runs/trace.py
@@ -104,7 +104,7 @@ class OpenMLRunTrace(object):
         )
 
     @classmethod
-    def _from_filesystem(cls, file_path):
+    def _from_filesystem(cls, file_path: str) -> 'OpenMLRunTrace':
         """
         Logic to deserialize the trace from the filesystem.
 

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -55,7 +55,7 @@ def _get_cached_tasks():
     return tasks
 
 
-def _get_cached_task(tid):
+def _get_cached_task(tid: int) -> OpenMLTask:
     """Return a cached task based on the given id.
 
     Parameters

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -19,7 +19,8 @@ from .task import (
     OpenMLLearningCurveTask,
     TaskTypeEnum,
     OpenMLRegressionTask,
-    OpenMLSupervisedTask
+    OpenMLSupervisedTask,
+    OpenMLTask
 )
 import openml.utils
 import openml._api_calls
@@ -299,7 +300,7 @@ def get_tasks(task_ids, download_data=True):
     return tasks
 
 
-def get_task(task_id, download_data=True):
+def get_task(task_id: int, download_data: bool = True) -> OpenMLTask:
     """Download OpenML task for a given task ID.
 
     Downloads the task representation, while the data splits can be

--- a/openml/tasks/split.py
+++ b/openml/tasks/split.py
@@ -58,7 +58,7 @@ class OpenMLSplit(object):
         return True
 
     @classmethod
-    def _from_arff_file(cls, filename):
+    def _from_arff_file(cls, filename: str) -> 'OpenMLSplit':
 
         repetitions = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,0 @@
-[build-system]
-requires = [
-  "setuptools",
-  "wheel",
-  "numpy>=1.6.2",
-  "scipy>=0.13.3"
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "setuptools",
+  "wheel",
+  "numpy>=1.6.2",
+  "scipy>=0.13.3"
+]

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,10 @@ import sys
 with open("openml/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
-try:
-    import numpy  # noqa: F401
-    import scipy  # noqa: F401
-except ImportError:
+if len(sys.argv) > 1 and sys.argv[1] == 'install':
     print('Please install this package with pip: `pip install -e .`'
           'Installation requires pip>=10.0')
     sys.exit(1)
-
 
 setuptools.setup(name="openml",
                  author="Matthias Feurer, Andreas Müller, Farzan Majdani, "

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,22 @@ setuptools.setup(name="openml",
                      'test': [
                          'nbconvert',
                          'jupyter_client',
-                         'matplotlib'
+                         'matplotlib',
+                         'pytest',
+                         'pytest-xdist',
+                         'pytest-timeout',
+
+                     ],
+                     'examples': [
+                        'matplotlib',
+                        'jupyter',
+                        'notebook',
+                        'nbconvert',
+                        'nbformat',
+                        'jupyter_client',
+                        'ipython',
+                        'ipykernel',
+                        'seaborn'
                      ]
                  },
                  test_suite="pytest",

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ with open("openml/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
 if len(sys.argv) > 1 and sys.argv[1] == 'install':
-    print('Please install this package with pip: `pip install -e .`'
-          'Installation requires pip>=10.0')
+    print('Please install this package with pip: `pip install -e .` '
+          'Installation requires pip>=10.0.')
     sys.exit(1)
 
 setuptools.setup(name="openml",

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ import sys
 with open("openml/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
+# Using Python setup.py install will try to build numpy which prone to failure and
+# very time consuming anyway.
 if len(sys.argv) > 1 and sys.argv[1] == 'install':
     print('Please install this package with pip: `pip install -e .` '
           'Installation requires pip>=10.0.')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 with open("openml/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
-# Using Python setup.py install will try to build numpy which prone to failure and
+# Using Python setup.py install will try to build numpy which is prone to failure and
 # very time consuming anyway.
 if len(sys.argv) > 1 and sys.argv[1] == 'install':
     print('Please install this package with pip: `pip install -e .` '

--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,12 @@ import sys
 with open("openml/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
-dependency_links = []
-
 try:
     import numpy  # noqa: F401
-except ImportError:
-    print('numpy is required during installation')
-    sys.exit(1)
-
-try:
     import scipy  # noqa: F401
 except ImportError:
-    print('scipy is required during installation')
+    print('Please install this package with pip: `pip install -e .`'
+          'Installation requires pip>=10.0')
     sys.exit(1)
 
 
@@ -30,12 +24,14 @@ setuptools.setup(name="openml",
                  description="Python API for OpenML",
                  license="BSD 3-clause",
                  url="http://openml.org/",
+                 project_urls={
+                     "Documentation": "https://openml.github.io/openml-python/master/",
+                     "Source Code": "https://github.com/openml/openml-python"
+                 },
                  version=version,
                  packages=setuptools.find_packages(),
                  package_data={'': ['*.txt', '*.md']},
                  install_requires=[
-                     'numpy>=1.6.2',
-                     'scipy>=0.13.3',
                      'liac-arff>=2.2.2',
                      'xmltodict',
                      'pytest',
@@ -45,6 +41,8 @@ setuptools.setup(name="openml",
                      'python-dateutil',
                      'oslo.concurrency',
                      'pandas>=0.19.2',
+                     'scipy>=0.13.3',
+                     'numpy>=1.6.2'
                  ],
                  extras_require={
                      'test': [
@@ -66,5 +64,5 @@ setuptools.setup(name="openml",
                               'Programming Language :: Python :: 3',
                               'Programming Language :: Python :: 3.4',
                               'Programming Language :: Python :: 3.5',
-                              'Programming Language :: Python :: 3.6'
+                              'Programming Language :: Python :: 3.6',
                               'Programming Language :: Python :: 3.7'])

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,12 @@ if len(sys.argv) > 1 and sys.argv[1] == 'install':
           'Installation requires pip>=10.0.')
     sys.exit(1)
 
+if sys.version_info < (3, 5):
+    raise ValueError(
+        'Unsupported Python version {}.{}.{} found. OpenML requires Python 3.5 or higher.'
+        .format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+    )
+
 setuptools.setup(name="openml",
                  author="Matthias Feurer, Andreas Müller, Farzan Majdani, "
                         "Joaquin Vanschoren, Jan van Rijn and Pieter Gijsbers",
@@ -51,15 +57,15 @@ setuptools.setup(name="openml",
 
                      ],
                      'examples': [
-                        'matplotlib',
-                        'jupyter',
-                        'notebook',
-                        'nbconvert',
-                        'nbformat',
-                        'jupyter_client',
-                        'ipython',
-                        'ipykernel',
-                        'seaborn'
+                         'matplotlib',
+                         'jupyter',
+                         'notebook',
+                         'nbconvert',
+                         'nbformat',
+                         'jupyter_client',
+                         'ipython',
+                         'ipykernel',
+                         'seaborn'
                      ]
                  },
                  test_suite="pytest",


### PR DESCRIPTION
Fixes #652 by specifying the build dependencies of the package in `pyproject.toml` as per [PEP518](https://www.python.org/dev/peps/pep-0518/). 
To install the package from the directory directly, you will need to use [`pip>=10.0`](https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support) (`pip install -e .`).
This PR is also hosted on [test.pypi](https://test.pypi.org/project/openml-pyprojtest/), so the install can be tested with `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple openml_pyprojtest`.

I have tested this by executing in a local docker container with just Python (and no numpy, scipy):
```
# pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple openml_pyprojtest
# python3
>>> import openml
>>> t = openml.tasks.get_task(3)
>>> t.get_X_and_y()
```
as well as the same through a local `pip install -e .` install, both work.

____
A few notes:
 - I added project urls to the metadata in `setup.py` but they seem to be ignored on the `test.pypi.org` site. Not sure why and if they will show up on the production version of pypi. Either way I think we should probably create an issue to update metadata anyway (in particular, a good description).
 - We could move away from using `setuptools` and use other frameworks such as [`flit`](https://github.com/takluyver/flit/) or [`poetry`](https://github.com/sdispater/poetry). Using e.g. `flit` allows us to specify all our dependencies and metadata in the `pyproject.toml` file, doing away with `setup.py` altogether. This is supported through [`PEP517`](https://www.python.org/dev/peps/pep-0517/) which is supported by [`pip>=19`](https://pip.pypa.io/en/stable/news/#features). @mfeurer mentions as an argument against that there are more examples using `setuptools` (such as scikit-learn) which we can learn from if we need something.
- test.pypi shows a version bump, this was only because it wouldn't let me reupload 0.8.0, but this version bump is not included in the PR.


