### PR TITLE
Fix dataset parsing for categories

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -408,6 +408,8 @@ class OpenMLDataset(object):
                 col.append(categories[int(x)])
             except (TypeError, ValueError):
                 col.append(np.nan)
+        # We require two lines to create a series of categories as detailed here:
+        # https://pandas.pydata.org/pandas-docs/version/0.24/user_guide/categorical.html#series-creation  # noqa E501
         raw_cat = pd.Categorical(col, ordered=True, categories=categories)
         return pd.Series(raw_cat, index=series.index, name=series.name)
 

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -408,8 +408,8 @@ class OpenMLDataset(object):
                 col.append(categories[int(x)])
             except (TypeError, ValueError):
                 col.append(np.nan)
-        return pd.Series(col, index=series.index, dtype='category',
-                         name=series.name)
+        raw_cat = pd.Categorical(col, ordered=True, categories=categories)
+        return pd.Series(raw_cat, index=series.index, name=series.name)
 
     def _download_data(self) -> None:
         """ Download ARFF data file to standard cache directory. Set `self.data_file`. """

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import pickle
 import time
-from typing import Any, IO, TextIO
+from typing import Any, IO, TextIO  # noqa F401
 import os
 
 import arff

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -192,6 +192,18 @@ class OpenMLDatasetTest(TestBase):
                 format='arff'
             )
 
+    def test_get_data_with_nonexisting_class(self):
+        # This class is using the anneal dataset with labels [1, 2, 3, 4, 5, 'U']. However,
+        # label 4 does not exist and we test that the features 5 and 'U' are correctly mapped to
+        # indices 4 and 5, and that nothing is mapped to index 3.
+        _, y = self.dataset.get_data('class', dataset_format='dataframe')
+        self.assertEqual(list(y.dtype.categories), ['1', '2', '3', '4', '5', 'U'])
+        _, y = self.dataset.get_data('class', dataset_format='array')
+        self.assertEqual(np.min(y), 0)
+        self.assertEqual(np.max(y), 5)
+        # Check that the
+        self.assertEqual(np.sum(y == 3), 0)
+
 
 class OpenMLDatasetTestOnTestServer(TestBase):
     def setUp(self):


### PR DESCRIPTION
The recent PR #548 changed the behavior of retrieving the categories of a categorical variable by inducing it from the data. In case the data does not contain a category, we loose information about its potential existence. This PR uses the category information provided by the arff file to determine all legal categories of a categorical variable.