### PR TITLE
Adding object summary

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -189,7 +189,7 @@ class OpenMLDataset(object):
         num_instances = ''
         if object_dict['qualities']['NumberOfInstances'] is not None:
             num_instances = '%-14s: %d\n' % ("# of instances",
-                                            object_dict['qualities']['NumberOfInstances'])
+                                             object_dict['qualities']['NumberOfInstances'])
         num_features = '%-14s: %d\n' % ("# of features", len(object_dict['features']))
         output_str = name + version + format + date + licence + d_url + w_url + local_file + \
             pickle_file + num_instances + num_features

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -178,23 +178,23 @@ class OpenMLDataset(object):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"Name": self.name,
-                            "Version": self.version,
-                            "Format": self.format,
-                            "Upload Date": self.upload_date.replace('T', ' '),
-                            "Licence": self.licence,
-                            "Download URL": self.url,
-                            "OpenML URL": "{}d/{}".format(base_url, self.dataset_id),
-                            "Data file": self.data_file,
-                            "Pickle file": self.data_pickle_file,
-                            "# of features": len(self.features)})
-
+        fields = {"Name": self.name,
+                  "Version": self.version,
+                  "Format": self.format,
+                  "Upload Date": self.upload_date.replace('T', ' '),
+                  "Licence": self.licence,
+                  "Download URL": self.url,
+                  "OpenML URL": "{}d/{}".format(base_url, self.dataset_id),
+                  "Data file": self.data_file,
+                  "Pickle file": self.data_pickle_file,
+                  "# of features": len(self.features)}
         if self.qualities['NumberOfInstances'] is not None:
-            fields.append(pd.Series({"# of instances": int(self.qualities['NumberOfInstances'])}))
+            fields["# of instances"] = int(self.qualities['NumberOfInstances'])
 
+        # determines the order in which the information will be printed
         order = ["Name", "Version", "Format", "Upload Date", "Licence", "Download URL",
-                 "OpenML URL", "Data File", "Pickle File", "# of features"]
-        fields = list(fields.reindex(order).dropna().iteritems())
+                 "OpenML URL", "Data File", "Pickle File", "# of features", "# of instances"]
+        fields = [(key, fields[key]) for key in order if key in fields]
 
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -181,13 +181,15 @@ class OpenMLDataset(object):
         fields = {"Name": self.name,
                   "Version": self.version,
                   "Format": self.format,
-                  "Upload Date": self.upload_date.replace('T', ' '),
                   "Licence": self.licence,
                   "Download URL": self.url,
-                  "OpenML URL": "{}d/{}".format(base_url, self.dataset_id),
                   "Data file": self.data_file,
                   "Pickle file": self.data_pickle_file,
                   "# of features": len(self.features)}
