### PR TITLE
Easy access test server

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -38,8 +38,8 @@ avoid_duplicate_runs = True if _defaults['avoid_duplicate_runs'] == 'True' else 
 connection_n_retries = _defaults['connection_n_retries']
 
 
-class ExampleConfiguration:
-    """ Allows easy switching to and from a test configuration. """
+class ConfigurationForExamples:
+    """ Allows easy switching to and from a test configuration, used for examples. """
     _last_used_server = None
     _last_used_key = None
     _start_last_called = False
@@ -188,8 +188,8 @@ def set_cache_directory(cachedir):
     cache_directory = cachedir
 
 
-start_use_example_configuration = ExampleConfiguration.start_use_example_configuration
-stop_use_example_configuration = ExampleConfiguration.stop_use_example_configuration
+start_use_example_configuration = ConfigurationForExamples.start_use_example_configuration
+stop_use_example_configuration = ConfigurationForExamples.stop_use_example_configuration
 
 __all__ = [
     'get_cache_directory', 'set_cache_directory',

--- a/openml/config.py
+++ b/openml/config.py
@@ -37,32 +37,36 @@ avoid_duplicate_runs = True if _defaults['avoid_duplicate_runs'] == 'True' else 
 # Number of retries if the connection breaks
 connection_n_retries = _defaults['connection_n_retries']
 
-# variables to keep track of last used settings for when `use_example_configuration` is activated
-_last_used_key = None
-_last_used_server = None
 
+class ExampleConfiguration:
+    """ Allows easy switching to and from a test configuration. """
+    _last_used_server = None
+    _last_used_key = None
 
-def start_use_example_configuration():
-    global server
-    global apikey
-    global _last_used_server
-    global _last_used_key
-    _last_used_server = server
-    _last_used_key = apikey
+    @classmethod
+    def start_use_example_configuration(cls):
+        """ Sets the configuration to connect to the test server with valid apikey.
 
-    # Test server key for examples
-    server = "https://test.openml.org/api/v1/xml"
-    apikey = "c0c42819af31e706efe1f4b88c23c6c1"
+        To configuration as was before this call is stored, and can be recovered
+        by using the `stop_use_example_configuration` method.
+        """
+        global server
+        global apikey
+        cls._last_used_server = server
+        cls._last_used_key = apikey
 
+        # Test server key for examples
+        server = "https://test.openml.org/api/v1/xml"
+        apikey = "c0c42819af31e706efe1f4b88c23c6c1"
 
-def stop_use_example_configuration():
-    global server
-    global apikey
-    global _last_used_server
-    global _last_used_key
+    @classmethod
+    def stop_use_example_configuration(cls):
+        """ Return to configuration as it was before `start_use_example_configuration`. """
+        global server
+        global apikey
 
-    server = _last_used_server
-    apikey = _last_used_key
+        server = cls._last_used_server
+        apikey = cls._last_used_key
 
 
 def _setup():
@@ -167,8 +171,12 @@ def set_cache_directory(cachedir):
     cache_directory = cachedir
 
 
+start_use_example_configuration = ExampleConfiguration.start_use_example_configuration
+stop_use_example_configuration = ExampleConfiguration.stop_use_example_configuration
+
 __all__ = [
-    'get_cache_directory', 'set_cache_directory'
+    'get_cache_directory', 'set_cache_directory',
+    'start_use_example_configuration', 'stop_use_example_configuration'
 ]
 
 _setup()

--- a/openml/config.py
+++ b/openml/config.py
@@ -42,6 +42,29 @@ _last_used_key = None
 _last_used_server = None
 
 
+def start_use_example_configuration():
+    global server
+    global apikey
+    global _last_used_server
+    global _last_used_key
+    _last_used_server = server
+    _last_used_key = apikey
+
+    # Test server key for examples
+    server = "https://test.openml.org/api/v1/xml"
+    apikey = "c0c42819af31e706efe1f4b88c23c6c1"
+
+
+def stop_use_example_configuration():
+    global server
+    global apikey
+    global _last_used_server
+    global _last_used_key
+
+    server = _last_used_server
+    apikey = _last_used_key
+
+
 def _setup():
     """Setup openml package. Called on first import.
 
@@ -142,25 +165,6 @@ def set_cache_directory(cachedir):
 
     global cache_directory
     cache_directory = cachedir
-
-
-def start_use_example_configuration():
-    global server
-    global apikey
-
-    _last_used_server = server
-    _last_used_key = apikey
-
-    # Test server key for examples
-    server = "https://test.openml.org/api/v1/xml"
-    apikey = "c0c42819af31e706efe1f4b88c23c6c1"
-
-
-def end_use_example_configuration():
-    global server
-    global apikey
-    server = _last_used_server
-    apikey = _last_used_key
 
 
 __all__ = [

--- a/openml/config.py
+++ b/openml/config.py
@@ -37,6 +37,10 @@ avoid_duplicate_runs = True if _defaults['avoid_duplicate_runs'] == 'True' else 
 # Number of retries if the connection breaks
 connection_n_retries = _defaults['connection_n_retries']
 
+# variables to keep track of last used settings for when `use_example_configuration` is activated
+_last_used_key = None
+_last_used_server = None
+
 
 def _setup():
     """Setup openml package. Called on first import.
@@ -138,6 +142,25 @@ def set_cache_directory(cachedir):
 
     global cache_directory
     cache_directory = cachedir
+
+
+def start_use_example_configuration():
+    global server
+    global apikey
+
+    _last_used_server = server
+    _last_used_key = apikey
+
+    # Test server key for examples
+    server = "https://test.openml.org/api/v1/xml"
+    apikey = "c0c42819af31e706efe1f4b88c23c6c1"
+
+
+def end_use_example_configuration():
+    global server
+    global apikey
+    server = _last_used_server
+    apikey = _last_used_key
 
 
 __all__ = [

--- a/openml/config.py
+++ b/openml/config.py
@@ -47,7 +47,7 @@ class ConfigurationForExamples:
     _test_apikey = "c0c42819af31e706efe1f4b88c23c6c1"
 
     @classmethod
-    def start_use_example_configuration(cls):
+    def start_using_configuration_for_example(cls):
         """ Sets the configuration to connect to the test server with valid apikey.
 
         To configuration as was before this call is stored, and can be recovered
@@ -70,7 +70,7 @@ class ConfigurationForExamples:
         apikey = cls._test_apikey
 
     @classmethod
-    def stop_use_example_configuration(cls):
+    def stop_using_configuration_for_example(cls):
         """ Return to configuration as it was before `start_use_example_configuration`. """
         if not cls._start_last_called:
             # We don't want to allow this because it will (likely) result in the `server` and
@@ -188,12 +188,18 @@ def set_cache_directory(cachedir):
     cache_directory = cachedir
 
 
-start_use_example_configuration = ConfigurationForExamples.start_use_example_configuration
-stop_use_example_configuration = ConfigurationForExamples.stop_use_example_configuration
+start_using_configuration_for_example = (
+    ConfigurationForExamples.start_using_configuration_for_example
+)
+stop_using_configuration_for_example = (
+    ConfigurationForExamples.stop_using_configuration_for_example
+)
 
 __all__ = [
-    'get_cache_directory', 'set_cache_directory',
-    'start_use_example_configuration', 'stop_use_example_configuration'
+    'get_cache_directory',
+    'set_cache_directory',
+    'start_using_configuration_for_example',
+    'stop_using_configuration_for_example',
 ]
 
 _setup()

--- a/openml/config.py
+++ b/openml/config.py
@@ -42,6 +42,9 @@ class ExampleConfiguration:
     """ Allows easy switching to and from a test configuration. """
     _last_used_server = None
     _last_used_key = None
+    _start_last_called = False
+    _test_server = "https://test.openml.org/api/v1/xml"
+    _test_apikey = "c0c42819af31e706efe1f4b88c23c6c1"
 
     @classmethod
     def start_use_example_configuration(cls):
@@ -52,21 +55,35 @@ class ExampleConfiguration:
         """
         global server
         global apikey
+
+        if cls._start_last_called and server == cls._test_server and apikey == cls._test_apikey:
+            # Method is called more than once in a row without modifying the server or apikey.
+            # We don't want to save the current test configuration as a last used configuration.
+            return
+
         cls._last_used_server = server
         cls._last_used_key = apikey
+        cls._start_last_called = True
 
         # Test server key for examples
-        server = "https://test.openml.org/api/v1/xml"
-        apikey = "c0c42819af31e706efe1f4b88c23c6c1"
+        server = cls._test_server
+        apikey = cls._test_apikey
 
     @classmethod
     def stop_use_example_configuration(cls):
         """ Return to configuration as it was before `start_use_example_configuration`. """
+        if not cls._start_last_called:
+            # We don't want to allow this because it will (likely) result in the `server` and
+            # `apikey` variables being set to None.
+            raise RuntimeError("`stop_use_example_configuration` called without a saved config."
+                               "`start_use_example_configuration` must be called first.")
+
         global server
         global apikey
 
         server = cls._last_used_server
         apikey = cls._last_used_key
+        cls._start_last_called = False
 
 
 def _setup():

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -19,7 +19,7 @@ class TestConfigurationForExamples(openml.testing.TestBase):
         openml.config.apikey = "610344db6388d9ba34f6db45a3cf71de"
         openml.config.server = self.production_server
 
-        openml.config.start_use_example_configuration()
+        openml.config.start_using_configuration_for_example()
 
         self.assertEqual(openml.config.apikey, "c0c42819af31e706efe1f4b88c23c6c1")
         self.assertEqual(openml.config.server, self.test_server)
@@ -30,8 +30,8 @@ class TestConfigurationForExamples(openml.testing.TestBase):
         openml.config.apikey = "610344db6388d9ba34f6db45a3cf71de"
         openml.config.server = self.production_server
 
-        openml.config.start_use_example_configuration()
-        openml.config.stop_use_example_configuration()
+        openml.config.start_using_configuration_for_example()
+        openml.config.stop_using_configuration_for_example()
 
         self.assertEqual(openml.config.apikey, "610344db6388d9ba34f6db45a3cf71de")
         self.assertEqual(openml.config.server, self.production_server)
@@ -40,16 +40,16 @@ class TestConfigurationForExamples(openml.testing.TestBase):
         """ Verifies an error is raised is `stop_...` is called before `start_...`. """
         error_regex = ".*stop_use_example_configuration.*start_use_example_configuration.*first"
         self.assertRaisesRegex(RuntimeError, error_regex,
-                               openml.config.stop_use_example_configuration)
+                               openml.config.stop_using_configuration_for_example)
 
     def test_example_configuration_start_twice(self):
         """ Checks that the original config can be returned to if `start..` is called twice. """
         openml.config.apikey = "610344db6388d9ba34f6db45a3cf71de"
         openml.config.server = self.production_server
 
-        openml.config.start_use_example_configuration()
-        openml.config.start_use_example_configuration()
-        openml.config.stop_use_example_configuration()
+        openml.config.start_using_configuration_for_example()
+        openml.config.start_using_configuration_for_example()
+        openml.config.stop_using_configuration_for_example()
 
         self.assertEqual(openml.config.apikey, "610344db6388d9ba34f6db45a3cf71de")
         self.assertEqual(openml.config.server, self.production_server)

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -9,3 +9,47 @@ class TestConfig(openml.testing.TestBase):
     def test_config_loading(self):
         self.assertTrue(os.path.exists(openml.config.config_file))
         self.assertTrue(os.path.isdir(os.path.expanduser('~/.openml')))
+
+
+class TestConfig(openml.testing.TestBase):
+
+    def test_switch_to_example_configuration(self):
+        """ Verifies the test configuration is loaded properly. """
+        # Below is the default test key which would be used anyway, but just for clarity:
+        openml.config.apikey = "610344db6388d9ba34f6db45a3cf71de"
+        openml.config.server = self.production_server
+
+        openml.config.start_use_example_configuration()
+
+        self.assertEqual(openml.config.apikey, "c0c42819af31e706efe1f4b88c23c6c1")
+        self.assertEqual(openml.config.server, self.test_server)
+
+    def test_switch_from_example_configuration(self):
+        """ Verifies the previous configuration is loaded after stopping. """
+        # Below is the default test key which would be used anyway, but just for clarity:
+        openml.config.apikey = "610344db6388d9ba34f6db45a3cf71de"
+        openml.config.server = self.production_server
+
+        openml.config.start_use_example_configuration()
+        openml.config.stop_use_example_configuration()
+
+        self.assertEqual(openml.config.apikey, "610344db6388d9ba34f6db45a3cf71de")
+        self.assertEqual(openml.config.server, self.production_server)
+
+    def test_example_configuration_stop_before_start(self):
+        """ Verifies an error is raised is `stop_...` is called before `start_...`. """
+        error_regex = ".*stop_use_example_configuration.*start_use_example_configuration.*first"
+        self.assertRaisesRegex(RuntimeError, error_regex,
+                               openml.config.stop_use_example_configuration)
+
+    def test_example_configuration_start_twice(self):
+        """ Checks that the original config can be returned to if `start..` is called twice. """
+        openml.config.apikey = "610344db6388d9ba34f6db45a3cf71de"
+        openml.config.server = self.production_server
+
+        openml.config.start_use_example_configuration()
+        openml.config.start_use_example_configuration()
+        openml.config.stop_use_example_configuration()
+
+        self.assertEqual(openml.config.apikey, "610344db6388d9ba34f6db45a3cf71de")
+        self.assertEqual(openml.config.server, self.production_server)

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -11,7 +11,7 @@ class TestConfig(openml.testing.TestBase):
         self.assertTrue(os.path.isdir(os.path.expanduser('~/.openml')))
 
 
-class TestConfig(openml.testing.TestBase):
+class TestConfigurationForExamples(openml.testing.TestBase):
 
     def test_switch_to_example_configuration(self):
         """ Verifies the test configuration is loaded properly. """


### PR DESCRIPTION
Two functions which make it easier to switch between a test environment and a production environment.
This is so we can create examples which operate on the test server and upload things, and have them easily be reproducible for people trying to follow the examples.

In the old style, you would have to set the server and apikey yourself. This is a little bit more verbose, possibly requires having to look up what the apikey is, and having the apikey in more plain sight.

With the changes we can instead use:
```
>>> import openml
>>> len(openml.tasks.list_tasks())
18742
>>> openml.config.start_use_example_configuration()
>>> len(openml.tasks.list_tasks())
1527
>>> openml.config.stop_use_example_configuration()
>>> len(openml.tasks.list_tasks())
18742
```

The apikey for the test server is from the openml tutorials, and is different from the one we use for unit testing. This is in the event we later need to purge specific subset of data from the test server (e.g. we find someone abused the example apikey and it is affecting unit tests).

Yay or nay?

I'll add a unit test if the concept is approved.