### PR TITLE
make ci log more readable, catch matrix subclass warning

### DIFF
--- a/openml/testing.py
+++ b/openml/testing.py
@@ -221,7 +221,8 @@ class TestBase(unittest.TestCase):
                     # deleting actual entry from tracker
                     TestBase._delete_entity_from_tracker(entity_type, entity)
                 except Exception as e:
-                    TestBase.logger.warn("Cannot delete ({},{}): {}".format(entity_type, entity, e))
+                    TestBase.logger.warning("Cannot delete ({},{}): {}".format(
+                        entity_type, entity, e))
         TestBase.logger.info("End of cleanup_fixture from {}".format(self.__class__))
 
     def _get_sentinel(self, sentinel=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,6 @@
 [metadata]
 description-file = README.md
 
-[nosetests]
-# nosetests skips test files with the executable bit by default
-# which can silently hide failing tests.
-exe = 1
-cover-html = 1
-cover-html-dir = coverage
-cover-package = openml
-
-detailed-errors = 1
-with-doctest = 1
-doctest-tests = 1
-doctest-extension = rst
-doctest-fixtures = _fixture
-#doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE
+[tool:pytest]
+filterwarnings =
+    ignore:the matrix subclass:PendingDeprecationWarning


### PR DESCRIPTION
This should shorten the CI log a bit.
It removes a deprecation warning from the logging module, and a PendingDeprecationWarning from numpy (that can't be avoided right now because of refactoring in scipy if I understand correctly).

I removed the nose configuration as it doesn't seem needed any more.