### PR TITLE
Fix bugs by using live server due to reduced volatility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   # Checks for older scikit-learn versions (which also don't nicely work with
   # Python3.7)
   - DISTRIB="conda" PYTHON_VERSION="3.6" SKLEARN_VERSION="0.19.2"
-  - DISTRIB="conda" PYTHON_VERSION="3.6" SKLEARN_VERSION="0.18.2"
+  - DISTRIB="conda" PYTHON_VERSION="3.6" SKLEARN_VERSION="0.18.2" SCIPY_VERSION=1.2.0
 
 # Travis issue
 # https://github.com/travis-ci/travis-ci/issues/8920

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -28,7 +28,7 @@ conda create -n testenv --yes python=$PYTHON_VERSION pip
 source activate testenv
 
 if [[ -v SCIPY_VERSION ]]; then
-    conda install scipy=$SCIPY_VERSION
+    conda install --yes scipy=$SCIPY_VERSION
 fi
 
 python --version

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -27,6 +27,11 @@ popd
 conda create -n testenv --yes python=$PYTHON_VERSION pip
 source activate testenv
 
+if [[ -v SCIPY_VERSION ]]; then
+do
+    conda install scipy=$SCIPY_VERSION
+done
+
 python --version
 pip install -e '.[test]'
 python -c "import numpy; print('numpy %s' % numpy.__version__)"

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -28,9 +28,8 @@ conda create -n testenv --yes python=$PYTHON_VERSION pip
 source activate testenv
 
 if [[ -v SCIPY_VERSION ]]; then
-do
     conda install scipy=$SCIPY_VERSION
-done
+fi
 
 python --version
 pip install -e '.[test]'

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -254,11 +254,13 @@ class TestOpenMLDataset(TestBase):
 
     def test__name_to_id_with_multiple_active(self):
         """ With multiple active datasets, retrieve the least recent active. """
-        self.assertEqual(openml.datasets.functions._name_to_id('iris'), 128)
+        openml.config.server = self.production_server
+        self.assertEqual(openml.datasets.functions._name_to_id('iris'), 61)
 
     def test__name_to_id_with_version(self):
         """ With multiple active datasets, retrieve the least recent active. """
-        self.assertEqual(openml.datasets.functions._name_to_id('iris', version=3), 151)
+        openml.config.server = self.production_server
+        self.assertEqual(openml.datasets.functions._name_to_id('iris', version=3), 969)
 
     def test__name_to_id_with_multiple_active_error(self):
         """ With multiple active datasets, retrieve the least recent active. """

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -141,7 +141,6 @@ class TestSetupFunctions(TestBase):
         openml.config.server = self.production_server
         flow_id = 6794
         setups = openml.setups.list_setups(flow=flow_id, output_format='object', size=10)
-        print(setups)
         self.assertIsInstance(setups, Dict)
         self.assertIsInstance(setups[list(setups.keys())[0]],
                               openml.setups.setup.OpenMLSetup)

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -138,21 +138,23 @@ class TestSetupFunctions(TestBase):
         self.assertIsInstance(setups, dict)
 
     def test_list_setups_output_format(self):
-        flow_id = 18
-        setups = openml.setups.list_setups(flow=flow_id, output_format='object')
+        openml.config.server = self.production_server
+        flow_id = 6794
+        setups = openml.setups.list_setups(flow=flow_id, output_format='object', size=10)
+        print(setups)
         self.assertIsInstance(setups, Dict)
         self.assertIsInstance(setups[list(setups.keys())[0]],
                               openml.setups.setup.OpenMLSetup)
-        self.assertGreater(len(setups), 0)
+        self.assertEqual(len(setups), 10)
 
-        setups = openml.setups.list_setups(flow=flow_id, output_format='dataframe')
+        setups = openml.setups.list_setups(flow=flow_id, output_format='dataframe', size=10)
         self.assertIsInstance(setups, pd.DataFrame)
-        self.assertGreater(len(setups), 0)
+        self.assertEqual(len(setups), 10)
 
-        setups = openml.setups.list_setups(flow=flow_id, output_format='dict')
+        setups = openml.setups.list_setups(flow=flow_id, output_format='dict', size=10)
         self.assertIsInstance(setups, Dict)
         self.assertIsInstance(setups[list(setups.keys())[0]], Dict)
-        self.assertGreater(len(setups), 0)
+        self.assertEqual(len(setups), 10)
 
     def test_setuplist_offset(self):
         # TODO: remove after pull on live for better testing


### PR DESCRIPTION
This PR fixes two bugs which were 'introduced' recently by data changes on the test server. This does not include the fix included in #693 and will therefore not fix all unit tests.