+        if self.upload_date is not None:
+            fields["Upload Date"] = self.upload_date.replace('T', ' ')
+        if self.dataset_id is not None:
+            fields["OpenML URL"] = "{}d/{}".format(base_url, self.dataset_id)
         if self.qualities['NumberOfInstances'] is not None:
             fields["# of instances"] = int(self.qualities['NumberOfInstances'])
 

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -176,21 +176,21 @@ class OpenMLDataset(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        name = '\n%14s: %s\n' % ("Name", object_dict['name'])
-        version = '%14s: %s\n' % ("Version", object_dict['version'])
-        format = '%14s: %s\n' % ("Format", object_dict['format'])
-        date = '%14s: %s\n' % ("Upload Date", object_dict['upload_date'].replace('T', ' '))
-        licence = '%14s: %s\n' % ("Licence", object_dict['licence'])
-        d_url = '%14s: %s\n' % ("Download URL", object_dict['url'])
+        name = '\n%-14s: %s\n' % ("Name", object_dict['name'])
+        version = '%-14s: %s\n' % ("Version", object_dict['version'])
+        format = '%-14s: %s\n' % ("Format", object_dict['format'])
+        date = '%-14s: %s\n' % ("Upload Date", object_dict['upload_date'].replace('T', ' '))
+        licence = '%-14s: %s\n' % ("Licence", object_dict['licence'])
+        d_url = '%-14s: %s\n' % ("Download URL", object_dict['url'])
         base_url = 'https://www.openml.org/d/'
-        w_url = '%14s: %s\n' % ("OpenML URL", base_url + str(self.dataset_id))
-        local_file = '%14s: %s\n' % ("Data file", object_dict['data_file'])
-        pickle_file = '%14s: %s\n' % ("Pickle file", object_dict['data_pickle_file'])
+        w_url = '%-14s: %s\n' % ("OpenML URL", base_url + str(self.dataset_id))
+        local_file = '%-14s: %s\n' % ("Data file", object_dict['data_file'])
+        pickle_file = '%-14s: %s\n' % ("Pickle file", object_dict['data_pickle_file'])
         num_instances = ''
         if object_dict['qualities']['NumberOfInstances'] is not None:
-            num_instances = '%14s: %d\n' % ("# of instances",
+            num_instances = '%-14s: %d\n' % ("# of instances",
                                             object_dict['qualities']['NumberOfInstances'])
-        num_features = '%14s: %d\n' % ("# of features", len(object_dict['features']))
+        num_features = '%-14s: %d\n' % ("# of features", len(object_dict['features']))
         output_str = name + version + format + date + licence + d_url + w_url + local_file + \
             pickle_file + num_instances + num_features
         return(output_str)

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -176,24 +176,27 @@ class OpenMLDataset(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        name = '\n%-14s: %s\n' % ("Name", object_dict['name'])
-        version = '%-14s: %s\n' % ("Version", object_dict['version'])
-        format = '%-14s: %s\n' % ("Format", object_dict['format'])
-        date = '%-14s: %s\n' % ("Upload Date", object_dict['upload_date'].replace('T', ' '))
-        licence = '%-14s: %s\n' % ("Licence", object_dict['licence'])
-        d_url = '%-14s: %s\n' % ("Download URL", object_dict['url'])
+        header = "OpenML Dataset"
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        name = '{:.<14}: {}\n'.format("Name", object_dict['name'])
+        version = '{:.<14}: {}\n'.format("Version", object_dict['version'])
+        format = '{:.<14}: {}\n'.format("Format", object_dict['format'])
+        date = '{:.<14}: {}\n'.format("Upload Date", object_dict['upload_date'].replace('T', ' '))
+        licence = '{:.<14}: {}\n'.format("Licence", object_dict['licence'])
+        d_url = '{:.<14}: {}\n'.format("Download URL", object_dict['url'])
         base_url = 'https://www.openml.org/d/'
-        w_url = '%-14s: %s\n' % ("OpenML URL", base_url + str(self.dataset_id))
-        local_file = '%-14s: %s\n' % ("Data file", object_dict['data_file'])
-        pickle_file = '%-14s: %s\n' % ("Pickle file", object_dict['data_pickle_file'])
+        w_url = '{:.<14}: {}\n'.format("OpenML URL", base_url + str(self.dataset_id))
+        local_file = '{:.<14}: {}\n'.format("Data file", object_dict['data_file'])
+        pickle_file = '{:.<14}: {}\n'.format("Pickle file", object_dict['data_pickle_file'])
+        num_features = '{:.<14}: {}\n'.format("# of features", len(object_dict['features']))
         num_instances = ''
         if object_dict['qualities']['NumberOfInstances'] is not None:
-            num_instances = '%-14s: %d\n' % ("# of instances",
-                                             object_dict['qualities']['NumberOfInstances'])
-        num_features = '%-14s: %d\n' % ("# of features", len(object_dict['features']))
-        output_str = name + version + format + date + licence + d_url + w_url + local_file + \
-            pickle_file + num_instances + num_features
-        return(output_str)
+            num_instances = '{:.<14}: {}\n'.format("# of instances",
+                                                   object_dict['qualities']['NumberOfInstances'])
+
+        output_str = '\n' + header + name + version + format + date + licence + d_url + w_url + \
+            local_file + pickle_file + num_features + num_instances + '\n'
+        return output_str
 
     def _data_arff_to_pickle(self, data_file):
         data_pickle_file = data_file.replace('.arff', '.pkl.py3')

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -173,6 +173,28 @@ class OpenMLDataset(object):
         else:
             self.data_pickle_file = None
 
+    def __str__(self):
+        object_dict = self.__dict__
+        output_str = ''
+        name = '\n%14s: %s\n' % ("Name", object_dict['name'])
+        version = '%14s: %s\n' % ("Version", object_dict['version'])
+        format = '%14s: %s\n' % ("Format", object_dict['format'])
+        date = '%14s: %s\n' % ("Upload Date", object_dict['upload_date'].replace('T', ' '))
+        licence = '%14s: %s\n' % ("Licence", object_dict['licence'])
+        d_url = '%14s: %s\n' % ("Download URL", object_dict['url'])
+        base_url = 'https://www.openml.org/d/'
+        w_url = '%14s: %s\n' % ("OpenML URL", base_url + str(self.dataset_id))
+        local_file = '%14s: %s\n' % ("Data file", object_dict['data_file'])
+        pickle_file = '%14s: %s\n' % ("Pickle file", object_dict['data_pickle_file'])
+        num_instances = ''
+        if object_dict['qualities']['NumberOfInstances'] is not None:
+            num_instances = '%14s: %d\n' % ("# of instances",
+                                            object_dict['qualities']['NumberOfInstances'])
+        num_features = '%14s: %d\n' % ("# of features", len(object_dict['features']))
+        output_str = name + version + format + date + licence + d_url + w_url + local_file + \
+            pickle_file + num_instances + num_features
+        return(output_str)
+
     def _data_arff_to_pickle(self, data_file):
         data_pickle_file = data_file.replace('.arff', '.pkl.py3')
         if os.path.exists(data_pickle_file):

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -1,3 +1,6 @@
+import openml.config
+import pandas as pd
+
 
 class OpenMLEvaluation(object):
     """
@@ -49,35 +52,30 @@ class OpenMLEvaluation(object):
         self.array_data = array_data
 
     def __str__(self):
-        object_dict = self.__dict__
-        output_str = ''
         header = "OpenML Evaluation"
         header = '{}\n{}\n'.format(header, '=' * len(header))
-        base_url = 'https://www.openml.org/'
-        upload = '{:.<14}: {}\n'.format('Upload Date', object_dict['upload_time'])
-        run = '{:.<14}: {}\n'.format('Run ID', object_dict['run_id'])
-        run = run + '{:.<14}: {}\n'.format('OpenML Run URL',
-                                           base_url + 'r/' + str(object_dict['run_id']))
 
-        task = '{:.<14}: {}\n'.format('Task ID', object_dict['task_id'])
-        task = task + '{:.<14}: {}\n'.format('OpenML Task URL',
-                                             base_url + 't/' + str(object_dict['task_id']))
+        base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
+        fields = pd.Series({"Upload Date": self.upload_time,
+                            "Run ID": self.run_id,
+                            "OpenML Run URL": "{}r/{}".format(base_url, self.run_id),
+                            "Task ID": self.task_id,
+                            "OpenML Task URL": "{}t/{}".format(base_url, self.task_id),
+                            "Flow ID": self.flow_id,
+                            "OpenML Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                            "Setup ID": self.setup_id,
+                            "Data ID": self.data_id,
+                            "Data Name": self.data_name,
+                            "OpenML Data URL": "{}d/{}".format(base_url, self.data_id),
+                            "Metric Used": self.function,
+                            "Result": self.value})
 
-        flow = '{:.<14}: {}\n'.format('Flow ID', object_dict['flow_id'])
-        flow = flow + '{:.<14}: {}\n'.format('Flow Name', object_dict['flow_name'])
-        flow = flow + '{:.<14}: {}\n'.format('OpenML Flow URL',
-                                             base_url + 'f/' + str(object_dict['flow_id']))
+        order = ["Uploader Date", "Run ID", "OpenML Run URL", "Task ID", "OpenML Task URL"
+                 "Flow ID", "OpenML Flow URL", "Setup ID", "Data ID", "Data Name",
+                 "OpenML Data URL", "Metric Used", "Result"]
+        fields = list(fields.reindex(order).dropna().iteritems())
 
-        setup = '{:.<14}: {}\n'.format('Setup ID', object_dict['setup_id'])
-
-        data = '{:.<14}: {}\n'.format('Data ID', int(object_dict['data_id']))
-        data = data + '{:.<14}: {}\n'.format('Data Name', object_dict['data_name'])
-        data = data + '{:.<14}: {}\n'.format('OpenML Data URL',
-                                             base_url + 'd/' + str(object_dict['data_id']))
-
-        metric = '{:.<14}: {}\n'.format('Metric Used', object_dict['function'])
-        value = '{:.<14}: {}\n'.format('Result', object_dict['value'])
-
-        output_str = '\n' + header + upload + run + task + flow + setup + data + metric + \
-            value + '\n'
-        return output_str
+        longest_field_name_length = max(len(name) for name, value in fields)
+        field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)
+        body = '\n'.join(field_line_format.format(name, value) for name, value in fields)
+        return header + body

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -52,28 +52,28 @@ class OpenMLEvaluation(object):
         object_dict = self.__dict__
         output_str = ''
         base_url = 'https://www.openml.org/'
-        upload = '\n%15s: %s\n\n' % ('Upload Date', object_dict['upload_time'])
-        run = '%15s: %d\n' % ('Run ID', object_dict['run_id'])
-        run = run + '%15s: %s\n\n' % ('OpenML Run URL',
+        upload = '\n%-15s: %s\n\n' % ('Upload Date', object_dict['upload_time'])
+        run = '%-15s: %d\n' % ('Run ID', object_dict['run_id'])
+        run = run + '%-15s: %s\n\n' % ('OpenML Run URL',
                                       base_url + 'r/' + str(object_dict['run_id']))
 
-        task = '%15s: %d\n' % ('Task ID', object_dict['task_id'])
-        task = task + '%15s: %s\n\n' % ('OpenML Task URL',
+        task = '%-15s: %d\n' % ('Task ID', object_dict['task_id'])
+        task = task + '%-15s: %s\n\n' % ('OpenML Task URL',
                                         base_url + 't/' + str(object_dict['task_id']))
 
-        flow = '%15s: %d\n' % ('Flow ID', object_dict['flow_id'])
-        flow = flow + '%15s: %s\n' % ('Flow Name', object_dict['flow_name'])
-        flow = flow + '%15s: %s\n\n' % ('OpenML Flow URL',
+        flow = '%-15s: %d\n' % ('Flow ID', object_dict['flow_id'])
+        flow = flow + '%-15s: %s\n' % ('Flow Name', object_dict['flow_name'])
+        flow = flow + '%-15s: %s\n\n' % ('OpenML Flow URL',
                                         base_url + 'f/' + str(object_dict['flow_id']))
 
-        setup = '%15s: %d\n\n' % ('Setup ID', object_dict['setup_id'])
+        setup = '%-15s: %d\n\n' % ('Setup ID', object_dict['setup_id'])
 
-        data = '%15s: %d\n' % ('Data ID', int(object_dict['data_id']))
-        data = data + '%15s: %s\n' % ('Data Name', object_dict['data_name'])
-        data = data + '%15s: %s\n\n' % ('OpenML Data URL',
+        data = '%-15s: %d\n' % ('Data ID', int(object_dict['data_id']))
+        data = data + '%-15s: %s\n' % ('Data Name', object_dict['data_name'])
+        data = data + '%-15s: %s\n\n' % ('OpenML Data URL',
                                         base_url + 'd/' + str(object_dict['data_id']))
 
-        metric = '%15s: %s\n' % ('Metric Used', object_dict['function'])
-        value = '%15s: %f\n' % ('Result', object_dict['value'])
+        metric = '%-15s: %s\n' % ('Metric Used', object_dict['function'])
+        value = '%-15s: %f\n' % ('Result', object_dict['value'])
         output_str = upload + run + task + flow + setup + data + metric + value
         return output_str

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -1,5 +1,4 @@
 import openml.config
-import pandas as pd
 
 
 class OpenMLEvaluation(object):

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -47,3 +47,28 @@ class OpenMLEvaluation(object):
         self.value = value
         self.values = values
         self.array_data = array_data
+
+    def __str__(self):
+        object_dict = self.__dict__
+        output_str = ''
+        base_url = 'https://www.openml.org/'
+        upload = '\n%15s: %s\n\n' % ('Upload Time', object_dict['upload_time'])
+        run = '%15s: %d\n' % ('Run ID', object_dict['run_id'])
+        run = run + '%15s: %s\n\n' % ('OpenML Run URL',
+                                    base_url + 'r/' + str(object_dict['run_id']))
+        task = '%15s: %d\n' % ('Task ID', object_dict['task_id'])
+        task = task + '%15s: %s\n\n' % ('OpenML Task URL',
+                                    base_url + 't/' + str(object_dict['task_id']))
+        flow = '%15s: %d\n' % ('Flow ID', object_dict['flow_id'])
+        flow = flow + '%15s: %s\n' % ('Flow Name', object_dict['flow_name'])
+        flow = flow + '%15s: %s\n\n' % ('OpenML Flow URL',
+                                    base_url + 'f/' + str(object_dict['flow_id']))
+        setup = '%15s: %d\n\n' % ('Setup ID', object_dict['setup_id'])
+        data = '%15s: %d\n' % ('Data ID', int(object_dict['data_id']))
+        data = data + '%15s: %s\n' % ('Data Name', object_dict['data_name'])
+        data = data + '%15s: %s\n\n' % ('OpenML Data URL',
+                                    base_url + 'd/' + str(object_dict['data_id']))
+        metric = '%15s: %s\n' % ('Metric Used', object_dict['function'])
+        value = '%15s: %f\n' % ('Result', object_dict['value'])
+
+        return upload + run + task + flow + setup + data + metric + value

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -55,23 +55,23 @@ class OpenMLEvaluation(object):
         upload = '\n%-15s: %s\n\n' % ('Upload Date', object_dict['upload_time'])
         run = '%-15s: %d\n' % ('Run ID', object_dict['run_id'])
         run = run + '%-15s: %s\n\n' % ('OpenML Run URL',
-                                      base_url + 'r/' + str(object_dict['run_id']))
+                                       base_url + 'r/' + str(object_dict['run_id']))
 
         task = '%-15s: %d\n' % ('Task ID', object_dict['task_id'])
         task = task + '%-15s: %s\n\n' % ('OpenML Task URL',
-                                        base_url + 't/' + str(object_dict['task_id']))
+                                         base_url + 't/' + str(object_dict['task_id']))
 
         flow = '%-15s: %d\n' % ('Flow ID', object_dict['flow_id'])
         flow = flow + '%-15s: %s\n' % ('Flow Name', object_dict['flow_name'])
         flow = flow + '%-15s: %s\n\n' % ('OpenML Flow URL',
-                                        base_url + 'f/' + str(object_dict['flow_id']))
+                                         base_url + 'f/' + str(object_dict['flow_id']))
 
         setup = '%-15s: %d\n\n' % ('Setup ID', object_dict['setup_id'])
 
         data = '%-15s: %d\n' % ('Data ID', int(object_dict['data_id']))
         data = data + '%-15s: %s\n' % ('Data Name', object_dict['data_name'])
         data = data + '%-15s: %s\n\n' % ('OpenML Data URL',
-                                        base_url + 'd/' + str(object_dict['data_id']))
+                                         base_url + 'd/' + str(object_dict['data_id']))
 
         metric = '%-15s: %s\n' % ('Metric Used', object_dict['function'])
         value = '%-15s: %f\n' % ('Result', object_dict['value'])

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -52,23 +52,23 @@ class OpenMLEvaluation(object):
         object_dict = self.__dict__
         output_str = ''
         base_url = 'https://www.openml.org/'
-        upload = '\n%15s: %s\n\n' % ('Upload Time', object_dict['upload_time'])
+        upload = '\n%15s: %s\n\n' % ('Upload Date', object_dict['upload_time'])
         run = '%15s: %d\n' % ('Run ID', object_dict['run_id'])
         run = run + '%15s: %s\n\n' % ('OpenML Run URL',
-                                    base_url + 'r/' + str(object_dict['run_id']))
+                                      base_url + 'r/' + str(object_dict['run_id']))
         task = '%15s: %d\n' % ('Task ID', object_dict['task_id'])
         task = task + '%15s: %s\n\n' % ('OpenML Task URL',
-                                    base_url + 't/' + str(object_dict['task_id']))
+                                        base_url + 't/' + str(object_dict['task_id']))
         flow = '%15s: %d\n' % ('Flow ID', object_dict['flow_id'])
         flow = flow + '%15s: %s\n' % ('Flow Name', object_dict['flow_name'])
         flow = flow + '%15s: %s\n\n' % ('OpenML Flow URL',
-                                    base_url + 'f/' + str(object_dict['flow_id']))
+                                        base_url + 'f/' + str(object_dict['flow_id']))
         setup = '%15s: %d\n\n' % ('Setup ID', object_dict['setup_id'])
         data = '%15s: %d\n' % ('Data ID', int(object_dict['data_id']))
         data = data + '%15s: %s\n' % ('Data Name', object_dict['data_name'])
         data = data + '%15s: %s\n\n' % ('OpenML Data URL',
-                                    base_url + 'd/' + str(object_dict['data_id']))
+                                        base_url + 'd/' + str(object_dict['data_id']))
         metric = '%15s: %s\n' % ('Metric Used', object_dict['function'])
         value = '%15s: %f\n' % ('Result', object_dict['value'])
-
-        return upload + run + task + flow + setup + data + metric + value
+        output_str = upload + run + task + flow + setup + data + metric + value
+        return output_str

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -72,7 +72,7 @@ class OpenMLEvaluation(object):
         data = data + '%15s: %s\n' % ('Data Name', object_dict['data_name'])
         data = data + '%15s: %s\n\n' % ('OpenML Data URL',
                                         base_url + 'd/' + str(object_dict['data_id']))
-                                        
+
         metric = '%15s: %s\n' % ('Metric Used', object_dict['function'])
         value = '%15s: %f\n' % ('Result', object_dict['value'])
         output_str = upload + run + task + flow + setup + data + metric + value

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -56,18 +56,23 @@ class OpenMLEvaluation(object):
         run = '%15s: %d\n' % ('Run ID', object_dict['run_id'])
         run = run + '%15s: %s\n\n' % ('OpenML Run URL',
                                       base_url + 'r/' + str(object_dict['run_id']))
+
         task = '%15s: %d\n' % ('Task ID', object_dict['task_id'])
         task = task + '%15s: %s\n\n' % ('OpenML Task URL',
                                         base_url + 't/' + str(object_dict['task_id']))
+
         flow = '%15s: %d\n' % ('Flow ID', object_dict['flow_id'])
         flow = flow + '%15s: %s\n' % ('Flow Name', object_dict['flow_name'])
         flow = flow + '%15s: %s\n\n' % ('OpenML Flow URL',
                                         base_url + 'f/' + str(object_dict['flow_id']))
+
         setup = '%15s: %d\n\n' % ('Setup ID', object_dict['setup_id'])
+
         data = '%15s: %d\n' % ('Data ID', int(object_dict['data_id']))
         data = data + '%15s: %s\n' % ('Data Name', object_dict['data_name'])
         data = data + '%15s: %s\n\n' % ('OpenML Data URL',
                                         base_url + 'd/' + str(object_dict['data_id']))
+                                        
         metric = '%15s: %s\n' % ('Metric Used', object_dict['function'])
         value = '%15s: %f\n' % ('Result', object_dict['value'])
         output_str = upload + run + task + flow + setup + data + metric + value

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -51,29 +51,33 @@ class OpenMLEvaluation(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
+        header = "OpenML Evaluation"
+        header = '{}\n{}\n'.format(header, '=' * len(header))
         base_url = 'https://www.openml.org/'
-        upload = '\n%-15s: %s\n\n' % ('Upload Date', object_dict['upload_time'])
-        run = '%-15s: %d\n' % ('Run ID', object_dict['run_id'])
-        run = run + '%-15s: %s\n\n' % ('OpenML Run URL',
-                                       base_url + 'r/' + str(object_dict['run_id']))
+        upload = '{:.<14}: {}\n'.format('Upload Date', object_dict['upload_time'])
+        run = '{:.<14}: {}\n'.format('Run ID', object_dict['run_id'])
+        run = run + '{:.<14}: {}\n'.format('OpenML Run URL',
+                                           base_url + 'r/' + str(object_dict['run_id']))
 
-        task = '%-15s: %d\n' % ('Task ID', object_dict['task_id'])
-        task = task + '%-15s: %s\n\n' % ('OpenML Task URL',
-                                         base_url + 't/' + str(object_dict['task_id']))
+        task = '{:.<14}: {}\n'.format('Task ID', object_dict['task_id'])
+        task = task + '{:.<14}: {}\n'.format('OpenML Task URL',
+                                             base_url + 't/' + str(object_dict['task_id']))
 
-        flow = '%-15s: %d\n' % ('Flow ID', object_dict['flow_id'])
-        flow = flow + '%-15s: %s\n' % ('Flow Name', object_dict['flow_name'])
-        flow = flow + '%-15s: %s\n\n' % ('OpenML Flow URL',
-                                         base_url + 'f/' + str(object_dict['flow_id']))
+        flow = '{:.<14}: {}\n'.format('Flow ID', object_dict['flow_id'])
+        flow = flow + '{:.<14}: {}\n'.format('Flow Name', object_dict['flow_name'])
+        flow = flow + '{:.<14}: {}\n'.format('OpenML Flow URL',
+                                             base_url + 'f/' + str(object_dict['flow_id']))
 
-        setup = '%-15s: %d\n\n' % ('Setup ID', object_dict['setup_id'])
+        setup = '{:.<14}: {}\n'.format('Setup ID', object_dict['setup_id'])
 
-        data = '%-15s: %d\n' % ('Data ID', int(object_dict['data_id']))
-        data = data + '%-15s: %s\n' % ('Data Name', object_dict['data_name'])
-        data = data + '%-15s: %s\n\n' % ('OpenML Data URL',
-                                         base_url + 'd/' + str(object_dict['data_id']))
+        data = '{:.<14}: {}\n'.format('Data ID', int(object_dict['data_id']))
+        data = data + '{:.<14}: {}\n'.format('Data Name', object_dict['data_name'])
+        data = data + '{:.<14}: {}\n'.format('OpenML Data URL',
+                                             base_url + 'd/' + str(object_dict['data_id']))
 
-        metric = '%-15s: %s\n' % ('Metric Used', object_dict['function'])
-        value = '%-15s: %f\n' % ('Result', object_dict['value'])
-        output_str = upload + run + task + flow + setup + data + metric + value
+        metric = '{:.<14}: {}\n'.format('Metric Used', object_dict['function'])
+        value = '{:.<14}: {}\n'.format('Result', object_dict['value'])
+
+        output_str = '\n' + header + upload + run + task + flow + setup + data + metric + \
+            value + '\n'
         return output_str

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -56,24 +56,24 @@ class OpenMLEvaluation(object):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"Upload Date": self.upload_time,
-                            "Run ID": self.run_id,
-                            "OpenML Run URL": "{}r/{}".format(base_url, self.run_id),
-                            "Task ID": self.task_id,
-                            "OpenML Task URL": "{}t/{}".format(base_url, self.task_id),
-                            "Flow ID": self.flow_id,
-                            "OpenML Flow URL": "{}f/{}".format(base_url, self.flow_id),
-                            "Setup ID": self.setup_id,
-                            "Data ID": self.data_id,
-                            "Data Name": self.data_name,
-                            "OpenML Data URL": "{}d/{}".format(base_url, self.data_id),
-                            "Metric Used": self.function,
-                            "Result": self.value})
+        fields = {"Upload Date": self.upload_time,
+                  "Run ID": self.run_id,
+                  "OpenML Run URL": "{}r/{}".format(base_url, self.run_id),
+                  "Task ID": self.task_id,
+                  "OpenML Task URL": "{}t/{}".format(base_url, self.task_id),
+                  "Flow ID": self.flow_id,
+                  "OpenML Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "Setup ID": self.setup_id,
+                  "Data ID": self.data_id,
+                  "Data Name": self.data_name,
+                  "OpenML Data URL": "{}d/{}".format(base_url, self.data_id),
+                  "Metric Used": self.function,
+                  "Result": self.value}
 
         order = ["Uploader Date", "Run ID", "OpenML Run URL", "Task ID", "OpenML Task URL"
                  "Flow ID", "OpenML Flow URL", "Setup ID", "Data ID", "Data Name",
                  "OpenML Data URL", "Metric Used", "Result"]
-        fields = list(fields.reindex(order).dropna().iteritems())
+        fields = [(key, fields[key]) for key in order if key in fields]
 
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -8,7 +8,6 @@ from ..extensions import get_extension_by_flow
 from ..utils import extract_xml_tags, _tag_entity
 
 import openml.config
-import pandas as pd
 
 
 class OpenMLFlow(object):
@@ -140,12 +139,17 @@ class OpenMLFlow(object):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = {"Flow ID": "{} (version {})".format(self.flow_id, self.version),
-                  "Flow URL": "{}f/{}".format(base_url, self.flow_id),
-                  "Flow Name": self.name,
+        fields = {"Flow Name": self.name,
                   "Flow Description": self.description,
-                  "Upload Date": self.upload_date.replace('T', ' '),
                   "Dependencies": self.dependencies}
+        if self.flow_id is not None:
+            if self.version is not None:
+                fields["Flow ID"] = "{} (version {})".format(self.flow_id, self.version)
+            else:
+                fields["Flow ID"] = self.flow_id
+            fields["Flow URL"] = "{}f/{}".format(base_url, self.flow_id)
+        if self.upload_date is not None:
+            fields["Upload Date"] = self.upload_date.replace('T', ' ')
         if self.binary_url is not None:
             fields["Binary URL"] = self.binary_url
 

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -135,19 +135,19 @@ class OpenMLFlow(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        id = '\n%16s: %s\n' % ('Flow ID', object_dict['flow_id'])
-        version = '%16s: %s\n' % ('Flow Version', object_dict['version'])
-        url = '%16s: %s\n' % ('Flow URL', 'https://www.openml.org/f/' + str(object_dict['flow_id']))
-        name = '%16s: %s\n' % ('Flow Name', object_dict['name'])
-        description = '%16s: %s\n\n' % ('Flow Description', object_dict['description'])
+        id = '\n%-16s: %s\n' % ('Flow ID', object_dict['flow_id'])
+        version = '%-16s: %s\n' % ('Flow Version', object_dict['version'])
+        url = '%-16s: %s\n' % ('Flow URL', 'https://www.openml.org/f/' + str(object_dict['flow_id']))
+        name = '%-16s: %s\n' % ('Flow Name', object_dict['name'])
+        description = '%-16s: %s\n\n' % ('Flow Description', object_dict['description'])
 
         binary = ''
         if object_dict['binary_url'] is not None:
-            binary = '%16s: %s\n\n' % ('Binary URL', object_dict['binary_url'])
+            binary = '%-16s: %s\n\n' % ('Binary URL', object_dict['binary_url'])
 
-        upload = '%16s: %s\n' % ('Upload Date', object_dict['upload_date'].replace('T', ' '))
-        language = '%16s: %s\n' % ('Language', object_dict['language'])
-        dependencies = '%16s: %s\n' % ('Dependencies', object_dict['dependencies'])
+        upload = '%-16s: %s\n' % ('Upload Date', object_dict['upload_date'].replace('T', ' '))
+        language = '%-16s: %s\n' % ('Language', object_dict['language'])
+        dependencies = '%-16s: %s\n' % ('Dependencies', object_dict['dependencies'])
         # 3740 for example
         output_str = id + version + url + name + description + binary + upload + \
             language + dependencies

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -132,6 +132,25 @@ class OpenMLFlow(object):
 
         self.extension = get_extension_by_flow(self)
 
+    def __str__(self):
+        object_dict = self.__dict__
+        output_str = ''
+        id = '\n%16s: %s\n' % ('Flow ID', object_dict['flow_id'])
+        version = '%16s: %s\n' % ('Flow Version', object_dict['version'])
+        url = '%16s: %s\n' % ('Flow URL', 'https://www.openml.org/f/' + str(object_dict['flow_id']))
+        name = '%16s: %s\n' % ('Flow Name', object_dict['name'])
+        description = '%16s: %s\n\n' % ('Flow Description', object_dict['description'])
+        binary = ''
+        if object_dict['binary_url'] is not None:
+            binary = '%16s: %s\n\n' % ('Binary URL', object_dict['binary_url'])
+        upload = '%16s: %s\n' % ('Upload Date', object_dict['upload_date'].replace('T', ' '))
+        language = '%16s: %s\n' % ('Language', object_dict['language'])
+        dependencies = '%16s: %s\n' % ('Dependencies', object_dict['dependencies'])
+        # 3740 for example
+        output_str = id + version + url + name + description + binary + upload + \
+            language + dependencies
+        return output_str
+
     def _to_xml(self) -> str:
         """Generate xml representation of self for upload to server.
 

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -137,7 +137,8 @@ class OpenMLFlow(object):
         output_str = ''
         id = '\n%-16s: %s\n' % ('Flow ID', object_dict['flow_id'])
         version = '%-16s: %s\n' % ('Flow Version', object_dict['version'])
-        url = '%-16s: %s\n' % ('Flow URL', 'https://www.openml.org/f/' + str(object_dict['flow_id']))
+        url = '%-16s: %s\n' % ('Flow URL',
+                               'https://www.openml.org/f/' + str(object_dict['flow_id']))
         name = '%-16s: %s\n' % ('Flow Name', object_dict['name'])
         description = '%-16s: %s\n\n' % ('Flow Description', object_dict['description'])
 

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -135,23 +135,24 @@ class OpenMLFlow(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        id = '\n%-16s: %s\n' % ('Flow ID', object_dict['flow_id'])
-        version = '%-16s: %s\n' % ('Flow Version', object_dict['version'])
-        url = '%-16s: %s\n' % ('Flow URL',
-                               'https://www.openml.org/f/' + str(object_dict['flow_id']))
-        name = '%-16s: %s\n' % ('Flow Name', object_dict['name'])
-        description = '%-16s: %s\n\n' % ('Flow Description', object_dict['description'])
+        header = "OpenML Flow"
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        id_version = '{:.<16}: {} (Version: {})\n'.format('Flow ID', object_dict['flow_id'],
+                                                          object_dict['version'])
+        url = '{:.<16}: {}\n'.format('Flow URL',
+                                     'https://www.openml.org/f/' + str(object_dict['flow_id']))
+        name = '{:.<16}: {}\n'.format('Flow Name', object_dict['name'])
+        description = '{:.<16}: {}\n'.format('Flow Description', object_dict['description'])
 
         binary = ''
         if object_dict['binary_url'] is not None:
-            binary = '%-16s: %s\n\n' % ('Binary URL', object_dict['binary_url'])
+            binary = '{:.<16}: {}\n'.format('Binary URL', object_dict['binary_url'])
 
-        upload = '%-16s: %s\n' % ('Upload Date', object_dict['upload_date'].replace('T', ' '))
-        language = '%-16s: %s\n' % ('Language', object_dict['language'])
-        dependencies = '%-16s: %s\n' % ('Dependencies', object_dict['dependencies'])
+        upload = '{:.<16}: {}\n'.format('Upload Date', object_dict['upload_date'].replace('T', ' '))
+        dependencies = '{:.<16}: {}\n'.format('Dependencies', object_dict['dependencies'])
         # 3740 for example
-        output_str = id + version + url + name + description + binary + upload + \
-            language + dependencies
+        output_str = '\n' + header + id_version + url + name + description + binary + \
+            upload + dependencies + '\n'
         return output_str
 
     def _to_xml(self) -> str:

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -140,18 +140,19 @@ class OpenMLFlow(object):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"Flow ID": "{} (version {})".format(self.flow_id, self.version),
-                            "Flow URL": "{}f/{}".format(base_url, self.flow_id),
-                            "Flow Name": self.name,
-                            "Flow Description": self.description,
-                            "Upload Date": self.upload_date.replace('T', ' '),
-                            "Dependencies": self.dependencies})
+        fields = {"Flow ID": "{} (version {})".format(self.flow_id, self.version),
+                  "Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "Flow Name": self.name,
+                  "Flow Description": self.description,
+                  "Upload Date": self.upload_date.replace('T', ' '),
+                  "Dependencies": self.dependencies}
         if self.binary_url is not None:
-            fields = fields.append(pd.Series({"Binary URL": self.binary_url}))
+            fields["Binary URL"] = self.binary_url
 
+        # determines the order in which the information will be printed
         order = ["Flow ID", "Flow URL", "Flow Name", "Flow Description", "Binary URL",
                  "Upload Date", "Dependencies"]
-        fields = list(fields.reindex(order).dropna().iteritems())
+        fields = [(key, fields[key]) for key in order if key in fields]
 
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -140,9 +140,11 @@ class OpenMLFlow(object):
         url = '%16s: %s\n' % ('Flow URL', 'https://www.openml.org/f/' + str(object_dict['flow_id']))
         name = '%16s: %s\n' % ('Flow Name', object_dict['name'])
         description = '%16s: %s\n\n' % ('Flow Description', object_dict['description'])
+
         binary = ''
         if object_dict['binary_url'] is not None:
             binary = '%16s: %s\n\n' % ('Binary URL', object_dict['binary_url'])
+            
         upload = '%16s: %s\n' % ('Upload Date', object_dict['upload_date'].replace('T', ' '))
         language = '%16s: %s\n' % ('Language', object_dict['language'])
         dependencies = '%16s: %s\n' % ('Dependencies', object_dict['dependencies'])

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -144,7 +144,7 @@ class OpenMLFlow(object):
         binary = ''
         if object_dict['binary_url'] is not None:
             binary = '%16s: %s\n\n' % ('Binary URL', object_dict['binary_url'])
-            
+
         upload = '%16s: %s\n' % ('Upload Date', object_dict['upload_date'].replace('T', ' '))
         language = '%16s: %s\n' % ('Language', object_dict['language'])
         dependencies = '%16s: %s\n' % ('Dependencies', object_dict['dependencies'])

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -64,12 +64,40 @@ class OpenMLRun(object):
         self.predictions_url = predictions_url
 
     def __str__(self):
-        flow_name = self.flow_name
-        if flow_name is not None and len(flow_name) > 26:
-            # long enough to show sklearn.pipeline.Pipeline
-            flow_name = flow_name[:26] + "..."
-        return "[run id: {}, task id: {}, flow id: {}, flow name: {}]".format(
-            self.run_id, self.task_id, self.flow_id, flow_name)
+        object_dict = self.__dict__
+        output_str = ''
+        uploader = '\n%16s: %s\n' % ('Uploader Name', object_dict['uploader_name'])
+        url = 'https://www.openml.org/u/' + str(object_dict['uploader'])
+        uploader = uploader + '%16s: %s\n\n' % ('Uploader Profile', url)
+
+        metric = '%16s: %s\n' % ('Metric', object_dict['task_evaluation_measure'])
+        result = ''
+        if object_dict['task_evaluation_measure'] in object_dict['evaluations']:
+            value = object_dict['evaluations'][object_dict['task_evaluation_measure']]
+            result = '%16s: %s\n' % ('Result', value)
+        run = '%16s: %s\n' % ('Run ID', object_dict['run_id'])
+        url = 'https://www.openml.org/r/' + str(object_dict['run_id'])
+        run = run + '%16s: %s\n\n' % ('Run URL', url)
+
+        task = '%16s: %s\n' % ('Task ID', object_dict['task_id'])
+        task = task + '%16s: %s\n' % ('Task Type', object_dict['task_type'])
+        url = 'https://www.openml.org/t/' + str(object_dict['task_id'])
+        task = task + '%16s: %s\n\n' % ('Task URL', url)
+
+        flow = '%16s: %s\n' % ('Flow ID', object_dict['flow_id'])
+        flow = flow + '%16s: %s\n' % ('Flow Name', object_dict['flow_name'])
+        url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
+        flow = flow + '%16s: %s\n\n' % ('Flow URL', url)
+
+        setup = '%16s: %s\n' % ('Setup ID', object_dict['setup_id'])
+        setup = setup + '%16s: %s\n\n' % ('Setup String', object_dict['setup_string'])
+
+        dataset = '%16s: %s\n' % ('Dataset ID', object_dict['dataset_id'])
+        url = 'https://www.openml.org/d/' + str(object_dict['dataset_id'])
+        dataset = dataset + '%16s: %s\n' % ('Dataset URL', url)
+
+        output_str = uploader + metric + result + run + task + flow + setup + dataset
+        return output_str
 
     def _repr_pretty_(self, pp, cycle):
         pp.text(str(self))

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -66,35 +66,35 @@ class OpenMLRun(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        uploader = '\n%16s: %s\n' % ('Uploader Name', object_dict['uploader_name'])
+        uploader = '\n%-16s: %s\n' % ('Uploader Name', object_dict['uploader_name'])
         url = 'https://www.openml.org/u/' + str(object_dict['uploader'])
-        uploader = uploader + '%16s: %s\n\n' % ('Uploader Profile', url)
+        uploader = uploader + '%-16s: %s\n\n' % ('Uploader Profile', url)
 
-        metric = '%16s: %s\n' % ('Metric', object_dict['task_evaluation_measure'])
+        metric = '%-16s: %s\n' % ('Metric', object_dict['task_evaluation_measure'])
         result = ''
         if object_dict['task_evaluation_measure'] in object_dict['evaluations']:
             value = object_dict['evaluations'][object_dict['task_evaluation_measure']]
-            result = '%16s: %s\n' % ('Result', value)
-        run = '%16s: %s\n' % ('Run ID', object_dict['run_id'])
+            result = '%-16s: %s\n' % ('Result', value)
+        run = '%-16s: %s\n' % ('Run ID', object_dict['run_id'])
         url = 'https://www.openml.org/r/' + str(object_dict['run_id'])
-        run = run + '%16s: %s\n\n' % ('Run URL', url)
+        run = run + '%-16s: %s\n\n' % ('Run URL', url)
 
-        task = '%16s: %s\n' % ('Task ID', object_dict['task_id'])
-        task = task + '%16s: %s\n' % ('Task Type', object_dict['task_type'])
+        task = '%-16s: %s\n' % ('Task ID', object_dict['task_id'])
+        task = task + '%-16s: %s\n' % ('Task Type', object_dict['task_type'])
         url = 'https://www.openml.org/t/' + str(object_dict['task_id'])
-        task = task + '%16s: %s\n\n' % ('Task URL', url)
+        task = task + '%-16s: %s\n\n' % ('Task URL', url)
 
-        flow = '%16s: %s\n' % ('Flow ID', object_dict['flow_id'])
-        flow = flow + '%16s: %s\n' % ('Flow Name', object_dict['flow_name'])
+        flow = '%-16s: %s\n' % ('Flow ID', object_dict['flow_id'])
+        flow = flow + '%-16s: %s\n' % ('Flow Name', object_dict['flow_name'])
         url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
-        flow = flow + '%16s: %s\n\n' % ('Flow URL', url)
+        flow = flow + '%-16s: %s\n\n' % ('Flow URL', url)
 
-        setup = '%16s: %s\n' % ('Setup ID', object_dict['setup_id'])
-        setup = setup + '%16s: %s\n\n' % ('Setup String', object_dict['setup_string'])
+        setup = '%-16s: %s\n' % ('Setup ID', object_dict['setup_id'])
+        setup = setup + '%-16s: %s\n\n' % ('Setup String', object_dict['setup_string'])
 
-        dataset = '%16s: %s\n' % ('Dataset ID', object_dict['dataset_id'])
+        dataset = '%-16s: %s\n' % ('Dataset ID', object_dict['dataset_id'])
         url = 'https://www.openml.org/d/' + str(object_dict['dataset_id'])
-        dataset = dataset + '%16s: %s\n' % ('Dataset URL', url)
+        dataset = dataset + '%-16s: %s\n' % ('Dataset URL', url)
 
         output_str = uploader + metric + result + run + task + flow + setup + dataset
         return output_str

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -7,7 +7,6 @@ import os
 import arff
 import numpy as np
 import xmltodict
-import pandas as pd
 
 import openml
 import openml._api_calls
@@ -70,13 +69,11 @@ class OpenMLRun(object):
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
         fields = {"Uploader Name": self.uploader_name,
-                  "Uploader Profile": "{}u/{}".format(base_url, self.uploader),
                   "Metric": self.task_evaluation_measure,
                   "Run ID": self.run_id,
-                  "Run URL": "{}r/{}".format(base_url, self.run_id),
                   "Task ID": self.task_id,
                   "Task Type": self.task_type,
-                  "Task URL": "{}t/{}".format(base_url, self.run_id),
+                  "Task URL": "{}t/{}".format(base_url, self.task_id),
                   "Flow ID": self.flow_id,
                   "Flow Name": self.flow_name,
                   "Flow URL": "{}f/{}".format(base_url, self.flow_id),
@@ -84,6 +81,10 @@ class OpenMLRun(object):
                   "Setup String": self.setup_string,
                   "Dataset ID": self.dataset_id,
                   "Dataset URL": "{}d/{}".format(base_url, self.dataset_id)}
+        if self.uploader is not None:
+            fields["Uploader Profile"] = "{}u/{}".format(base_url, self.uploader)
+        if self.run_id is not None:
+            fields["Run URL"] = "{}r/{}".format(base_url, self.run_id)
         if self.task_evaluation_measure in self.evaluations:
             fields["Result"] = self.evaluations[self.task_evaluation_measure]
 

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -66,37 +66,40 @@ class OpenMLRun(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        uploader = '\n%-16s: %s\n' % ('Uploader Name', object_dict['uploader_name'])
+        header = 'OpenML Run'
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        uploader = '{:.<16}: {}\n'.format('Uploader Name', object_dict['uploader_name'])
         url = 'https://www.openml.org/u/' + str(object_dict['uploader'])
-        uploader = uploader + '%-16s: %s\n\n' % ('Uploader Profile', url)
+        uploader = uploader + '{:.<16}: {}\n'.format('Uploader Profile', url)
 
-        metric = '%-16s: %s\n' % ('Metric', object_dict['task_evaluation_measure'])
+        metric = '{:.<16}: {}\n'.format('Metric', object_dict['task_evaluation_measure'])
         result = ''
         if object_dict['task_evaluation_measure'] in object_dict['evaluations']:
             value = object_dict['evaluations'][object_dict['task_evaluation_measure']]
-            result = '%-16s: %s\n' % ('Result', value)
-        run = '%-16s: %s\n' % ('Run ID', object_dict['run_id'])
+            result = '{:.<16}: {}\n'.format('Result', value)
+        run = '{:.<16}: {}\n'.format('Run ID', object_dict['run_id'])
         url = 'https://www.openml.org/r/' + str(object_dict['run_id'])
-        run = run + '%-16s: %s\n\n' % ('Run URL', url)
+        run = run + '{:.<16}: {}\n'.format('Run URL', url)
 
-        task = '%-16s: %s\n' % ('Task ID', object_dict['task_id'])
-        task = task + '%-16s: %s\n' % ('Task Type', object_dict['task_type'])
+        task = '{:.<16}: {}\n'.format('Task ID', object_dict['task_id'])
+        task = task + '{:.<16}: {}\n'.format('Task Type', object_dict['task_type'])
         url = 'https://www.openml.org/t/' + str(object_dict['task_id'])
-        task = task + '%-16s: %s\n\n' % ('Task URL', url)
+        task = task + '{:.<16}: {}\n'.format('Task URL', url)
 
-        flow = '%-16s: %s\n' % ('Flow ID', object_dict['flow_id'])
-        flow = flow + '%-16s: %s\n' % ('Flow Name', object_dict['flow_name'])
+        flow = '{:.<16}: {}\n'.format('Flow ID', object_dict['flow_id'])
+        flow = flow + '{:.<16}: {}\n'.format('Flow Name', object_dict['flow_name'])
         url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
-        flow = flow + '%-16s: %s\n\n' % ('Flow URL', url)
+        flow = flow + '{:.<16}: {}\n'.format('Flow URL', url)
 
-        setup = '%-16s: %s\n' % ('Setup ID', object_dict['setup_id'])
-        setup = setup + '%-16s: %s\n\n' % ('Setup String', object_dict['setup_string'])
+        setup = '{:.<16}: {}\n'.format('Setup ID', object_dict['setup_id'])
+        setup = setup + '{:.<16}: {}\n'.format('Setup String', object_dict['setup_string'])
 
-        dataset = '%-16s: %s\n' % ('Dataset ID', object_dict['dataset_id'])
+        dataset = '{:.<16}: {}\n'.format('Dataset ID', object_dict['dataset_id'])
         url = 'https://www.openml.org/d/' + str(object_dict['dataset_id'])
-        dataset = dataset + '%-16s: %s\n' % ('Dataset URL', url)
+        dataset = dataset + '{:.<16}: {}\n'.format('Dataset URL', url)
 
-        output_str = uploader + metric + result + run + task + flow + setup + dataset
+        output_str = '\n' + header + uploader + metric + result + run + task + flow + setup + \
+            dataset + '\n'
         return output_str
 
     def _repr_pretty_(self, pp, cycle):

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -69,29 +69,29 @@ class OpenMLRun(object):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"Uploader Name": self.uploader_name,
-                            "Uploader Profile": "{}u/{}".format(base_url, self.uploader),
-                            "Metric": self.task_evaluation_measure,
-                            "Run ID": self.run_id,
-                            "Run URL": "{}r/{}".format(base_url, self.run_id),
-                            "Task ID": self.task_id,
-                            "Task Type": self.task_type,
-                            "Task URL": "{}t/{}".format(base_url, self.run_id),
-                            "Flow ID": self.flow_id,
-                            "Flow Name": self.flow_name,
-                            "Flow URL": "{}f/{}".format(base_url, self.flow_id),
-                            "Setup ID": self.setup_id,
-                            "Setup String": self.setup_string,
-                            "Dataset ID": self.dataset_id,
-                            "Dataset URL": "{}d/{}".format(base_url, self.dataset_id)})
+        fields = {"Uploader Name": self.uploader_name,
+                  "Uploader Profile": "{}u/{}".format(base_url, self.uploader),
+                  "Metric": self.task_evaluation_measure,
+                  "Run ID": self.run_id,
+                  "Run URL": "{}r/{}".format(base_url, self.run_id),
+                  "Task ID": self.task_id,
+                  "Task Type": self.task_type,
+                  "Task URL": "{}t/{}".format(base_url, self.run_id),
+                  "Flow ID": self.flow_id,
+                  "Flow Name": self.flow_name,
+                  "Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "Setup ID": self.setup_id,
+                  "Setup String": self.setup_string,
+                  "Dataset ID": self.dataset_id,
+                  "Dataset URL": "{}d/{}".format(base_url, self.dataset_id)}
         if self.task_evaluation_measure in self.evaluations:
-            value = self.evaluations[self.task_evaluation_measure]
-            fields = fields.append(pd.Series({"Result": value}))
+            fields["Result"] = self.evaluations[self.task_evaluation_measure]
 
+        # determines the order in which the information will be printed
         order = ["Uploader Name", "Uploader Profile", "Metric", "Result", "Run ID", "Run URL",
                  "Task ID", "Task Type", "Task URL", "Flow ID", "Flow Name", "Flow URL",
                  "Setup ID", "Setup String", "Dataset ID", "Dataset URL"]
-        fields = list(fields.reindex(order).dropna().iteritems())
+        fields = [(key, fields[key]) for key in order if key in fields]
 
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)

--- a/openml/setups/setup.py
+++ b/openml/setups/setup.py
@@ -33,12 +33,14 @@ class OpenMLSetup(object):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"Setup ID": self.setup_id,
-                            "Flow ID": self.flow_id,
-                            "Flow URL": "{}f/{}".format(base_url, self.flow_id),
-                            "# of Parameters": len(self.parameters)})
+        fields = {"Setup ID": self.setup_id,
+                  "Flow ID": self.flow_id,
+                  "Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "# of Parameters": len(self.parameters)}
+
+        # determines the order in which the information will be printed
         order = ["Setup ID", "Flow ID", "Flow URL", "# of Parameters"]
-        fields = list(fields.reindex(order).dropna().iteritems())
+        fields = [(key, fields[key]) for key in order if key in fields]
 
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)
@@ -86,26 +88,27 @@ class OpenMLParameter(object):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"ID": self.id,
-                            "Flow ID": self.flow_id,
-                            # "Flow Name": self.flow_name,
-                            "Flow Name": self.full_name,
-                            "Flow URL": "{}f/{}".format(base_url, self.flow_id),
-                            "Parameter Name": self.parameter_name})
+        fields = {"ID": self.id,
+                  "Flow ID": self.flow_id,
+                  # "Flow Name": self.flow_name,
+                  "Flow Name": self.full_name,
+                  "Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "Parameter Name": self.parameter_name}
         # indented prints for parameter attributes
         # indention = 2 spaces + 1 | + 2 underscores
         indent = "{}|{}".format(" " * 2, "_" * 2)
         parameter_data_type = "{}Data Type".format(indent)
+        fields[parameter_data_type] = self.data_type
         parameter_default = "{}Default".format(indent)
+        fields[parameter_default] = self.default_value
         parameter_value = "{}Value".format(indent)
-        fields = fields.append(pd.Series({parameter_data_type: self.data_type,
-                                          parameter_default: self.default_value,
-                                          parameter_value: self.value}))
+        fields[parameter_value] = self.value
 
+        # determines the order in which the information will be printed
         order = ["ID", "Flow ID", "Flow Name", "Flow URL", "Parameter Name",
                  parameter_data_type, parameter_default, parameter_value]
-        fields = list(fields.reindex(order).dropna().iteritems())
-        
+        fields = [(key, fields[key]) for key in order if key in fields]
+
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)
         body = '\n'.join(field_line_format.format(name, value) for name, value in fields)

