### PR TITLE
Fix596 dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ local disk:
    $ git checkout -b feature/my-feature
    ```
 
-   Always use a ``feature`` branch. It's good practice to never work on the ``master`` or ``develop`` branch! To make the nature of your pull request easily visible, please perpend the name of the branch with the type of changes you want to merge, such as ``feature`` if it contains a new feature, ``fix`` for a bugfix, ``doc`` for documentation and ``maint`` for other maintenance on the package.
+   Always use a ``feature`` branch. It's good practice to never work on the ``master`` or ``develop`` branch! 
+   To make the nature of your pull request easily visible, please prepend the name of the branch with the type of changes you want to merge, such as ``feature`` if it contains a new feature, ``fix`` for a bugfix, ``doc`` for documentation and ``maint`` for other maintenance on the package.
 
 4. Develop the feature on your feature branch. Add changed files using ``git add`` and then ``git commit`` files:
 
@@ -59,7 +60,15 @@ We recommended that your contribution complies with the
 following rules before you submit a pull request:
 
 -  Follow the
-   [pep8 style guilde](https://www.python.org/dev/peps/pep-0008/).
+   [pep8 style guide](https://www.python.org/dev/peps/pep-0008/).
+   With the following exceptions or additions:
+    - The max line length is 100 characters instead of 80.
+    - When creating a multi-line expression with binary operators, break before the operator.
+    - Add type hints to all function signatures.
+    (note: not all functions have type hints yet, this is work in progress.)
+    - Use the [`str.format`](https://docs.python.org/3/library/stdtypes.html#str.format) over [`printf`](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) style formatting.
+     E.g. use `"{} {}".format('hello', 'world')` not `"%s %s" % ('hello', 'world')`.
+     (note: old code may still use `printf`-formatting, this is work in progress.)
 
 -  If your pull request addresses an issue, please use the pull request title
    to describe the issue and mention the issue number in the pull request description. This will make sure a link back to the original issue is
@@ -105,18 +114,18 @@ tools:
   $ pytest --cov=. path/to/tests_for_package
   ```
 
--  No pyflakes warnings, check with:
+-  No style warnings, check with:
 
   ```bash
-  $ pip install pyflakes
-  $ pyflakes path/to/module.py
+  $ pip install flake8
+  $ flake8 --ignore E402,W503 --show-source --max-line-length 100
   ```
 
--  No PEP8 warnings, check with:
+-  No mypy (typing) issues, check with:
 
   ```bash
-  $ pip install pep8
-  $ pep8 path/to/module.py
+  $ pip install mypy
+  $ mypy openml --ignore-missing-imports --follow-imports skip
   ```
 
 Filing bugs
@@ -151,8 +160,8 @@ following rules before submitting:
 New contributor tips
 --------------------
 
