### PR TITLE
add sort to list_evaluations

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.10.0
 ~~~~~~
+* ADD #715: `list_evaluations` now has an option to sort evaluations by score (value).
 * FIX #589: Fixing a bug that did not successfully upload the columns to ignore when creating and publishing a dataset.
 * DOC #639: More descriptive documention for function to convert array format.
 * ADD #687: Adds a function to retrieve the list of evaluation measures available.

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -20,7 +20,7 @@ def list_evaluations(
     uploader: Optional[List] = None,
     tag: Optional[str] = None,
     per_fold: Optional[bool] = None,
-    sort: Optional[str] = None,
+    sort_order: Optional[str] = None,
     output_format: str = 'object'
 ) -> Union[Dict, pd.DataFrame]:
     """
@@ -50,7 +50,7 @@ def list_evaluations(
 
     per_fold : bool, optional
 
-    sort : str, optional
+    sort_order : str, optional
        order of sorting evaluations, ascending ("asc") or descending ("desc")
 
     output_format: str, optional (default='object')
@@ -82,7 +82,7 @@ def list_evaluations(
                                   flow=flow,
                                   uploader=uploader,
                                   tag=tag,
-                                  sort=sort,
+                                  sort_order=sort_order,
                                   per_fold=per_fold_str)
 
 
@@ -93,7 +93,7 @@ def _list_evaluations(
     setup: Optional[List] = None,
     flow: Optional[List] = None,
     uploader: Optional[List] = None,
-    sort: Optional[str] = None,
+    sort_order: Optional[str] = None,
     output_format: str = 'object',
     **kwargs
 ) -> Union[Dict, pd.DataFrame]:
@@ -121,7 +121,7 @@ def _list_evaluations(
     kwargs: dict, optional
         Legal filter operators: tag, limit, offset.
 
-    sort : str, optional
+    sort_order : str, optional
         order of sorting evaluations, ascending ("asc") or descending ("desc")
 
     output_format: str, optional (default='dict')
@@ -151,8 +151,8 @@ def _list_evaluations(
         api_call += "/flow/%s" % ','.join([str(int(i)) for i in flow])
     if uploader is not None:
         api_call += "/uploader/%s" % ','.join([str(int(i)) for i in uploader])
-    if sort is not None:
-        api_call += "/sort/%s" % sort
+    if sort_order is not None:
+        api_call += "/sort_order/%s" % sort_order
 
     return __list_evaluations(api_call, output_format=output_format)
 

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -2,6 +2,7 @@ import json
 import xmltodict
 import pandas as pd
 from typing import Union, List, Optional, Dict
+import collections
 
 import openml.utils
 import openml._api_calls
@@ -168,7 +169,7 @@ def __list_evaluations(api_call, output_format='object'):
     assert type(evals_dict['oml:evaluations']['oml:evaluation']) == list, \
         type(evals_dict['oml:evaluations'])
 
-    evals = dict()
+    evals = collections.OrderedDict()
     for eval_ in evals_dict['oml:evaluations']['oml:evaluation']:
         run_id = int(eval_['oml:run_id'])
         value = None

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -19,6 +19,7 @@ def list_evaluations(
     uploader: Optional[List] = None,
     tag: Optional[str] = None,
     per_fold: Optional[bool] = None,
+    sort: Optional[str] = None,
     output_format: str = 'object'
 ) -> Union[Dict, pd.DataFrame]:
     """
@@ -47,6 +48,9 @@ def list_evaluations(
     tag : str, optional
 
     per_fold : bool, optional
+
+    sort : str, optional
+       order of sorting evaluations, ascending ("asc") or descending ("desc")
 
     output_format: str, optional (default='object')
         The parameter decides the format of the output.
@@ -77,6 +81,7 @@ def list_evaluations(
                                   flow=flow,
                                   uploader=uploader,
                                   tag=tag,
+                                  sort=sort,
                                   per_fold=per_fold_str)
 
 
@@ -87,6 +92,7 @@ def _list_evaluations(
     setup: Optional[List] = None,
     flow: Optional[List] = None,
     uploader: Optional[List] = None,
+    sort: Optional[str] = None,
     output_format: str = 'object',
     **kwargs
 ) -> Union[Dict, pd.DataFrame]:
@@ -113,6 +119,9 @@ def _list_evaluations(
 
     kwargs: dict, optional
         Legal filter operators: tag, limit, offset.
+
+    sort : str, optional
+        order of sorting evaluations, ascending ("asc") or descending ("desc")
 
     output_format: str, optional (default='dict')
         The parameter decides the format of the output.
@@ -141,6 +150,8 @@ def _list_evaluations(
         api_call += "/flow/%s" % ','.join([str(int(i)) for i in flow])
     if uploader is not None:
         api_call += "/uploader/%s" % ','.join([str(int(i)) for i in uploader])
+    if sort is not None:
+        api_call += "/sort/%s" % sort
 
     return __list_evaluations(api_call, output_format=output_format)
 

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -5,6 +5,7 @@ import shutil
 import warnings
 import pandas as pd
 from functools import wraps
+import collections
 
 import openml._api_calls
 import openml.exceptions
@@ -182,7 +183,7 @@ def _list_all(listing_call, output_format='dict', *args, **filters):
     active_filters = {key: value for key, value in filters.items()
                       if value is not None}
     page = 0
-    result = {}
+    result = collections.OrderedDict()
     if output_format == 'dataframe':
         result = pd.DataFrame()
 

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -116,8 +116,7 @@ class TestEvaluationFunctions(TestBase):
         for run_id in evaluations.keys():
             self.assertIsNotNone(evaluations[run_id].value)
             self.assertIsNone(evaluations[run_id].values)
-
-
+            
     def test_evaluation_list_sort(self):
         openml.config.server = self.test_server
         size = 10

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -118,7 +118,7 @@ class TestEvaluationFunctions(TestBase):
             self.assertIsNone(evaluations[run_id].values)
 
     def test_evaluation_list_sort(self):
-        openml.config.server = self.production_server
+        openml.config.server = self.test_server
         size = 10
         task_id = 1769
         # Get all evaluations of the task
@@ -126,7 +126,7 @@ class TestEvaluationFunctions(TestBase):
             "predictive_accuracy", offset=0, task=[task_id])
         # Get top 10 evaluations of the same task
         sorted_eval = openml.evaluations.list_evaluations(
-            "predictive_accuracy", size=size, offset=0, task=[task_id], sort="desc")
+            "predictive_accuracy", size=size, offset=0, task=[task_id], sort_order="desc")
 
         sorted_output = []
         unsorted_output = []

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -116,7 +116,7 @@ class TestEvaluationFunctions(TestBase):
         for run_id in evaluations.keys():
             self.assertIsNotNone(evaluations[run_id].value)
             self.assertIsNone(evaluations[run_id].values)
-            
+
     def test_evaluation_list_sort(self):
         openml.config.server = self.test_server
         size = 10

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -127,7 +127,7 @@ class TestEvaluationFunctions(TestBase):
         sorted_eval = openml.evaluations.list_evaluations(
             "predictive_accuracy", size=size, offset=0, task=[task_id], sort_order="desc")
         self.assertEqual(len(sorted_eval), size)
-        self.assertGreater(len(unsorted_eval),0)
+        self.assertGreater(len(unsorted_eval), 0)
         sorted_output = []
         unsorted_output = []
         for eval in sorted_eval.values():

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -128,12 +128,8 @@ class TestEvaluationFunctions(TestBase):
             "predictive_accuracy", size=size, offset=0, task=[task_id], sort_order="desc")
         self.assertEqual(len(sorted_eval), size)
         self.assertGreater(len(unsorted_eval), 0)