--- a/openml/setups/setup.py
+++ b/openml/setups/setup.py
@@ -28,12 +28,14 @@ class OpenMLSetup(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        setup = '\n%-15s: %s\n' % ("Setup ID", object_dict['setup_id'])
-        flow = '%-15s: %s\n' % ("Flow ID", object_dict['flow_id'])
+        header = 'OpenML Setup'
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        setup = '{:.<15}: {}\n'.format("Setup ID", object_dict['setup_id'])
+        flow = '{:.<15}: {}\n'.format("Flow ID", object_dict['flow_id'])
         url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
-        flow = flow + '%-15s: %s\n' % ("Flow URL", url)
-        params = '%-15s: %s\n' % ("# of Parameters", len(object_dict['parameters']))
-        output_str = setup + flow + params
+        flow = flow + '{:.<15}: {}\n'.format("Flow URL", url)
+        params = '{:.<15}: {}\n'.format("# of Parameters", len(object_dict['parameters']))
+        output_str = '\n' + header + setup + flow + params + '\n'
         return(output_str)
 
 
@@ -75,16 +77,18 @@ class OpenMLParameter(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        id = '\n%-18s: %s\n' % ("ID", object_dict['id'])
-        flow = '%-18s: %s\n' % ("Flow ID", object_dict['flow_id'])
-        flow = flow + '%-18s: %s\n' % ("Flow Name", object_dict['flow_name'])
-        flow = flow + '%-18s: %s\n' % ("Flow Full Name", object_dict['full_name'])
+        header = 'OpenML Parameter'
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        id = '{:.<18}: {}\n'.format("ID", object_dict['id'])
+        flow = '{:.<18}: {}\n'.format("Flow ID", object_dict['flow_id'])
+        flow = flow + '{:.<18}: {}\n'.format("Flow Name", object_dict['flow_name'])
+        flow = flow + '{:.<18}: {}\n'.format("Flow Full Name", object_dict['full_name'])
         url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
-        flow = flow + '%-18s: %s\n' % ("Flow URL", url)
-        filler = " " * 4
-        params = '%-18s: %s\n' % ("Parameter Name", object_dict['parameter_name'])
-        params = params + filler + '%-14s: %s\n' % ("Data_Type", object_dict['data_type'])
-        params = params + filler + '%-14s: %s\n' % ("Default", object_dict['default_value'])
-        params = params + filler + '%-14s: %s\n' % ("Value", object_dict['value'])
-        output_str = id + flow + params
+        flow = flow + '{:.<18}: {}\n'.format("Flow URL", url)
+        filler = " |" + "_" * 2
+        params = '{:.<18}: {}\n'.format("Parameter Name", object_dict['parameter_name'])
+        params = params + filler + '{:.<14}: {}\n'.format("Data_Type", object_dict['data_type'])
+        params = params + filler + '{:.<14}: {}\n'.format("Default", object_dict['default_value'])
+        params = params + filler + '{:.<14}: {}\n'.format("Value", object_dict['value'])
+        output_str = '\n' + header + id + flow + params + '\n'
         return(output_str)

--- a/openml/setups/setup.py
+++ b/openml/setups/setup.py
@@ -25,6 +25,17 @@ class OpenMLSetup(object):
         self.flow_id = flow_id
         self.parameters = parameters
 
+    def __str__(self):
+        object_dict = self.__dict__
+        output_str = ''
+        setup = '\n%-15s: %s\n' % ("Setup ID", object_dict['setup_id'])
+        flow = '%-15s: %s\n' % ("Flow ID", object_dict['flow_id'])
+        url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
+        flow = flow + '%-15s: %s\n' % ("Flow URL", url)
+        params = '%-15s: %s\n' % ("# of Parameters", len(object_dict['parameters']))
+        output_str = setup + flow + params
+        return(output_str)
+
 
 class OpenMLParameter(object):
     """Parameter object (used in setup).
@@ -60,3 +71,20 @@ class OpenMLParameter(object):
         self.data_type = data_type
         self.default_value = default_value
         self.value = value
+
+    def __str__(self):
+        object_dict = self.__dict__
+        output_str = ''
+        id = '\n%-18s: %s\n' % ("ID", object_dict['id'])
+        flow = '%-18s: %s\n' % ("Flow ID", object_dict['flow_id'])
+        flow = flow + '%-18s: %s\n' % ("Flow Name", object_dict['flow_name'])
+        flow = flow + '%-18s: %s\n' % ("Flow Full Name", object_dict['full_name'])
+        url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
+        flow = flow + '%-18s: %s\n' % ("Flow URL", url)
+        filler = " "*4
+        params = '%-18s: %s\n' % ("Parameter Name", object_dict['parameter_name'])
+        params = params + filler + '%-14s: %s\n' % ("Data_Type", object_dict['data_type'])
+        params = params + filler + '%-14s: %s\n' % ("Default", object_dict['default_value'])
+        params = params + filler + '%-14s: %s\n' % ("Value", object_dict['value'])
+        output_str = id + flow + params
+        return(output_str)

--- a/openml/setups/setup.py
+++ b/openml/setups/setup.py
@@ -1,5 +1,4 @@
 import openml.config
-import pandas as pd
 
 
 class OpenMLSetup(object):

--- a/openml/setups/setup.py
+++ b/openml/setups/setup.py
@@ -81,7 +81,7 @@ class OpenMLParameter(object):
         flow = flow + '%-18s: %s\n' % ("Flow Full Name", object_dict['full_name'])
         url = 'https://www.openml.org/f/' + str(object_dict['flow_id'])
         flow = flow + '%-18s: %s\n' % ("Flow URL", url)
-        filler = " "*4
+        filler = " " * 4
         params = '%-18s: %s\n' % ("Parameter Name", object_dict['parameter_name'])
         params = params + filler + '%-14s: %s\n' % ("Data_Type", object_dict['data_type'])
         params = params + filler + '%-14s: %s\n' % ("Default", object_dict['default_value'])

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -119,37 +119,6 @@ class BaseStudy(object):
         body = '\n'.join(field_line_format.format(name, value) for name, value in fields)
         return body
 
-    def old_str(self):
-        object_dict = self.__dict__
-        output_str = ''
-        id = '{:.<16}: {}\n'.format("ID", object_dict['id'])
-        name = '{:.<16}: {}\n'.format("Name", object_dict['name'])
-        status = '{:.<16}: {}\n'.format("Status", object_dict['status'])
-        main_entity_type = '{:.<16}: {}\n'.format("Main Entity Type",
-                                                  object_dict['main_entity_type'])
-        url = 'https://www.openml.org/s/' + str(object_dict['id'])
-        study_url = '{:.<16}: {}\n'.format("Study URL", url)
-        data = ''
-        if object_dict['data'] is not None:
-            data = '{:.<16}: {}\n'.format("# of Data", len(object_dict['data']))
-        tasks = ''
-        if object_dict['tasks'] is not None:
-            tasks = '{:.<16}: {}\n'.format("# of Tasks", len(object_dict['tasks']))
-        flows = ''
-        if object_dict['flows'] is not None:
-            flows = '{:.<16}: {}\n'.format("# of Flows", len(object_dict['flows']))
-        runs = ''
-        if object_dict['runs'] is not None:
-            runs = '{:.<16}: {}\n'.format("# of Runs", len(object_dict['runs']))
-
-        url = 'https://www.openml.org/u/' + str(object_dict['creator'])
-        creator = '{:.<16}: {}\n'.format("Creator", url)
-        upload_time = '{:.<16}: {}\n'.format("Upload Time",
-                                             object_dict['creation_date'].replace('T', ' '))
-        output_str = id + name + status + main_entity_type + study_url + data + \
-            tasks + flows + runs + creator + upload_time
-        return output_str
-
     def publish(self) -> int:
         """
         Publish the study on the OpenML server.

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -89,6 +89,36 @@ class BaseStudy(object):
         self.runs = runs
         pass
 
+    def __str__(self):
+        object_dict = self.__dict__
+        output_str = ''
+        id = '\n%-16s: %s\n' % ("ID", object_dict['id'])
+        name = '%-16s: %s\n' % ("Name", object_dict['name'])
+        status = '%-16s: %s\n' % ("Status", object_dict['status'])
+        main_entity_type = '%-16s: %s\n' % ("Main Entity Type", object_dict['main_entity_type'])
+        url = 'https://www.openml.org/s/' + str(object_dict['id'])
+        study_url = '%-16s: %s\n' % ("Study URL", url)
+        data = ''
+        if object_dict['data'] is not None:
+            data = '%-16s: %s\n' % ("# of Data", len(object_dict['data']))
+        tasks = ''
+        if object_dict['tasks'] is not None:
+            tasks = '%-16s: %s\n' % ("# of Tasks", len(object_dict['tasks']))
+        flows = ''
+        if object_dict['flows'] is not None:
+            flows = '%-16s: %s\n' % ("# of Flows", len(object_dict['flows']))
+        runs = ''
+        if object_dict['runs'] is not None:
+            runs = '%-16s: %s\n' % ("# of Runs", len(object_dict['runs']))
+
+        url = 'https://www.openml.org/u/' + str(object_dict['creator'])
+        creator = '\n%-16s: %s\n' % ("Creator", url)
+        upload_time = '%-16s: %s\n' % ("Upload Time",
+                                       object_dict['creation_date'].replace('T', ' '))
+        output_str = id + name + status + main_entity_type + study_url + data + \
+            tasks + flows + runs + creator + upload_time
+        return(output_str)
+
     def publish(self) -> int:
         """
         Publish the study on the OpenML server.
@@ -232,6 +262,31 @@ class OpenMLStudy(BaseStudy):
             runs=runs,
             setups=setups,
         )
+
+    # def __str__(self):
+    #     object_dict = self.__dict__
+    #     output_str = ''
+    #     id = '\n%-16s: %s\n' % ("ID", object_dict['id'])
+    #     name = '%-16s: %s\n' % ("Name", object_dict['name'])
+    #     status = '%-16s: %s\n' % ("Status", object_dict['status'])
+    #     main_entity_type = '%-16s: %s\n' % ("Main Entity Type", object_dict['main_entity_type'])
+    #     url = 'https://www.openml.org/s/' + str(object_dict['id'])
+    #     url = '%-16s: %s\n' % ("Study URL", url)
+    #     data = ''
+    #     if object_dict['data'] is not None:
+    #         data = '%-16s: %s\n' % ("# of Data", len(object_dict['data']))
+    #     tasks = ''
+    #     if object_dict['tasks'] is not None:
+    #         tasks = '%-16s: %s\n' % ("# of Tasks", len(object_dict['tasks']))
+    #     flows = ''
+    #     if object_dict['flows'] is not None:
+    #         flows = '%-16s: %s\n' % ("# of Flows", len(object_dict['flows']))
+    #     runs = ''
+    #     if object_dict['runs'] is not None:
+    #         runs = '%-16s: %s\n' % ("# of Runs", len(object_dict['runs']))
+    #     output_str = id + name + status + main_entity_type + url + data + \
+    #         tasks + flows + runs
+    #     return(output_str)
 
 
 class OpenMLBenchmarkSuite(BaseStudy):

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -92,32 +92,33 @@ class BaseStudy(object):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        id = '\n%-16s: %s\n' % ("ID", object_dict['id'])
-        name = '%-16s: %s\n' % ("Name", object_dict['name'])
-        status = '%-16s: %s\n' % ("Status", object_dict['status'])
-        main_entity_type = '%-16s: %s\n' % ("Main Entity Type", object_dict['main_entity_type'])
+        id = '{:.<16}: {}\n'.format("ID", object_dict['id'])
+        name = '{:.<16}: {}\n'.format("Name", object_dict['name'])
+        status = '{:.<16}: {}\n'.format("Status", object_dict['status'])
+        main_entity_type = '{:.<16}: {}\n'.format("Main Entity Type",
+                                                  object_dict['main_entity_type'])
         url = 'https://www.openml.org/s/' + str(object_dict['id'])
-        study_url = '%-16s: %s\n' % ("Study URL", url)
+        study_url = '{:.<16}: {}\n'.format("Study URL", url)
         data = ''
         if object_dict['data'] is not None:
-            data = '%-16s: %s\n' % ("# of Data", len(object_dict['data']))
+            data = '{:.<16}: {}\n'.format("# of Data", len(object_dict['data']))
         tasks = ''
         if object_dict['tasks'] is not None:
-            tasks = '%-16s: %s\n' % ("# of Tasks", len(object_dict['tasks']))
+            tasks = '{:.<16}: {}\n'.format("# of Tasks", len(object_dict['tasks']))
         flows = ''
         if object_dict['flows'] is not None:
-            flows = '%-16s: %s\n' % ("# of Flows", len(object_dict['flows']))
+            flows = '{:.<16}: {}\n'.format("# of Flows", len(object_dict['flows']))
         runs = ''
         if object_dict['runs'] is not None:
-            runs = '%-16s: %s\n' % ("# of Runs", len(object_dict['runs']))
+            runs = '{:.<16}: {}\n'.format("# of Runs", len(object_dict['runs']))
 
         url = 'https://www.openml.org/u/' + str(object_dict['creator'])
-        creator = '\n%-16s: %s\n' % ("Creator", url)
-        upload_time = '%-16s: %s\n' % ("Upload Time",
-                                       object_dict['creation_date'].replace('T', ' '))
+        creator = '{:.<16}: {}\n'.format("Creator", url)
+        upload_time = '{:.<16}: {}\n'.format("Upload Time",
+                                             object_dict['creation_date'].replace('T', ' '))
         output_str = id + name + status + main_entity_type + study_url + data + \
             tasks + flows + runs + creator + upload_time
-        return(output_str)
+        return output_str
 
     def publish(self) -> int:
         """
@@ -263,6 +264,13 @@ class OpenMLStudy(BaseStudy):
             setups=setups,
         )
 
+    def __str__(self):
+        header = "OpenML Study"
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        body = super(OpenMLStudy, self).__str__()
+        output_str = '\n' + header + body + '\n'
+        return output_str
+
 
 class OpenMLBenchmarkSuite(BaseStudy):
 
@@ -332,3 +340,10 @@ class OpenMLBenchmarkSuite(BaseStudy):
             runs=None,
             setups=None,
         )
