### PR TITLE
Don't block invocation of `python setup.py install`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,6 @@ import sys
 with open("openml/__version__.py") as fh:
     version = fh.readlines()[-1].split()[-1].strip("\"'")
 
-# Using Python setup.py install will try to build numpy which is prone to failure and
-# very time consuming anyway.
-if len(sys.argv) > 1 and sys.argv[1] == 'install':
-    print('Please install this package with pip: `pip install -e .` '
-          'Installation requires pip>=10.0.')
-    sys.exit(1)
-
 if sys.version_info < (3, 5):
     raise ValueError(
         'Unsupported Python version {}.{}.{} found. OpenML requires Python 3.5 or higher.'


### PR DESCRIPTION
Replaces PR #731 
Fixes #727 

After a discussion on #731, we decided to heed the advice of @pganssle and allow for `setup.py install` calls. Thanks again for chiming in :+1:
For now we will not check for additional specific conditions which may cause problems. We'll first see what problems users run into (if any).

I decided to open a new PR since changes from the old PR would be undone/unused.

As far as I can tell, the `python setup.py install` is not anymore in our documentation. However, a page with this advice is still very much live [here](https://openml.github.io/openml-python/master/contributing.html#installation). @mfeurer is this a known issue? I thought doc rebuilds were automatically triggered? 
edit: doh, looks like it is because it refers to master branch docs instead of develop. Still even the master docs should (have) indicate(d) to use pip instead.
