### PR TITLE
Disable a unit test which currently has a serverside issue.

### DIFF
--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -78,6 +78,8 @@ class TestTask(TestBase):
 
         self.assertIsInstance(tasks, dict)
 
+    @unittest.skip("Server will currently incorrectly return only 99 tasks."
+                   "See https://github.com/openml/OpenML/issues/980")
     def test_list_tasks_by_tag(self):
         num_basic_tasks = 100  # number is flexible, check server if fails
         tasks = openml.tasks.list_tasks(tag='OpenML100')


### PR DESCRIPTION
Due to a serverside issue one of our unit tests currently fails (https://github.com/openml/OpenML/issues/980). Skip this unit test for now, so that we can more easily verify that all other functionality still works in PRs.