+
+    def __str__(self):
+        header = "OpenML Benchmark Suite"
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        body = super(OpenMLBenchmarkSuite, self).__str__()
+        output_str = '\n' + header + body + '\n'
+        return output_str

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -263,31 +263,6 @@ class OpenMLStudy(BaseStudy):
             setups=setups,
         )
 
-    # def __str__(self):
-    #     object_dict = self.__dict__
-    #     output_str = ''
-    #     id = '\n%-16s: %s\n' % ("ID", object_dict['id'])
-    #     name = '%-16s: %s\n' % ("Name", object_dict['name'])
-    #     status = '%-16s: %s\n' % ("Status", object_dict['status'])
-    #     main_entity_type = '%-16s: %s\n' % ("Main Entity Type", object_dict['main_entity_type'])
-    #     url = 'https://www.openml.org/s/' + str(object_dict['id'])
-    #     url = '%-16s: %s\n' % ("Study URL", url)
-    #     data = ''
-    #     if object_dict['data'] is not None:
-    #         data = '%-16s: %s\n' % ("# of Data", len(object_dict['data']))
-    #     tasks = ''
-    #     if object_dict['tasks'] is not None:
-    #         tasks = '%-16s: %s\n' % ("# of Tasks", len(object_dict['tasks']))
-    #     flows = ''
-    #     if object_dict['flows'] is not None:
-    #         flows = '%-16s: %s\n' % ("# of Flows", len(object_dict['flows']))
-    #     runs = ''
-    #     if object_dict['runs'] is not None:
-    #         runs = '%-16s: %s\n' % ("# of Runs", len(object_dict['runs']))
-    #     output_str = id + name + status + main_entity_type + url + data + \
-    #         tasks + flows + runs
-    #     return(output_str)
-
 
 class OpenMLBenchmarkSuite(BaseStudy):
 

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 import xmltodict
 
 import openml
