### PR TITLE
Fixing dataset_id referenced before assignment 

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -6,6 +6,10 @@
 Changelog
 =========
 
+0.10.0
+~~~~~~
+* FIX #608: Fixing dataset_id referenced before assignment error in get_run function.
+
 0.9.0
 ~~~~~
 * ADD #560: OpenML-Python can now handle regression tasks as well.

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -579,7 +579,7 @@ def get_run(run_id: int, ignore_cache: bool = False) -> OpenMLRun:
 
     try:
         if not ignore_cache:
-            _get_cached_run(run_id)
+            return _get_cached_run(run_id)
         else:
             raise OpenMLCacheException(message='dummy')
 

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -668,9 +668,12 @@ def _create_run_from_xml(xml, from_server=True):
     elif not from_server:
         dataset_id = None
     else:
-        raise ValueError('Uploaded run does not contain input_data for run_id={}.\n'
-                         'Kindly report this server-side issue at: '
-                         'https://github.com/openml/openml-python/issues'.format(run_id))
+        # fetching the task to obtain dataset_id
+        t = openml.tasks.get_task(task_id, download_data=False)
+        if not hasattr(t, 'dataset_id'):
+            raise ValueError("Unable to fetch dataset_id from the task({}) "
+                             "linked to run({})".format(task_id, run_id))
+        dataset_id = t.dataset_id
 
     files = OrderedDict()
     evaluations = OrderedDict()

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -579,7 +579,7 @@ def get_run(run_id: int, ignore_cache: bool = False) -> OpenMLRun:
 
     try:
         if not ignore_cache:
-            return _get_cached_run(run_id)
+            _get_cached_run(run_id)
         else:
             raise OpenMLCacheException(message='dummy')
 
@@ -665,8 +665,11 @@ def _create_run_from_xml(xml, from_server=True):
 
     if 'oml:input_data' in run:
         dataset_id = int(run['oml:input_data']['oml:dataset']['oml:did'])
-    elif not from_server:
-        dataset_id = None
+    else:
+        if not from_server:
+            dataset_id = None
+        else:
+            raise ValueError('Uploaded run does not contain input_data.')
 
     files = OrderedDict()
     evaluations = OrderedDict()

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -665,11 +665,12 @@ def _create_run_from_xml(xml, from_server=True):
 
     if 'oml:input_data' in run:
         dataset_id = int(run['oml:input_data']['oml:dataset']['oml:did'])
+    elif not from_server:
+        dataset_id = None
     else:
-        if not from_server:
-            dataset_id = None
-        else:
-            raise ValueError('Uploaded run does not contain input_data.')
+        raise ValueError('Uploaded run does not contain input_data for run_id={}.\n'
+                         'Kindly report this server-side issue at: '
+                         'https://github.com/openml/openml-python/issues'.format(run_id))
 
     files = OrderedDict()
     evaluations = OrderedDict()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog!
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
Addreses #608.

#### What does this PR implement/fix? Explain your changes.
Adds an else to handle the condition and raises an error.

#### How should this PR be tested?
`import openml`
`run = openml.runs.get_run(186276)`

#### Any other comments?
Enters an else block if input_data key is not present. Error is raised if inside else and `from_server=False`.

