### PR TITLE
Fix typo which is no longer allowed per Pytest 5.0

### DIFF
--- a/ci_scripts/test.sh
+++ b/ci_scripts/test.sh
@@ -22,7 +22,7 @@ run_tests() {
         PYTEST_ARGS=''
     fi
 
-    pytest -n 4 --duration=20 --timeout=600 --timeout-method=thread -sv --ignore='test_OpenMLDemo.py' $PYTEST_ARGS $test_dir
+    pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread -sv --ignore='test_OpenMLDemo.py' $PYTEST_ARGS $test_dir
 }
 
 if [[ "$RUN_FLAKE8" == "true" ]]; then


### PR DESCRIPTION
With PyTest 5.0, [prefixes of command-line arguments are no longer allowed](https://docs.pytest.org/en/latest/changelog.html#removals). The full argument is [duration**s**](https://docs.pytest.org/en/latest/usage.html#profiling-test-execution-duration), but `duration` (singular) was used.