-import pandas as pd
 
 
 class BaseStudy(object):
@@ -93,13 +92,16 @@ class BaseStudy(object):
     def __str__(self):
         # header is provided by the sub classes
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = {"ID": self.id,
-                  "Name": self.name,
+        fields = {"Name": self.name,
                   "Status": self.status,
-                  "Main Entity Type": self.main_entity_type,
-                  "Study URL": "{}s/{}".format(base_url, self.id),
-                  "Creator": "{}u/{}".format(base_url, self.creator),
-                  "Upload Time": self.creation_date.replace('T', ' ')}
+                  "Main Entity Type": self.main_entity_type}
+        if self.id is not None:
+            fields["ID"] = self.id
+            fields["Study URL"] = "{}s/{}".format(base_url, self.id)
+        if self.creator is not None:
+            fields["Creator"] = "{}u/{}".format(base_url, self.creator)
+        if self.creation_date is not None:
+            fields["Upload Time"] = self.creation_date.replace('T', ' ')
         if self.data is not None:
             fields["# of Data"] = len(self.data)
         if self.tasks is not None:

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -93,26 +93,27 @@ class BaseStudy(object):
     def __str__(self):
         # header is provided by the sub classes
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"ID": self.id,
-                            "Name": self.name,
-                            "Status": self.status,
-                            "Main Entity Type": self.main_entity_type,
-                            "Study URL": "{}s/{}".format(base_url, self.id),
-                            "Creator": "{}u/{}".format(base_url, self.creator),
-                            "Upload Time": self.creation_date.replace('T', ' ')})
+        fields = {"ID": self.id,
+                  "Name": self.name,
+                  "Status": self.status,
+                  "Main Entity Type": self.main_entity_type,
+                  "Study URL": "{}s/{}".format(base_url, self.id),
+                  "Creator": "{}u/{}".format(base_url, self.creator),
+                  "Upload Time": self.creation_date.replace('T', ' ')}
         if self.data is not None:
