### PR TITLE
New example for evalutions

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -135,4 +135,3 @@ Modules
     get_task
     get_tasks
     list_tasks
-

--- a/examples/fetch_evaluations.py
+++ b/examples/fetch_evaluations.py
@@ -11,8 +11,8 @@ from pprint import pprint
 
 ############################################################################
 #
-# Evalutions contain details of all runs and the resulting results that
-# was uploaded for those settings - data, flow, task, etc.
+# Evalutions contain details (IDs and names) of data, flow, tasks, of all runs
+# and the resulting results that was uploaded for those settings.
 # The listing functions take optional parameters which can be used to filter
 # results and fetch only the evaluations required.
 #
@@ -23,10 +23,7 @@ from pprint import pprint
 # Listing evaluations
 # ^^^^^^^^^^^^^^^^^^^
 #
-# We shall retrieve a small list and test the listing function for evaluations
-evals = openml.evaluations.list_evaluations(function='predictive_accuracy', size=10)
-pprint(evals)
-# To have a tabular output
+# We shall retrieve a small set to test the listing function for evaluations
 openml.evaluations.list_evaluations(function='predictive_accuracy', size=10,
                                     output_format='dataframe')
 # Using other evaluation metrics
@@ -38,13 +35,14 @@ openml.evaluations.list_evaluations(function='precision', size=10,
 #
 # We will start by displaying a simple *supervised classification* task:
 task_id = 167140        # https://www.openml.org/t/167140
-task = openml.tasks.get_tasks([task_id])[0]
+task = openml.tasks.get_task(task_id)
 pprint(vars(task))
 
 # Obtaining all the evaluations for the task
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-evals = openml.evaluations.list_evaluations(function='predictive_accuracy', task=[task_id],
+metric = 'predictive_accuracy'
+evals = openml.evaluations.list_evaluations(function=metric, task=[task_id],
                                             output_format='dataframe')
 # Displaying the first 10 rows
 pprint(evals.head(n=10))
@@ -52,14 +50,14 @@ pprint(evals.head(n=10))
 evals = evals.sort_values(by='value', ascending=False)
 pprint(evals.head())
 
-# Obtain CDF
-# ^^^^^^^^^^
+# Obtain CDF of metric for chosen task
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 from matplotlib import pyplot as plt
 
 
 def plot_cdf(values, metric='predictive_accuracy'):
-    plt.hist(values, density=True, histtype='step', cumulative=True)
+    plt.hist(values, density=True, histtype='step', cumulative=True, linewidth=3)
     plt.xlim(max(0, min(values) - 0.1), 1)
     plt.title('CDF')
     plt.xlabel(metric)
@@ -69,4 +67,35 @@ def plot_cdf(values, metric='predictive_accuracy'):
     plt.show()
 
 
-plot_cdf(evals.value)
+plot_cdf(evals.value, metric)
+
+# Compare top 10 performing flows
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+import numpy as np
+import pandas as pd
+
+
+def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
+    # Collecting the top 10 performing unique flow_id
+    flow_list = np.unique(evaluations.flow_id)[:10]
+
+    df = pd.DataFrame()
+    for i in range(len(flow_list)):
+        df = pd.concat([df, pd.DataFrame(evaluations[evaluations.flow_id == flow_list[i]].value)],
+                       ignore_index=True, axis=1)
+    fig, axs = plt.subplots()
+    df.boxplot()
+    axs.set_title('Boxplot comparing ' + metric + ' for different flows')
+    axs.set_ylabel(metric)
+    axs.set_xlabel('Flow ID')
+    axs.set_xticklabels(flow_list)
+    flow_freq = list(df.count(axis=0, numeric_only=True))
+    print(len(flow_freq), flow_freq)
+    print(len(flow_list), flow_list)
+    for i in range(len(flow_list)):
+        axs.text(i + 1.05, np.nanmin(df.values), str(flow_freq[i]) + ' run(s)')
+    plt.show()
+
+
+plot_flow_compare(evals, metric=metric)

--- a/examples/fetch_evaluations.py
+++ b/examples/fetch_evaluations.py
@@ -1,0 +1,69 @@
+"""
+Tasks
+=====
+
+A tutorial on how to fetch evalutions on a task.
+"""
+
+import openml
+# import pandas as pd
+from pprint import pprint
+
+############################################################################
+#
+# Evalutions contain details of all runs and the resulting results that
+# was uploaded for those settings - data, flow, task, etc.
+# The listing functions take optional parameters which can be used to filter
+# results and fetch only the evaluations required.
+#
+# In this example, we'll primarily see how to retrieve the results for a
+# particular task and attempt to compare performance of different runs.
+
+############################################################################
+# Listing evaluations
+# ^^^^^^^^^^^^^^^^^^^
+#
+# We shall retrieve a small list and test the listing function for evaluations
+evals = openml.evaluations.list_evaluations(function='predictive_accuracy', size=10)
+pprint(evals)
+# To have a tabular output
+openml.evaluations.list_evaluations(function='predictive_accuracy', size=10,
+                                    output_format='dataframe')
+# Using other evaluation metrics
+openml.evaluations.list_evaluations(function='precision', size=10,
+                                    output_format='dataframe')
+
+# Listing tasks
+# ^^^^^^^^^^^^^
+#
+# We will start by displaying a simple *supervised classification* task:
+task_id = 167140        # https://www.openml.org/t/167140
+task = openml.tasks.get_tasks([task_id])[0]
+pprint(vars(task))
+
+# Obtaining all the evaluations for the task
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+evals = openml.evaluations.list_evaluations(function='predictive_accuracy', task=[task_id],
+                                            output_format='dataframe')
+# Displaying the first 10 rows
+pprint(evals.head(n=10))
+# Sorting the evaluations in decreasing order of the metric chosen
+evals = evals.sort_values(by='value', ascending=False)
+pprint(evals.head())
+
+# Obtain CDF
+# ^^^^^^^^^^
+#
+from matplotlib import pyplot as plt
+def plot_cdf(values, metric='predictive_accuracy'):
+    plt.hist(values, density=True, histtype='step', cumulative=True)
+    plt.xlim(max(0,min(values)-0.1),1)
+    plt.title('CDF')
+    plt.xlabel(metric)
+    plt.ylabel('Likelihood')
+    plt.grid(b=True, which='major', linestyle='-')
+    plt.grid(b=True, which='minor', linestyle='--')
+    plt.show()
+
+plot_cdf(evals.value)

--- a/examples/fetch_evaluations.py
+++ b/examples/fetch_evaluations.py
@@ -56,14 +56,17 @@ pprint(evals.head())
 # ^^^^^^^^^^
 #
 from matplotlib import pyplot as plt
+
+
 def plot_cdf(values, metric='predictive_accuracy'):
     plt.hist(values, density=True, histtype='step', cumulative=True)
-    plt.xlim(max(0,min(values)-0.1),1)
+    plt.xlim(max(0, min(values) - 0.1), 1)
     plt.title('CDF')
     plt.xlabel(metric)
     plt.ylabel('Likelihood')
     plt.grid(b=True, which='major', linestyle='-')
     plt.grid(b=True, which='minor', linestyle='--')
     plt.show()
+
 
 plot_cdf(evals.value)

--- a/examples/fetch_evaluations.py
+++ b/examples/fetch_evaluations.py
@@ -1,12 +1,12 @@
 """
-Tasks
-=====
+=================
+Fetch Evaluations
+=================
 
-A tutorial on how to fetch evalutions on a task.
+A tutorial on how to fetch evalutions of a task.
 """
-
+############################################################################
 import openml
-# import pandas as pd
 from pprint import pprint
 
 ############################################################################
@@ -21,8 +21,8 @@ from pprint import pprint
 
 ############################################################################
 # Listing evaluations
-# ^^^^^^^^^^^^^^^^^^^
-#
+# *******************
+
 # We shall retrieve a small set to test the listing function for evaluations
 openml.evaluations.list_evaluations(function='predictive_accuracy', size=10,
                                     output_format='dataframe')
@@ -30,17 +30,19 @@ openml.evaluations.list_evaluations(function='predictive_accuracy', size=10,
 openml.evaluations.list_evaluations(function='precision', size=10,
                                     output_format='dataframe')
 
+#############################################################################
 # Listing tasks
-# ^^^^^^^^^^^^^
-#
+# =============
+
 # We will start by displaying a simple *supervised classification* task:
 task_id = 167140        # https://www.openml.org/t/167140
 task = openml.tasks.get_task(task_id)
 pprint(vars(task))
 
+#############################################################################
 # Obtaining all the evaluations for the task
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#
+# ==========================================
+
 metric = 'predictive_accuracy'
 evals = openml.evaluations.list_evaluations(function=metric, task=[task_id],
                                             output_format='dataframe')
@@ -50,9 +52,10 @@ pprint(evals.head(n=10))
 evals = evals.sort_values(by='value', ascending=False)
 pprint(evals.head())
 
+#############################################################################
 # Obtain CDF of metric for chosen task
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#
+# ************************************
+
 from matplotlib import pyplot as plt
 
 
@@ -69,9 +72,10 @@ def plot_cdf(values, metric='predictive_accuracy'):
 
 plot_cdf(evals.value, metric)
 
+#############################################################################
 # Compare top 10 performing flows
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#
+# *******************************
+
 import numpy as np
 import pandas as pd
 

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -116,7 +116,7 @@ def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
     # Creating a data frame containing only the metric values of the selected flows
     #   assuming evaluations is sorted in decreasing order of metric
     for i in range(len(flow_ids)):
-        flow_values = evaluations[evaluations.flow_id == flow_ids[i]].value 
+        flow_values = evaluations[evaluations.flow_id == flow_ids[i]].value
         df = pd.concat([df, flow_values], ignore_index=True, axis=1)
     fig, axs = plt.subplots()
     df.boxplot()

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -10,16 +10,6 @@ import openml
 from pprint import pprint
 
 ############################################################################
-#
-# Evalutions contain details (IDs and names) of data, flow, tasks, of all runs
-# and the resulting results that was uploaded for those settings.
-# The listing functions take optional parameters which can be used to filter
-# results and fetch only the evaluations required.
-#
-# In this example, we'll primarily see how to retrieve the results for a
-# particular task and attempt to compare performance of different runs.
-
-############################################################################
 # Listing evaluations
 # *******************
 
@@ -95,10 +85,8 @@ def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
     axs.set_xlabel('Flow ID')
     axs.set_xticklabels(flow_list)
     flow_freq = list(df.count(axis=0, numeric_only=True))
-    print(len(flow_freq), flow_freq)
-    print(len(flow_list), flow_list)
     for i in range(len(flow_list)):
-        axs.text(i + 1.05, np.nanmin(df.values), str(flow_freq[i]) + ' run(s)')
+        axs.text(i + 1.05, np.nanmin(df.values), str(flow_freq[i]) + '\nrun(s)', fontsize=7)
     plt.show()
 
 

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -19,14 +19,14 @@ from pprint import pprint
 ############################################################################
 # Listing evaluations
 # *******************
-# Evaluations can be retrieved from the database in the chosen output format
-# Required filters can be applied to retrieve results from runs as required
+# Evaluations can be retrieved from the database in the chosen output format.
+# Required filters can be applied to retrieve results from runs as required.
 
 # We shall retrieve a small set (only 10 entries) to test the listing function for evaluations
 openml.evaluations.list_evaluations(function='predictive_accuracy', size=10,
                                     output_format='dataframe')
 
-# Using other evaluation metrics, 'precision; in this case
+# Using other evaluation metrics, 'precision' in this case
 evals = openml.evaluations.list_evaluations(function='precision', size=10,
                                             output_format='dataframe')
 
@@ -36,7 +36,7 @@ pprint(evals[evals.value > 0.98])
 #############################################################################
 # View a sample task
 # ==================
-# Over here we shall briefly take a look at the details of the task we'll use in this example
+# Over here we shall briefly take a look at the details of the task.
 
 # We will start by displaying a simple *supervised classification* task:
 task_id = 167140        # https://www.openml.org/t/167140
@@ -46,8 +46,8 @@ pprint(vars(task))
 #############################################################################
 # Obtaining all the evaluations for the task
 # ==========================================
-# We'll now obtain all the runs that were made for the task we displayed previously
-# Note that we now filter the evaluations based on another parameter 'task'
+# We'll now obtain all the runs that were made for the task we displayed previously.
+# Note that we now filter the evaluations based on another parameter 'task'.
 
 metric = 'predictive_accuracy'
 evals = openml.evaluations.list_evaluations(function=metric, task=[task_id],
@@ -62,9 +62,9 @@ pprint(evals.head())
 #############################################################################
 # Obtain CDF of metric for chosen task
 # ************************************
-# We shall now analyse how the performance of various flows have been to address
-# this chosen task, by seeing the likelihood of the accuracy obtained across all runs.
-# We shall now plot a cumulative distributive function (CDF) for the accuracy obtained.
+# We shall now analyse how the performance of various flows have been on this task,
+# by seeing the likelihood of the accuracy obtained across all runs.
+# We shall now plot a cumulative distributive function (CDF) for the accuracies obtained.
 
 from matplotlib import pyplot as plt
 
@@ -117,9 +117,9 @@ def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
     axs.set_ylabel(metric)
     axs.set_xlabel('Flow ID')
     axs.set_xticklabels(flow_list)
-    axs.grid(which='majpr', linestyle='-', linewidth='0.5', color='gray')
+    axs.grid(which='major', linestyle='-', linewidth='0.5', color='gray', axis='y')
     axs.minorticks_on()
-    axs.grid(which='minor', linestyle='--', linewidth='0.5', color='gray')
+    axs.grid(which='minor', linestyle='--', linewidth='0.5', color='gray', axis='y')
     # Counting the number of entries for each flow in the data frame
     #   which gives the number of runs for each flow
     flow_freq = list(df.count(axis=0, numeric_only=True))

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -116,8 +116,8 @@ def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
     # Creating a data frame containing only the metric values of the selected flows
     #   assuming evaluations is sorted in decreasing order of metric
     for i in range(len(flow_ids)):
-        flow_values = evaluations[evaluations.flow_id == flow_ids[i]].value.tolist()
-        df = pd.concat([df, pd.DataFrame(flow_values)], ignore_index=True, axis=1)
+        flow_values = evaluations[evaluations.flow_id == flow_ids[i]].value 
+        df = pd.concat([df, flow_values], ignore_index=True, axis=1)
     fig, axs = plt.subplots()
     df.boxplot()
     axs.set_title('Boxplot comparing ' + metric + ' for different flows')

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -1,15 +1,21 @@
 """
-=================
-Fetch Evaluations
-=================
-
-A tutorial on how to fetch evalutions of a task.
+====================
+Fetching Evaluations
+====================
 
 Evalutions contain a concise summary of the results of all runs made. Each evaluation
 provides information on the dataset used, the flow applied, the setup used, the metric
 evaluated, and the result obtained on the metric, for each such run made. These collection
 of results can be used for efficient benchmarking of an algorithm and also allow transparent
 reuse of results from previous experiments on similar parameters.
+
+In this example, we shall do the following:
+
+* Retrieve evaluations based on different metrics
+* Fetch evaluations pertaining to a specific task
+* Sort the obtained results in descending order of the metric
+* Plot a cumulative distribution function for the evaluations
+* Compare the top 10 performing flows based on the evaluation performance
 """
 
 ############################################################################
@@ -34,8 +40,8 @@ evals = openml.evaluations.list_evaluations(function='precision', size=10,
 pprint(evals[evals.value > 0.98])
 
 #############################################################################
-# View a sample task
-# ==================
+# Viewing a sample task
+# =====================
 # Over here we shall briefly take a look at the details of the task.
 
 # We will start by displaying a simple *supervised classification* task:
@@ -46,7 +52,8 @@ pprint(vars(task))
 #############################################################################
 # Obtaining all the evaluations for the task
 # ==========================================
-# We'll now obtain all the runs that were made for the task we displayed previously.
+# We'll now obtain all the evaluations that were uploaded for the task
+# we displayed previously.
 # Note that we now filter the evaluations based on another parameter 'task'.
 
 metric = 'predictive_accuracy'
@@ -60,8 +67,8 @@ print("\nDisplaying head of sorted dataframe: ")
 pprint(evals.head())
 
 #############################################################################
-# Obtain CDF of metric for chosen task
-# ************************************
+# Obtaining CDF of metric for chosen task
+# ***************************************
 # We shall now analyse how the performance of various flows have been on this task,
 # by seeing the likelihood of the accuracy obtained across all runs.
 # We shall now plot a cumulative distributive function (CDF) for the accuracies obtained.
@@ -92,10 +99,10 @@ plot_cdf(evals.value, metric)
 # with non-zero probability. While the maximum accuracy seen till now is 96.5%.
 
 #############################################################################
-# Compare top 10 performing flows
-# *******************************
+# Comparing top 10 performing flows
+# *********************************
 # Let us now try to see which flows generally performed the best for this task.
-# To this effect, we shall compare the top performing flows.
+# For this, we shall compare the top performing flows.
 
 import numpy as np
 import pandas as pd
@@ -103,27 +110,27 @@ import pandas as pd
 
 def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
     # Collecting the top 10 performing unique flow_id
-    flow_list = evaluations.flow_id.unique()[:top_n]
+    flow_ids = evaluations.flow_id.unique()[:top_n]
 
     df = pd.DataFrame()
     # Creating a data frame containing only the metric values of the selected flows
     #   assuming evaluations is sorted in decreasing order of metric
-    for i in range(len(flow_list)):
-        df = pd.concat([df, pd.DataFrame(evaluations[evaluations.flow_id == flow_list[i]].value)],
-                       ignore_index=True, axis=1)
+    for i in range(len(flow_ids)):
+        flow_values = evaluations[evaluations.flow_id == flow_ids[i]].value.tolist()
+        df = pd.concat([df, pd.DataFrame(flow_values)], ignore_index=True, axis=1)
     fig, axs = plt.subplots()
     df.boxplot()
     axs.set_title('Boxplot comparing ' + metric + ' for different flows')
     axs.set_ylabel(metric)
     axs.set_xlabel('Flow ID')
-    axs.set_xticklabels(flow_list)
+    axs.set_xticklabels(flow_ids)
     axs.grid(which='major', linestyle='-', linewidth='0.5', color='gray', axis='y')
     axs.minorticks_on()
     axs.grid(which='minor', linestyle='--', linewidth='0.5', color='gray', axis='y')
     # Counting the number of entries for each flow in the data frame
     #   which gives the number of runs for each flow
     flow_freq = list(df.count(axis=0, numeric_only=True))
-    for i in range(len(flow_list)):
+    for i in range(len(flow_ids)):
         axs.text(i + 1.05, np.nanmin(df.values), str(flow_freq[i]) + '\nrun(s)', fontsize=7)
     plt.show()
 
@@ -134,3 +141,10 @@ plot_flow_compare(evals, metric=metric, top_n=10)
 # that flow (number of runs denoted at the bottom of the boxplots). The higher the
 # green line, the better the flow is for the task at hand. The ordering of the flows
 # are in the descending order of the higest accuracy value seen under that flow.
+
+# Printing the corresponding flow names for the top 10 performing flow IDs
+top_n = 10
+flow_ids = evals.flow_id.unique()[:top_n]
+flow_names = evals.flow_name.unique()[:top_n]
+for i in range(top_n):
+    pprint((flow_ids[i], flow_names[i]))

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -4,7 +4,14 @@ Fetch Evaluations
 =================
 
 A tutorial on how to fetch evalutions of a task.
+
+Evalutions contain a concise summary of the results of all runs made. Each evaluation
+provides information on the dataset used, the flow applied, the setup used, the metric
+evaluated, and the result obtained on the metric, for each such run made. These collection
+of results can be used for efficient benchmarking of an algorithm and also allow transparent
+reuse of results from previous experiments on similar parameters.
 """
+
 ############################################################################
 import openml
 from pprint import pprint
@@ -12,17 +19,24 @@ from pprint import pprint
 ############################################################################
 # Listing evaluations
 # *******************
+# Evaluations can be retrieved from the database in the chosen output format
+# Required filters can be applied to retrieve results from runs as required
 
-# We shall retrieve a small set to test the listing function for evaluations
+# We shall retrieve a small set (only 10 entries) to test the listing function for evaluations
 openml.evaluations.list_evaluations(function='predictive_accuracy', size=10,
                                     output_format='dataframe')
-# Using other evaluation metrics
-openml.evaluations.list_evaluations(function='precision', size=10,
-                                    output_format='dataframe')
+
+# Using other evaluation metrics, 'precision; in this case
+evals = openml.evaluations.list_evaluations(function='precision', size=10,
+                                            output_format='dataframe')
+
+# Querying the returned results for precision above 0.98
+pprint(evals[evals.value > 0.98])
 
 #############################################################################
-# Listing tasks
-# =============
+# View a sample task
+# ==================
+# Over here we shall briefly take a look at the details of the task we'll use in this example
 
 # We will start by displaying a simple *supervised classification* task:
 task_id = 167140        # https://www.openml.org/t/167140
@@ -32,6 +46,8 @@ pprint(vars(task))
 #############################################################################
 # Obtaining all the evaluations for the task
 # ==========================================
+# We'll now obtain all the runs that were made for the task we displayed previously
+# Note that we now filter the evaluations based on another parameter 'task'
 
 metric = 'predictive_accuracy'
 evals = openml.evaluations.list_evaluations(function=metric, task=[task_id],
@@ -40,31 +56,46 @@ evals = openml.evaluations.list_evaluations(function=metric, task=[task_id],
 pprint(evals.head(n=10))
 # Sorting the evaluations in decreasing order of the metric chosen
 evals = evals.sort_values(by='value', ascending=False)
+print("\nDisplaying head of sorted dataframe: ")
 pprint(evals.head())
 
 #############################################################################
 # Obtain CDF of metric for chosen task
 # ************************************
+# We shall now analyse how the performance of various flows have been to address
+# this chosen task, by seeing the likelihood of the accuracy obtained across all runs.
+# We shall now plot a cumulative distributive function (CDF) for the accuracy obtained.
 
 from matplotlib import pyplot as plt
 
 
 def plot_cdf(values, metric='predictive_accuracy'):
-    plt.hist(values, density=True, histtype='step', cumulative=True, linewidth=3)
+    max_val = max(values)
+    n, bins, patches = plt.hist(values, density=True, histtype='step',
+                                cumulative=True, linewidth=3)
+    patches[0].set_xy(patches[0].get_xy()[:-1])
     plt.xlim(max(0, min(values) - 0.1), 1)
     plt.title('CDF')
     plt.xlabel(metric)
     plt.ylabel('Likelihood')
     plt.grid(b=True, which='major', linestyle='-')
+    plt.minorticks_on()
     plt.grid(b=True, which='minor', linestyle='--')
+    plt.axvline(max_val, linestyle='--', color='gray')
+    plt.text(max_val, 0, "%.3f" % max_val, fontsize=9)
     plt.show()
 
 
 plot_cdf(evals.value, metric)
+# This CDF plot shows that for the given task, based on the results of the
+# runs uploaded, it is almost certain to achieve an accuracy above 52%, i.e.,
+# with non-zero probability. While the maximum accuracy seen till now is 96.5%.
 
 #############################################################################
 # Compare top 10 performing flows
 # *******************************
+# Let us now try to see which flows generally performed the best for this task.
+# To this effect, we shall compare the top performing flows.
 
 import numpy as np
 import pandas as pd
@@ -72,9 +103,11 @@ import pandas as pd
 
 def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
     # Collecting the top 10 performing unique flow_id
-    flow_list = np.unique(evaluations.flow_id)[:10]
+    flow_list = evaluations.flow_id.unique()[:top_n]
 
     df = pd.DataFrame()
+    # Creating a data frame containing only the metric values of the selected flows
+    #   assuming evaluations is sorted in decreasing order of metric
     for i in range(len(flow_list)):
         df = pd.concat([df, pd.DataFrame(evaluations[evaluations.flow_id == flow_list[i]].value)],
                        ignore_index=True, axis=1)
@@ -84,10 +117,20 @@ def plot_flow_compare(evaluations, top_n=10, metric='predictive_accuracy'):
     axs.set_ylabel(metric)
     axs.set_xlabel('Flow ID')
     axs.set_xticklabels(flow_list)
+    axs.grid(which='majpr', linestyle='-', linewidth='0.5', color='gray')
+    axs.minorticks_on()
+    axs.grid(which='minor', linestyle='--', linewidth='0.5', color='gray')
+    # Counting the number of entries for each flow in the data frame
+    #   which gives the number of runs for each flow
     flow_freq = list(df.count(axis=0, numeric_only=True))
     for i in range(len(flow_list)):
         axs.text(i + 1.05, np.nanmin(df.values), str(flow_freq[i]) + '\nrun(s)', fontsize=7)
     plt.show()
 
 
-plot_flow_compare(evals, metric=metric)
+plot_flow_compare(evals, metric=metric, top_n=10)
+# The boxplots below show how the flows perform across multiple runs on the chosen
+# task. The green horizontal lines represent the median accuracy of all the runs for
+# that flow (number of runs denoted at the bottom of the boxplots). The higher the
+# green line, the better the flow is for the task at hand. The ordering of the flows
+# are in the descending order of the higest accuracy value seen under that flow.

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -237,7 +237,6 @@ def list_datasets(
 
 
 def _list_datasets(output_format='dict', **kwargs):
-
     """
     Perform api call to return a list of all datasets.
 
@@ -308,7 +307,8 @@ def _load_features_from_file(features_file: str) -> Dict:
 
 
 def check_datasets_active(dataset_ids: List[int]) -> Dict[int, bool]:
-    """ Check if the dataset ids provided are active.
+    """
+    Check if the dataset ids provided are active.
 
     Parameters
     ----------


### PR DESCRIPTION
#### What does this PR implement/fix? Explain your changes.

Adds a new example to fetch evaluations. 

#### How should this PR be tested?

The _examples/_ folder has a new file named _fetch_evaluations_tutorial.py_. 

#### Any other comments?

Currently, the example shows the following:
- Fetch a task's evaluations
- Create a CDF of predictive accuracy for all runs obtained
- Create box plots to compare the predictive accuracy of the top 10 flows

Would like to have feedback on more additions to the example or plot enhancements.

Thanks.