-        sorted_output = []
-        unsorted_output = []
-        for eval in sorted_eval.values():
-            sorted_output.append(eval.value)
-        for eval in unsorted_eval.values():
-            unsorted_output.append(eval.value)
+        sorted_output = [evaluation.value for evaluation in sorted_eval.values()]
+        unsorted_output = [evaluation.value for evaluation in unsorted_eval.values()]
 
         # Check if output from sort is sorted in the right order
         self.assertTrue(sorted(sorted_output, reverse=True) == sorted_output)

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -116,3 +116,28 @@ class TestEvaluationFunctions(TestBase):
         for run_id in evaluations.keys():
             self.assertIsNotNone(evaluations[run_id].value)
             self.assertIsNone(evaluations[run_id].values)
+
+    def test_evaluation_list_sort(self):
+        openml.config.server = self.production_server
+        size = 10
+        task_id = 1769
+        # Get all evaluations of the task
+        unsorted_eval = openml.evaluations.list_evaluations(
+            "predictive_accuracy", offset=0, task=[task_id])
+        # Get top 10 evaluations of the same task
+        sorted_eval = openml.evaluations.list_evaluations(
+            "predictive_accuracy", size=size, offset=0, task=[task_id], sort="desc")
+
+        sorted_output = []
+        unsorted_output = []
+        for run_id in sorted_eval.keys():
+            sorted_output.append(sorted_eval[run_id].value)
+        for run_id in unsorted_eval.keys():
+            unsorted_output.append(unsorted_eval[run_id].value)
+
+        # Check if output from sort is sorted in the right order
+        self.assertTrue(sorted(sorted_output, reverse=True) == sorted_output)
+
+        # Compare manual sorting against sorted output
+        test_output = sorted(unsorted_output, reverse=True)
+        self.assertTrue(test_output[:size] == sorted_output)

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -118,22 +118,22 @@ class TestEvaluationFunctions(TestBase):
             self.assertIsNone(evaluations[run_id].values)
 
     def test_evaluation_list_sort(self):
-        openml.config.server = self.test_server
         size = 10
-        task_id = 1769
+        task_id = 115
         # Get all evaluations of the task
         unsorted_eval = openml.evaluations.list_evaluations(
             "predictive_accuracy", offset=0, task=[task_id])
         # Get top 10 evaluations of the same task
         sorted_eval = openml.evaluations.list_evaluations(
             "predictive_accuracy", size=size, offset=0, task=[task_id], sort_order="desc")
-
+        self.assertEqual(len(sorted_eval), size)
+        self.assertGreater(len(unsorted_eval),0)
         sorted_output = []
         unsorted_output = []
-        for run_id in sorted_eval.keys():
-            sorted_output.append(sorted_eval[run_id].value)
-        for run_id in unsorted_eval.keys():
-            unsorted_output.append(unsorted_eval[run_id].value)
+        for eval in sorted_eval.values():
+            sorted_output.append(eval.value)
+        for eval in unsorted_eval.values():
+            unsorted_output.append(eval.value)
 
         # Check if output from sort is sorted in the right order
         self.assertTrue(sorted(sorted_output, reverse=True) == sorted_output)


### PR DESCRIPTION
<!--
#### Reference Issue
<!-- Fixes #962-->


#### What does this PR implement/fix? Explain your changes.
Added sort option to list evaluations

#### How should this PR be tested?
from openml import evaluations
##### Sort descending:
evaluations.list_evaluations(function='predictive_accuracy', task=[task_id], sort='desc', offset=0, size=10)
##### Sort ascending:
evaluations.list_evaluations(function='predictive_accuracy', task=[task_id], sort='asc', offset=0, size=10)


#### Any other comments?
sort_by option discussed before is irrelevant for now, as the api only supports a sort_by value.