-            fields = fields.append(pd.Series({"# of Data": len(self.data)}))
+            fields["# of Data"] = len(self.data)
         if self.tasks is not None:
-            fields = fields.append(pd.Series({"# of Tasks": len(self.tasks)}))
+            fields["# of Tasks"] = len(self.tasks)
         if self.flows is not None:
-            fields = fields.append(pd.Series({"# of Flows": len(self.flows)}))
+            fields["# of Flows"] = len(self.flows)
         if self.runs is not None:
-            fields = fields.append(pd.Series({"# of Runs": len(self.runs)}))
+            fields["# of Runs"] = len(self.runs)
 
+        # determines the order in which the information will be printed
         order = ["ID", "Name", "Status", "Main Entity Type", "Study URL",
                  "# of Data", "# of Tasks", "# of Flows", "# of Runs",
                  "Creator", "Upload Time"]
-        fields = list(fields.reindex(order).dropna().iteritems())
+        fields = [(key, fields[key]) for key in order if key in fields]
 
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 import xmltodict
 
 import openml
+import pandas as pd
 
 
 class BaseStudy(object):
@@ -90,6 +91,35 @@ class BaseStudy(object):
         pass
 
     def __str__(self):
+        # header is provided by the sub classes
+        base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
+        fields = pd.Series({"ID": self.id,
+                            "Name": self.name,
+                            "Status": self.status,
+                            "Main Entity Type": self.main_entity_type,
+                            "Study URL": "{}s/{}".format(base_url, self.id),
+                            "Creator": "{}u/{}".format(base_url, self.creator),
+                            "Upload Time": self.creation_date.replace('T', ' ')})
+        if self.data is not None:
+            fields = fields.append(pd.Series({"# of Data": len(self.data)}))
+        if self.tasks is not None:
+            fields = fields.append(pd.Series({"# of Tasks": len(self.tasks)}))
+        if self.flows is not None:
+            fields = fields.append(pd.Series({"# of Flows": len(self.flows)}))
+        if self.runs is not None:
+            fields = fields.append(pd.Series({"# of Runs": len(self.runs)}))
+
+        order = ["ID", "Name", "Status", "Main Entity Type", "Study URL",
+                 "# of Data", "# of Tasks", "# of Flows", "# of Runs",
+                 "Creator", "Upload Time"]
+        fields = list(fields.reindex(order).dropna().iteritems())
+
+        longest_field_name_length = max(len(name) for name, value in fields)
+        field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)
+        body = '\n'.join(field_line_format.format(name, value) for name, value in fields)
+        return body
+
+    def old_str(self):
         object_dict = self.__dict__
         output_str = ''
         id = '{:.<16}: {}\n'.format("ID", object_dict['id'])
