### PR TITLE
Adding function to retrieve evaluation measures

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -83,6 +83,7 @@ Modules
    :template: function.rst
 
     list_evaluations
+    list_evaluation_measures
 
 :mod:`openml.flows`: Flow Functions
 -----------------------------------

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -21,6 +21,7 @@ Changelog
 * ADD #659: Lazy loading of task splits.
 * ADD #516: `run_flow_on_task` flow uploading is now optional.
 * ADD #680: Adds `openml.config.start_using_configuration_for_example` (and resp. stop) to easily connect to the test server.
+* ADD #687: Adds a function to retrieve the list of evaluation measures available.
 * FIX #642: `check_datasets_active` now correctly also returns active status of deactivated datasets.
 * FIX #304, #636: Allow serialization of numpy datatypes and list of lists of more types (e.g. bools, ints) for flows.
 * FIX #651: Fixed a bug that would prevent openml-python from finding the user's config file.

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -6,6 +6,10 @@
 Changelog
 =========
 
+0.10.0
+~~~~~~
+* ADD #687: Adds a function to retrieve the list of evaluation measures available.
+
 0.9.0
 ~~~~~
 * ADD #560: OpenML-Python can now handle regression tasks as well.
@@ -21,7 +25,6 @@ Changelog
 * ADD #659: Lazy loading of task splits.
 * ADD #516: `run_flow_on_task` flow uploading is now optional.
 * ADD #680: Adds `openml.config.start_using_configuration_for_example` (and resp. stop) to easily connect to the test server.
-* ADD #687: Adds a function to retrieve the list of evaluation measures available.
 * FIX #642: `check_datasets_active` now correctly also returns active status of deactivated datasets.
 * FIX #304, #636: Allow serialization of numpy datatypes and list of lists of more types (e.g. bools, ints) for flows.
 * FIX #651: Fixed a bug that would prevent openml-python from finding the user's config file.

--- a/openml/evaluations/__init__.py
+++ b/openml/evaluations/__init__.py
@@ -1,4 +1,4 @@
 from .evaluation import OpenMLEvaluation
-from .functions import list_evaluations
+from .functions import list_evaluations, list_evaluation_measures
 
-__all__ = ['OpenMLEvaluation', 'list_evaluations']
+__all__ = ['OpenMLEvaluation', 'list_evaluations', 'list_evaluation_measures']

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -202,7 +202,7 @@ def __list_evaluations(api_call, output_format='object'):
     return evals
 
 
-def list_evaluation_measures() -> list:
+def list_evaluation_measures() -> List[str]:
     """ Return list of evaluation measures available.
 
     The function performs an API call to retrieve the entire list of

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -200,3 +200,29 @@ def __list_evaluations(api_call, output_format='object'):
         evals = pd.DataFrame.from_dict(evals, orient='index')
 
     return evals
+
+
+def list_evaluation_measures() -> list:
+    """ Return list of data qualities available.
+
+    The function performs an API call to retrieve the entire list of
+    data qualities that are computed on the datasets uploaded.
+
+    Returns
+    -------
+    list
+
+    """
+    api_call = "evaluationmeasure/list"
+    xml_string = openml._api_calls._perform_api_call(api_call, 'get')
+    qualities = xmltodict.parse(xml_string, force_list=('oml:measures'))
+    # Minimalistic check if the XML is useful
+    if 'oml:evaluation_measures' not in qualities:
+        raise ValueError('Error in return XML, does not contain '
+                         '"oml:evaluation_measures"')
+    if not isinstance(qualities['oml:evaluation_measures']['oml:measures'][0]['oml:measure'],
+                      list):
+        raise TypeError('Error in return XML, does not contain '
+                        '"oml:measure" as a list')
+    qualities = qualities['oml:evaluation_measures']['oml:measures'][0]['oml:measure']
+    return qualities

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -203,10 +203,10 @@ def __list_evaluations(api_call, output_format='object'):
 
 
 def list_evaluation_measures() -> list:
-    """ Return list of data qualities available.
+    """ Return list of evaluation measures available.
 
     The function performs an API call to retrieve the entire list of
-    data qualities that are computed on the datasets uploaded.
+    evaluation measures that are available.
 
     Returns
     -------

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -116,3 +116,8 @@ class TestEvaluationFunctions(TestBase):
         for run_id in evaluations.keys():
             self.assertIsNotNone(evaluations[run_id].value)
             self.assertIsNone(evaluations[run_id].values)
+
+    def test_list_evaluation_measures(self):
+        measures = openml.evaluations.list_evaluation_measures()
+        self.assertEqual([isinstance(measures), list)
+        self.assertEqual(all([isinstance(s, str) for s in measures]), True)

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -119,5 +119,5 @@ class TestEvaluationFunctions(TestBase):
 
     def test_list_evaluation_measures(self):
         measures = openml.evaluations.list_evaluation_measures()
-        self.assertEqual([isinstance(measures), list)
+        self.assertEqual(isinstance(measures, list), True)
         self.assertEqual(all([isinstance(s, str) for s in measures]), True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog!
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
Addresses #687.

#### What does this PR implement/fix? Explain your changes.
Adds a new function to get a list of evaluation measures.

#### How should this PR be tested?
`openml.evaluations.list_evaluation_measures()`

#### Any other comments?
Have placed it in `openml/evaluations/functions.py` file. That seemed like the appropriate location for this function. Kindly advise if not.