-A great way to start contributing to scikit-learn is to pick an item
-from the list of [Easy issues](https://github.com/openml/openml-python/issues?q=label%3Aeasy)
+A great way to start contributing to openml-python is to pick an item
+from the list of [Good First Issues](https://github.com/openml/openml-python/labels/Good%20first%20issue)
 in the issue tracker. Resolving these issues allow you to start
 contributing to the project without much prior knowledge. Your
 assistance in this area will be greatly appreciated by the more
@@ -175,6 +184,14 @@ information.
 
 For building the documentation, you will need
 [sphinx](http://sphinx.pocoo.org/),
-[matplotlib](http://matplotlib.org/), and
-[pillow](http://pillow.readthedocs.io/en/latest/).
-[sphinx-bootstrap-theme](https://ryan-roemer.github.io/sphinx-bootstrap-theme/)
+[sphinx-bootstrap-theme](https://ryan-roemer.github.io/sphinx-bootstrap-theme/),
+[sphinx-gallery](https://sphinx-gallery.github.io/)
+and
+[numpydoc](https://numpydoc.readthedocs.io/en/latest/).
+```bash
+$ pip install sphinx sphinx-bootstrap-theme sphinx-gallery numpydoc
+```
+When dependencies are installed, run
+```bash
+$ sphinx-build -b html doc YOUR_PREFERRED_OUTPUT_DIRECTORY
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ local disk:
    $ cd openml-python
    ```
 
-3. Swith to the ``develop`` branch:
+3. Switch to the ``develop`` branch:
 
    ```bash
    $ git checkout develop

--- a/ci_scripts/flake8_diff.sh
+++ b/ci_scripts/flake8_diff.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+# Update /CONTRIBUTING.md if these commands change.
+# The reason for not advocating using this script directly is that it
+# might not work out of the box on Windows.
 flake8 --ignore E402,W503 --show-source --max-line-length 100 $options
 mypy openml --ignore-missing-imports --follow-imports skip

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -90,8 +90,14 @@ The package source code is available from
     git clone https://github.com/openml/openml-python.git
 
 
-Once you cloned the package, change into the new directory ``python`` and
-execute
+Once you cloned the package, change into the new directory.
+If you are a regular user, install with
+
+.. code:: bash
+
+    pip install -e .
+
+If you are a contributor, you will also need to install test dependencies
 
 .. code:: bash
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -95,7 +95,8 @@ execute
 
 .. code:: bash
 
-    python setup.py install
+    pip install -e ".[test]"
+
 
 Testing
 =======

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -12,6 +12,8 @@ Changelog
 0.9.0
 ~~~~~
 
+* MAINT #596: Fewer dependencies for regular pip install.
+* MAINT #652: Numpy and Scipy are no longer required before installation.
 * ADD #560: OpenML-Python can now handle regression tasks as well.
 * MAINT #184: Dropping Python2 support.
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -23,8 +23,7 @@ from ..exceptions import (
 from ..utils import (
     _create_cache_directory,
     _remove_cache_dir_for_id,
-    _create_cache_directory_for_id,
-    _create_lockfiles_dir,
+    _create_cache_directory_for_id
 )
 
 

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -5,7 +5,6 @@ import io
 import re
 import xmltodict
 from typing import Union, Dict
-from oslo_concurrency import lockutils
 
 from ..exceptions import OpenMLCacheException
 import openml._api_calls

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -70,6 +70,7 @@ def _get_cached_flow(fid: int) -> OpenMLFlow:
                                    "cached" % fid)
 
 
+@openml.utils.thread_safe_if_oslo_installed
 def get_flow(flow_id: int, reinstantiate: bool = False) -> OpenMLFlow:
     """Download the OpenML flow for a given flow ID.
 
@@ -87,11 +88,7 @@ def get_flow(flow_id: int, reinstantiate: bool = False) -> OpenMLFlow:
         the flow
     """
     flow_id = int(flow_id)
-    with lockutils.external_lock(
-            name='flows.functions.get_flow:%d' % flow_id,
-            lock_path=openml.utils._create_lockfiles_dir(),
-    ):
-        flow = _get_flow_description(flow_id)
+    flow = _get_flow_description(flow_id)
 
     if reinstantiate:
         flow.model = flow.extension.flow_to_model(flow)

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -466,6 +466,7 @@ def get_runs(run_ids):
     return runs
 
 
+@openml.utils.thread_safe_if_oslo_installed
 def get_run(run_id):
     """Gets run corresponding to run_id.
 

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -2,13 +2,6 @@ from collections import OrderedDict
 import io
 import re
 import os
-import warnings
-
-# Currently, importing oslo raises a lot of warning that it will stop working
-# under python3.8; remove this once they disappear
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from oslo_concurrency import lockutils
 import xmltodict
 
 from ..exceptions import OpenMLCacheException

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -300,6 +300,7 @@ def get_tasks(task_ids, download_data=True):
     return tasks
 
 
+@openml.utils.thread_safe_if_oslo_installed
 def get_task(task_id: int, download_data: bool = True) -> OpenMLTask:
     """Download OpenML task for a given task ID.
 
@@ -324,34 +325,30 @@ def get_task(task_id: int, download_data: bool = True) -> OpenMLTask:
         raise ValueError("Dataset ID is neither an Integer nor can be "
                          "cast to an Integer.")
 
-    with lockutils.external_lock(
-            name='task.functions.get_task:%d' % task_id,
-            lock_path=openml.utils._create_lockfiles_dir(),
-    ):
-        tid_cache_dir = openml.utils._create_cache_directory_for_id(
-            TASKS_CACHE_DIR_NAME, task_id,
-        )
+    tid_cache_dir = openml.utils._create_cache_directory_for_id(
+        TASKS_CACHE_DIR_NAME, task_id,
+    )
 
-        try:
-            task = _get_task_description(task_id)
-            dataset = get_dataset(task.dataset_id, download_data)
-            # List of class labels availaible in dataset description
-            # Including class labels as part of task meta data handles
-            #   the case where data download was initially disabled
-            if isinstance(task, OpenMLClassificationTask):
-                task.class_labels = \
-                    dataset.retrieve_class_labels(task.target_name)
-            # Clustering tasks do not have class labels
-            # and do not offer download_split
-            if download_data:
-                if isinstance(task, OpenMLSupervisedTask):
-                    task.download_split()
-        except Exception as e:
-            openml.utils._remove_cache_dir_for_id(
-                TASKS_CACHE_DIR_NAME,
-                tid_cache_dir,
-            )
-            raise e
+    try:
+        task = _get_task_description(task_id)
+        dataset = get_dataset(task.dataset_id, download_data)
+        # List of class labels availaible in dataset description
+        # Including class labels as part of task meta data handles
+        #   the case where data download was initially disabled
+        if isinstance(task, OpenMLClassificationTask):
+            task.class_labels = \
+                dataset.retrieve_class_labels(task.target_name)
+        # Clustering tasks do not have class labels
+        # and do not offer download_split
+        if download_data:
+            if isinstance(task, OpenMLSupervisedTask):
+                task.download_split()
+    except Exception as e:
+        openml.utils._remove_cache_dir_for_id(
+            TASKS_CACHE_DIR_NAME,
+            tid_cache_dir,
+        )
+        raise e
 
     return task
 

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -294,7 +294,7 @@ def _remove_cache_dir_for_id(key, cache_dir):
 def thread_safe_if_oslo_installed(func):
     if oslo_installed:
         def safe_func(*args, **kwargs):
-            # Lock directories use the id that is passed as either a first argument, or as a keyword.
+            # Lock directories use the id that is passed as either positional or keyword argument.
             id_parameters = [parameter_name for parameter_name in kwargs if '_id' in parameter_name]
             if len(id_parameters) == 1:
                 id_ = kwargs[id_parameters[0]]

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,9 @@ setuptools.setup(name="openml",
                  install_requires=[
                      'liac-arff>=2.2.2',
                      'xmltodict',
-                     'pytest',
                      'requests',
                      'scikit-learn>=0.18',
-                     'nbformat',
-                     'python-dateutil',
+                     'python-dateutil',  # Installed through pandas anyway.
                      'oslo.concurrency',
                      'pandas>=0.19.2',
                      'scipy>=0.13.3',
@@ -56,7 +54,7 @@ setuptools.setup(name="openml",
                          'pytest',
                          'pytest-xdist',
                          'pytest-timeout',
-
+                         'nbformat'
                      ],
                      'examples': [
                          'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setuptools.setup(name="openml",
                      'requests',
                      'scikit-learn>=0.18',
                      'python-dateutil',  # Installed through pandas anyway.
-                     'oslo.concurrency',
                      'pandas>=0.19.2',
                      'scipy>=0.13.3',
                      'numpy>=1.6.2'
@@ -54,7 +53,8 @@ setuptools.setup(name="openml",
                          'pytest',
                          'pytest-xdist',
                          'pytest-timeout',
-                         'nbformat'
+                         'nbformat',
+                         'oslo.concurrency'
                      ],
                      'examples': [
                          'matplotlib',


### PR DESCRIPTION
Remove `oslo.concurrency`, `nbformat` and `pytest` from general package dependencies, as they are only used for testing (and are this under the `extra_requires 'test'` flag).
I also updated the documentation (as I was looking for when any `python setup.py install` was mentioned). Have to hold out to see if it still works in CI setting.

Locally runs as expected (downloads task, data, flow, run):
```python
import openml
from sklearn.tree import DecisionTreeClassifier
t = openml.tasks.get_task(59)
r = openml.runs.run_model_on_task(DecisionTreeClassifier(), t)
run = openml.runs.get_run(10160808)
```

This moves the package dependencies (without test environment) from:
``` Successfully installed Babel-2.6.0 PyYAML-5.1 atomicwrites-1.3.0 attrs-19.1.0 certifi-2019.3.9 chardet-3.0.4 debtcollector-1.21.0 decorator-4.4.0 fasteners-0.14.1 idna-2.8 ipython-genutils-0.2.0 iso8601-0.1.12 jsonschema-3.0.1 jupyter-core-4.4.0 liac-arff-2.4.0 monotonic-1.5 more-itertools-7.0.0 nbformat-4.4.0 netaddr-0.7.19 netifaces-0.10.9 numpy-1.16.2 openml oslo.concurrency-3.29.1 oslo.config-6.8.1 oslo.i18n-3.23.1 oslo.utils-3.40.3 pandas-0.24.2 pathlib2-2.3.3 pbr-5.1.3 pluggy-0.9.0 py-1.8.0 pyparsing-2.4.0 pyrsistent-0.14.11 pytest-4.4.1 python-dateutil-2.8.0 pytz-2019.1 requests-2.21.0 rfc3986-1.2.0 scikit-learn-0.20.3 scipy-1.2.1 six-1.12.0 stevedore-1.30.1 traitlets-4.3.2 urllib3-1.24.1 wrapt-1.11.1 xmltodict-0.12.0```

to
``` Successfully installed certifi-2019.3.9 chardet-3.0.4 idna-2.8 liac-arff-2.4.0 numpy-1.16.2 openml pandas-0.24.2 python-dateutil-2.8.0 pytz-2019.1 requests-2.21.0 scikit-learn-0.20.3 scipy-1.2.1 six-1.12.0 urllib3-1.24.1 xmltodict-0.12.0```

:)
