### PR TITLE
Handling blank evaluations in object summary output

### DIFF
--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -89,7 +89,7 @@ class OpenMLRun(object):
             fields["Uploader Profile"] = "{}u/{}".format(base_url, self.uploader)
         if self.run_id is not None:
             fields["Run URL"] = "{}r/{}".format(base_url, self.run_id)
-        if self.task_evaluation_measure in self.evaluations:
+        if self.evaluations is not None and self.task_evaluation_measure in self.evaluations:
             fields["Result"] = self.evaluations[self.task_evaluation_measure]
 
         # determines the order in which the information will be printed


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog!
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
-->

#### What does this PR implement/fix? Explain your changes.
Currently, if an `OpenMLRun` object hasn't got `task_evaluation_measure` and `evaluation` defined, the `__str__` call throws an error. 
This PR handles this None condition and omits the printing of that field.

#### How should this PR be tested?
Trying the [flow_and_runs_tutorial](https://github.com/openml/openml-python/blob/develop/examples/flows_and_runs_tutorial.py#L59) and printing the run object created throws the error. This PR should fix that.