@@ -268,8 +298,7 @@ class OpenMLStudy(BaseStudy):
         header = "OpenML Study"
         header = '{}\n{}\n'.format(header, '=' * len(header))
         body = super(OpenMLStudy, self).__str__()
-        output_str = '\n' + header + body + '\n'
-        return output_str
+        return header + body
 
 
 class OpenMLBenchmarkSuite(BaseStudy):
@@ -345,5 +374,4 @@ class OpenMLBenchmarkSuite(BaseStudy):
         header = "OpenML Benchmark Suite"
         header = '{}\n{}\n'.format(header, '=' * len(header))
         body = super(OpenMLBenchmarkSuite, self).__str__()
-        output_str = '\n' + header + body + '\n'
-        return output_str
+        return header + body

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -42,6 +42,34 @@ class OpenMLTask(ABC):
         self.estimation_procedure_id = estimation_procedure_id
         self.split = None  # type: Optional[OpenMLSplit]
 
+    def __str__(self):
+        object_dict = self.__dict__
+        output_str = ''
+        task_type = '\n%-20s: %s\n' % ("Task Type", object_dict['task_type'])
+        task_id = '%-20s: %s\n' % ("Task ID", object_dict['task_id'])
+        url = 'https://www.openml.org/t/' + str(object_dict['task_id'])
+        task_url = '%-20s: %s\n' % ("Task URL", url)
+        evaluation_measure = ''
+        if object_dict['evaluation_measure'] is not None:
+            evaluation_measure = '%-20s: %s\n' % ("Evaluation Measure",
+                                                  object_dict['evaluation_measure'])
+        estimation_procedure = ''
+        if object_dict['estimation_procedure'] is not None:
+            estimation_procedure = '%-20s: %s\n' % ("Estimation Procedure",
+                                                    object_dict['estimation_procedure']['type'])
+        target = ''
+        class_labels = ''
+        cost_matrix = ''
+        if object_dict['target_name'] is not None:
+            target = '%-20s: %s\n' % ("Target Feature", object_dict['target_name'])
+            if 'class_labels' in object_dict:
+                class_labels = '%-20s: %s\n' % ("# of Classes", len(object_dict['class_labels']))
+            if 'cost_matrix' in object_dict:
+                cost_matrix = '%-20s: %s\n' % ("Cost Matrix", "Available")
+        output_str = task_type + task_id + task_url + evaluation_measure + estimation_procedure + \
+            target + class_labels + cost_matrix
+        return(output_str)
+
     def get_dataset(self) -> datasets.OpenMLDataset:
         """Download dataset associated with task"""
         return datasets.get_dataset(self.dataset_id)

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -45,29 +45,32 @@ class OpenMLTask(ABC):
     def __str__(self):
         object_dict = self.__dict__
         output_str = ''
-        task_type = '\n%-20s: %s\n' % ("Task Type", object_dict['task_type'])
-        task_id = '%-20s: %s\n' % ("Task ID", object_dict['task_id'])
+        header = "OpenML Task"
+        header = '{}\n{}\n'.format(header, '=' * len(header))
+        task_type = '{:.<20}: {}\n'.format("Task Type", object_dict['task_type'])
+        task_id = '{:.<20}: {}\n'.format("Task ID", object_dict['task_id'])
         url = 'https://www.openml.org/t/' + str(object_dict['task_id'])
-        task_url = '%-20s: %s\n' % ("Task URL", url)
+        task_url = '{:.<20}: {}\n'.format("Task URL", url)
         evaluation_measure = ''
         if object_dict['evaluation_measure'] is not None:
-            evaluation_measure = '%-20s: %s\n' % ("Evaluation Measure",
-                                                  object_dict['evaluation_measure'])
+            evaluation_measure = '{:.<20}: {}\n'.format("Evaluation Measure",
+                                                        object_dict['evaluation_measure'])
         estimation_procedure = ''
         if object_dict['estimation_procedure'] is not None:
-            estimation_procedure = '%-20s: %s\n' % ("Estimation Procedure",
-                                                    object_dict['estimation_procedure']['type'])
+            procedure = object_dict['estimation_procedure']['type']
+            estimation_procedure = '{:.<20}: {}\n'.format("Estimation Procedure", procedure)
         target = ''
         class_labels = ''
         cost_matrix = ''
         if object_dict['target_name'] is not None:
-            target = '%-20s: %s\n' % ("Target Feature", object_dict['target_name'])
+            target = '{:.<20}: {}\n'.format("Target Feature", object_dict['target_name'])
             if 'class_labels' in object_dict:
-                class_labels = '%-20s: %s\n' % ("# of Classes", len(object_dict['class_labels']))
+                class_labels = '{:.<20}: {}\n'.format("# of Classes",
+                                                      len(object_dict['class_labels']))
             if 'cost_matrix' in object_dict:
-                cost_matrix = '%-20s: %s\n' % ("Cost Matrix", "Available")
-        output_str = task_type + task_id + task_url + evaluation_measure + estimation_procedure + \
-            target + class_labels + cost_matrix
+                cost_matrix = '{:.<20}: {}\n'.format("Cost Matrix", "Available")
+        output_str = '\n' + header + task_type + task_id + task_url + estimation_procedure + \
+            evaluation_measure + target + class_labels + cost_matrix + '\n'
         return(output_str)
 
     def get_dataset(self) -> datasets.OpenMLDataset:

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -47,23 +47,24 @@ class OpenMLTask(ABC):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = pd.Series({"Task Type": self.task_type,
-                            "Task ID": self.task_id,
-                            "Task URL": "{}t/{}".format(base_url, self.task_id)})
+        fields = {"Task Type": self.task_type,
+                  "Task ID": self.task_id,
+                  "Task URL": "{}t/{}".format(base_url, self.task_id)}
         if self.evaluation_measure is not None:
-            fields = fields.append(pd.Series({"Evaluation Measure": self.evaluation_measure}))
+            fields["Evaluation Measure"] = self.evaluation_measure
         if self.estimation_procedure is not None:
-            fields = fields.append(pd.Series({"Estimation Procedure": self.estimation_procedure['type']}))
+            fields["Estimation Procedure"] = self.estimation_procedure['type']
         if self.target_name is not None:
-            fields = fields.append(pd.Series({"Target Feature": self.target_name}))
+            fields["Target Feature"] = self.target_name
             if hasattr(self, 'class_labels'):
-                fields = fields.append(pd.Series({"# of Classes": len(self.class_labels)}))
+                fields["# of Classes"] = len(self.class_labels)
             if hasattr(self, 'cost_matrix'):
-                fields = fields.append(pd.Series({"Cost Matrix": "Available"}))
+                fields["Cost Matrix"] = "Available"
 
+        # determines the order in which the information will be printed
         order = ["Task Type", "Task ID", "Task URL", "Estimation Procedure", "Evaluation Measure",
                  "Target Feature", "# of Classes", "Cost Matrix"]
-        fields = list(fields.reindex(order).dropna().iteritems())
+        fields = [(key, fields[key]) for key in order if key in fields]
 
         longest_field_name_length = max(len(name) for name, value in fields)
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -47,9 +47,10 @@ class OpenMLTask(ABC):
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = {"Task Type": self.task_type,
-                  "Task ID": self.task_id,
-                  "Task URL": "{}t/{}".format(base_url, self.task_id)}
+        fields = {"Task Type": self.task_type}
+        if self.task_id is not None:
+            fields["Task ID"] = self.task_id
+            fields["Task URL"] = "{}t/{}".format(base_url, self.task_id)
         if self.evaluation_measure is not None:
             fields["Evaluation Measure"] = self.evaluation_measure
         if self.estimation_procedure is not None:


### PR DESCRIPTION
#### Reference Issue
Addresses #653.

#### What does this PR implement/fix? Explain your changes.
Adds `__str__` for top-level classes that returns a custom string for displaying brief, necessary object information.

#### How should this PR be tested?
By a `print()` of the object variable.

Examples:
- `d = openml.datasets.get_dataset(523); print(d)`
- `f = openml.flows.get_flow(3740); print(f)`
- `r = openml.runs.get_run(10000); print(r)`
- `t = openml.tasks.get_task(31); print(t)`
- `s = openml.study.get_study(16); print(s)`
- `b = openml.study.get_suite(218); print(b)`
- `s = openml.setups.get_setup(10); print(s)`
  - `print(s.parameters[190])`
- `e = openml.evaluations.list_evaluations(function='predictive_accuracy', task=[31], size=10)`
  - `print(e[51])`

#### Any other comments?
- The reason for including URLs (which are not object attributes) is to nudge the user to visit the website for additional information since certain _descriptions_ can get arbitrarily long.
- I have tested with only a handful of IDs. I would be keen to test these on datasets, tasks, flows, etc. that are anomalous and can break this.
- Please provide suggestions, corrections on how the above can be done better.
- Also, if the examples should be edited to show that object summaries can be _pretty printed_.
