### PR TITLE
Adding sklearn docstring to flow

### DIFF
--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -556,7 +556,7 @@ class SklearnExtension(Extension):
             index1 = s.index(match_format("Parameters"))
         except ValueError as e:
             # when sklearn docstring has no 'Parameters' section
-            logging.info("{} {}".format(match_format("Parameters"), e))
+            logging.warning("{} {}".format(match_format("Parameters"), e))
             return None
 
         headings = ["Attributes", "Notes", "See also", "Note", "References"]
@@ -566,7 +566,7 @@ class SklearnExtension(Extension):
                 index2 = s.index(match_format(h))
                 break
             except ValueError:
-                logging.info("{} not available in docstring".format(h))
+                logging.warning("{} not available in docstring".format(h))
                 continue
         else:
             # in the case only 'Parameters' exist, trim till end of docstring

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -513,7 +513,7 @@ class SklearnExtension(Extension):
                 s = "{}...".format(s[:char_lim - 3])
             return s.strip()
         except ValueError:
-            logging.info("'Read more' not found in descriptions. "
+            logging.warning("'Read more' not found in descriptions. "
                          "Trying to trim till 'Parameters' if available in docstring.")
             pass
         try:
@@ -522,7 +522,7 @@ class SklearnExtension(Extension):
             index = s.index(match_format(pattern))
         except ValueError:
             # returning full docstring
-            logging.info("'Parameters' not found in docstring. Omitting docstring trimming.")
+            logging.warning("'Parameters' not found in docstring. Omitting docstring trimming.")
             index = len(s)
         s = s[:index]
         # trimming docstring to be within char_lim

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -514,7 +514,7 @@ class SklearnExtension(Extension):
             return s.strip()
         except ValueError:
             logging.warning("'Read more' not found in descriptions. "
-                         "Trying to trim till 'Parameters' if available in docstring.")
+                            "Trying to trim till 'Parameters' if available in docstring.")
             pass
         try:
             # if 'Read more' doesn't exist, trim till 'Parameters'

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -308,7 +308,8 @@ def _check_flow_for_server_id(flow: OpenMLFlow) -> None:
 def assert_flows_equal(flow1: OpenMLFlow, flow2: OpenMLFlow,
                        ignore_parameter_values_on_older_children: str = None,
                        ignore_parameter_values: bool = False,
-                       ignore_custom_name_if_none: bool = False) -> None:
+                       ignore_custom_name_if_none: bool = False,
+                       check_description: bool = True) -> None:
     """Check equality of two flows.
 
     Two flows are equal if their all keys which are not set by the server
@@ -327,8 +328,11 @@ def assert_flows_equal(flow1: OpenMLFlow, flow2: OpenMLFlow,
     ignore_parameter_values : bool
         Whether to ignore parameter values when comparing flows.
 
-   ignore_custom_name_if_none : bool
+    ignore_custom_name_if_none : bool
         Whether to ignore the custom name field if either flow has `custom_name` equal to `None`.
+
+    check_description : bool
+        Whether to ignore matching of flow descriptions.
     """
     if not isinstance(flow1, OpenMLFlow):
         raise TypeError('Argument 1 must be of type OpenMLFlow, but is %s' %
@@ -366,7 +370,7 @@ def assert_flows_equal(flow1: OpenMLFlow, flow2: OpenMLFlow,
                                    ignore_custom_name_if_none)
         elif key == '_extension':
             continue
-        elif key == 'description':
+        elif check_description and key == 'description':
             # to ignore matching of descriptions since sklearn based flows may have
             # altering docstrings and is not guaranteed to be consistent
             continue
@@ -404,8 +408,8 @@ def assert_flows_equal(flow1: OpenMLFlow, flow2: OpenMLFlow,
             elif key == 'parameters_meta_info':
                 # this value is a dictionary where each key is a parameter name, containing another
                 # dictionary with keys specifying the parameter's 'description' and 'data_type'
-                # check of descriptions can be ignored since that might change
-                # data type check can be ignored if one of them is not defined, i.e., None
+                # checking parameter descriptions can be ignored since that might change
+                # data type check can also be ignored if one of them is not defined, i.e., None
                 params1 = set(flow1.parameters_meta_info.keys())
                 params2 = set(flow2.parameters_meta_info.keys())
                 if params1 != params2:

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -409,7 +409,8 @@ def assert_flows_equal(flow1: OpenMLFlow, flow2: OpenMLFlow,
                 params1 = set(flow1.parameters_meta_info.keys())
                 params2 = set(flow2.parameters_meta_info.keys())
                 if params1 != params2:
-                    raise ValueError('Parameter list in meta info for parameters differ in the two flows.')
+                    raise ValueError('Parameter list in meta info for parameters differ '
+                                     'in the two flows.')
                 # iterating over the parameter's meta info list
                 for param in params1:
                     if isinstance(flow1.parameters_meta_info[param], Dict) and \
@@ -424,8 +425,9 @@ def assert_flows_equal(flow1: OpenMLFlow, flow2: OpenMLFlow,
                     if value1 is None or value2 is None:
                         continue
                     elif value1 != value2:
-                        raise ValueError("Flow {}: data type for parameter {} in parameters_meta_info differ as "
-                                         "{}\nvs\n{}".format(flow1.name, key, value1, value2))
+                        raise ValueError("Flow {}: data type for parameter {} in {} differ "
+                                         "as {}\nvs\n{}".format(flow1.name, param, key,
+                                                                value1, value2))
                 # the continue is to avoid the 'attr != attr2' check at end of function
                 continue
 

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -277,26 +277,26 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,DummyClassifier)'
 
         if version.parse(sklearn.__version__) >= version.parse("0.21.0"):
-            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially " \
-                                  "apply a list of transforms and a final estimator.\nIntermediate " \
-                                  "steps of the pipeline must be 'transforms', that is, they\nmust " \
-                                  "implement fit and transform methods.\nThe final estimator only " \
-                                  "needs to implement fit.\nThe transformers in the pipeline can be " \
-                                  "cached using ``memory`` argument.\n\nThe purpose of the pipeline is" \
-                                  " to assemble several steps that can be\ncross-validated together " \
-                                  "while setting different parameters.\nFor this, it enables setting " \
-                                  "parameters of the various steps using their\nnames and the " \
-                                  "parameter name separated by a '__', as in the example below.\nA " \
-                                  "step's estimator may be replaced entirely by setting the " \
-                                  "parameter\nwith its name to another estimator, or a transformer " \
-                                  "removed by setting\nit to 'passthrough' or ``None``."
+            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
+                                  " apply a list of transforms and a final estimator.\n"\
+                                  "Intermediate steps of the pipeline must be 'transforms', that "\
+                                  "is, they\nmust implement fit and transform methods.\nThe final "\
+                                  "estimator only needs to implement fit.\nThe transformers in "\
+                                  "the pipeline can be cached using ``memory`` argument.\n\nThe "\
+                                  "purpose of the pipeline is to assemble several steps that can "\
+                                  "be\ncross-validated together while setting different parameters"\
+                                  ".\nFor this, it enables setting parameters of the various steps"\
+                                  " using their\nnames and the parameter name separated by a '__',"\
+                                  " as in the example below.\nA step's estimator may be replaced "\
+                                  "entirely by setting the parameter\nwith its name to another "\
+                                  "estimator, or a transformer removed by setting\nit to "\
+                                  "'passthrough' or ``None``."
         else:
             fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
-                                  " apply a list of transforms and a final estimator.\nIntermediate"\
-                                  " steps of the pipeline must be 'transforms', that is, they\nmust "\
-                                  "implement fit and transform methods.\nThe final estimator only "\
-                                  "needs to implement fit.\nThe transformers in the pipeline can "\
-                                  "be cached using ``memory`` argument.\n\nThe purpose of the "\
+                                  " apply a list of transforms and a final estimator.\n"\
+                                  "Intermediate steps of the pipeline must be 'transforms', that "\
+                                  "is, they\nmust implement fit and transform methods.\nThe final"\
+                                  " estimator only needs to implement fit.\n\nThe purpose of the "\
                                   "pipeline is to assemble several steps that can be\n"\
                                   "cross-validated together while setting different parameters."\
                                   "\nFor this, it enables setting parameters of the various steps"\
@@ -397,26 +397,26 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,KMeans)'
 
         if version.parse(sklearn.__version__) >= version.parse("0.21.0"):
-            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially " \
-                                  "apply a list of transforms and a final estimator.\nIntermediate " \
-                                  "steps of the pipeline must be 'transforms', that is, they\nmust " \
-                                  "implement fit and transform methods.\nThe final estimator only " \
-                                  "needs to implement fit.\nThe transformers in the pipeline can be " \
-                                  "cached using ``memory`` argument.\n\nThe purpose of the pipeline is" \
-                                  " to assemble several steps that can be\ncross-validated together " \
-                                  "while setting different parameters.\nFor this, it enables setting " \
-                                  "parameters of the various steps using their\nnames and the " \
-                                  "parameter name separated by a '__', as in the example below.\nA " \
-                                  "step's estimator may be replaced entirely by setting the " \
-                                  "parameter\nwith its name to another estimator, or a transformer " \
-                                  "removed by setting\nit to 'passthrough' or ``None``."
+            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
+                                  " apply a list of transforms and a final estimator.\n"\
+                                  "Intermediate steps of the pipeline must be 'transforms', that "\
+                                  "is, they\nmust implement fit and transform methods.\nThe final "\
+                                  "estimator only needs to implement fit.\nThe transformers in "\
+                                  "the pipeline can be cached using ``memory`` argument.\n\nThe "\
+                                  "purpose of the pipeline is to assemble several steps that can "\
+                                  "be\ncross-validated together while setting different parameters"\
+                                  ".\nFor this, it enables setting parameters of the various steps"\
+                                  " using their\nnames and the parameter name separated by a '__',"\
+                                  " as in the example below.\nA step's estimator may be replaced "\
+                                  "entirely by setting the parameter\nwith its name to another "\
+                                  "estimator, or a transformer removed by setting\nit to "\
+                                  "'passthrough' or ``None``."
         else:
             fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
-                                  " apply a list of transforms and a final estimator.\nIntermediate"\
-                                  " steps of the pipeline must be 'transforms', that is, they\nmust "\
-                                  "implement fit and transform methods.\nThe final estimator only "\
-                                  "needs to implement fit.\nThe transformers in the pipeline can "\
-                                  "be cached using ``memory`` argument.\n\nThe purpose of the "\
+                                  " apply a list of transforms and a final estimator.\n"\
+                                  "Intermediate steps of the pipeline must be 'transforms', that "\
+                                  "is, they\nmust implement fit and transform methods.\nThe final"\
+                                  " estimator only needs to implement fit.\n\nThe purpose of the "\
                                   "pipeline is to assemble several steps that can be\n"\
                                   "cross-validated together while setting different parameters."\
                                   "\nFor this, it enables setting parameters of the various steps"\

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -75,7 +75,8 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
             fixture_name = 'sklearn.tree.tree.DecisionTreeClassifier'
             fixture_short_name = 'sklearn.DecisionTreeClassifier'
-            fixture_description = self.extension._get_sklearn_description(model)
+            # str obtained from self.extension._get_sklearn_description(model)
+            fixture_description = 'A decision tree classifier.'
             version_fixture = 'sklearn==%s\nnumpy>=1.6.1\nscipy>=0.9' \
                               % sklearn.__version__
             # min_impurity_decrease has been introduced in 0.20
@@ -143,7 +144,8 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
             fixture_name = 'sklearn.cluster.k_means_.KMeans'
             fixture_short_name = 'sklearn.KMeans'
-            fixture_description = self.extension._get_sklearn_description(model)
+            # str obtained from self.extension._get_sklearn_description(model)
+            fixture_description = 'K-Means clustering'
             version_fixture = 'sklearn==%s\nnumpy>=1.6.1\nscipy>=0.9' \
                               % sklearn.__version__
             # n_jobs default has changed to None in 0.20
@@ -207,11 +209,18 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        '(base_estimator=sklearn.tree.tree.DecisionTreeClassifier)'
         fixture_class_name = 'sklearn.ensemble.weight_boosting.AdaBoostClassifier'
         fixture_short_name = 'sklearn.AdaBoostClassifier'
-        fixture_description = self.extension._get_sklearn_description(model)
+        # str obtained from self.extension._get_sklearn_description(model)
+        fixture_description = 'An AdaBoost classifier.\n\nAn AdaBoost [1] classifier is a '\
+                              'meta-estimator that begins by fitting a\nclassifier on the original'\
+                              ' dataset and then fits additional copies of the\nclassifier on the '\
+                              'same dataset but where the weights of incorrectly\nclassified '\
+                              'instances are adjusted such that subsequent classifiers focus\nmore'\
+                              ' on difficult cases.\n\nThis class implements the algorithm known '\
+                              'as AdaBoost-SAMME [2].'
         fixture_subcomponent_name = 'sklearn.tree.tree.DecisionTreeClassifier'
         fixture_subcomponent_class_name = 'sklearn.tree.tree.DecisionTreeClassifier'
-        fixture_subcomponent_description = \
-            self.extension._get_sklearn_description(model.base_estimator)
+        # str obtained from self.extension._get_sklearn_description(model.base_estimator)
+        fixture_subcomponent_description = 'A decision tree classifier.'
         fixture_structure = {
             fixture_name: [],
             'sklearn.tree.tree.DecisionTreeClassifier': ['base_estimator']
@@ -265,7 +274,20 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        'scaler=sklearn.preprocessing.data.StandardScaler,' \
                        'dummy=sklearn.dummy.DummyClassifier)'
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,DummyClassifier)'
-        fixture_description = self.extension._get_sklearn_description(model)
+        # str obtained from self.extension._get_sklearn_description(model)
+        fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially " \
+                              "apply a list of transforms and a final estimator.\nIntermediate "\
+                              "steps of the pipeline must be 'transforms', that is, they\nmust "\
+                              "implement fit and transform methods.\nThe final estimator only "\
+                              "needs to implement fit.\nThe transformers in the pipeline can be "\
+                              "cached using ``memory`` argument.\n\nThe purpose of the pipeline is"\
+                              " to assemble several steps that can be\ncross-validated together "\
+                              "while setting different parameters.\nFor this, it enables setting "\
+                              "parameters of the various steps using their\nnames and the "\
+                              "parameter name separated by a '__', as in the example below.\nA "\
+                              "step's estimator may be replaced entirely by setting the "\
+                              "parameter\nwith its name to another estimator, or a transformer "\
+                              "removed by setting\nit to 'passthrough' or ``None``."
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],
@@ -354,7 +376,20 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        'scaler=sklearn.preprocessing.data.StandardScaler,' \
                        'clusterer=sklearn.cluster.k_means_.KMeans)'
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,KMeans)'
-        fixture_description = self.extension._get_sklearn_description(model)
+        # str obtained from self.extension._get_sklearn_description(model)
+        fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially "\
+                              "apply a list of transforms and a final estimator.\nIntermediate "\
+                              "steps of the pipeline must be 'transforms', that is, they\nmust "\
+                              "implement fit and transform methods.\nThe final estimator only "\
+                              "needs to implement fit.\nThe transformers in the pipeline can be "\
+                              "cached using ``memory`` argument.\n\nThe purpose of the pipeline is"\
+                              " to assemble several steps that can be\ncross-validated together "\
+                              "while setting different parameters.\nFor this, it enables setting "\
+                              "parameters of the various steps using their\nnames and the "\
+                              "parameter name separated by a '__', as in the example below.\nA "\
+                              "step's estimator may be replaced entirely by setting the parameter"\
+                              "\nwith its name to another estimator, or a transformer removed "\
+                              "by setting\nit to 'passthrough' or ``None``."
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],
@@ -446,7 +481,14 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                   'numeric=sklearn.preprocessing.data.StandardScaler,' \
                   'nominal=sklearn.preprocessing._encoders.OneHotEncoder)'
         fixture_short_name = 'sklearn.ColumnTransformer'
-        fixture_description = self.extension._get_sklearn_description(model)
+        # str obtained from self.extension._get_sklearn_description(model)
+        fixture_description = 'Applies transformers to columns of an array or pandas DataFrame.\n' \
+                              '\nThis estimator allows different columns or column subsets of the '\
+                              'input\nto be transformed separately and the features generated by '\
+                              'each transformer\nwill be concatenated to form a single feature '\
+                              'space.\nThis is useful for heterogeneous or columnar data, to '\
+                              'combine several\nfeature extraction mechanisms or transformations '\
+                              'into a single transformer.'
         fixture_structure = {
             fixture: [],
             'sklearn.preprocessing.data.StandardScaler': ['numeric'],
@@ -505,7 +547,20 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             fixture_name: [],
         }
 
-        fixture_description = self.extension._get_sklearn_description(model)
+        # str obtained from self.extension._get_sklearn_description(model)
+        fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially "\
+                              "apply a list of transforms and a final estimator.\nIntermediate "\
+                              "steps of the pipeline must be 'transforms', that is, they\nmust "\
+                              "implement fit and transform methods.\nThe final estimator only "\
+                              "needs to implement fit.\nThe transformers in the pipeline can be "\
+                              "cached using ``memory`` argument.\n\nThe purpose of the pipeline "\
+                              "is to assemble several steps that can be\ncross-validated together "\
+                              "while setting different parameters.\nFor this, it enables setting "\
+                              "parameters of the various steps using their\nnames and the "\
+                              "parameter name separated by a '__', as in the example below.\nA "\
+                              "step's estimator may be replaced entirely by setting the parameter"\
+                              "\nwith its name to another estimator, or a transformer removed by "\
+                              "setting\nit to 'passthrough' or ``None``."
         serialization = self.extension.model_to_flow(model)
         structure = serialization.get_structure('name')
         self.assertEqual(serialization.name, fixture_name)

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -8,6 +8,7 @@ from distutils.version import LooseVersion
 from collections import OrderedDict
 from unittest import mock
 import warnings
+from packaging import version
 
 import numpy as np
 import scipy.optimize
@@ -274,20 +275,35 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        'scaler=sklearn.preprocessing.data.StandardScaler,' \
                        'dummy=sklearn.dummy.DummyClassifier)'
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,DummyClassifier)'
-        # str obtained from self.extension._get_sklearn_description(model)
-        fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially " \
-                              "apply a list of transforms and a final estimator.\nIntermediate "\
-                              "steps of the pipeline must be 'transforms', that is, they\nmust "\
-                              "implement fit and transform methods.\nThe final estimator only "\
-                              "needs to implement fit.\nThe transformers in the pipeline can be "\
-                              "cached using ``memory`` argument.\n\nThe purpose of the pipeline is"\
-                              " to assemble several steps that can be\ncross-validated together "\
-                              "while setting different parameters.\nFor this, it enables setting "\
-                              "parameters of the various steps using their\nnames and the "\
-                              "parameter name separated by a '__', as in the example below.\nA "\
-                              "step's estimator may be replaced entirely by setting the "\
-                              "parameter\nwith its name to another estimator, or a transformer "\
-                              "removed by setting\nit to 'passthrough' or ``None``."
+
+        if version.parse(sklearn.__version__) >= version.parse("0.21.0"):
+            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially " \
+                                  "apply a list of transforms and a final estimator.\nIntermediate " \
+                                  "steps of the pipeline must be 'transforms', that is, they\nmust " \
+                                  "implement fit and transform methods.\nThe final estimator only " \
+                                  "needs to implement fit.\nThe transformers in the pipeline can be " \
+                                  "cached using ``memory`` argument.\n\nThe purpose of the pipeline is" \
+                                  " to assemble several steps that can be\ncross-validated together " \
+                                  "while setting different parameters.\nFor this, it enables setting " \
+                                  "parameters of the various steps using their\nnames and the " \
+                                  "parameter name separated by a '__', as in the example below.\nA " \
+                                  "step's estimator may be replaced entirely by setting the " \
+                                  "parameter\nwith its name to another estimator, or a transformer " \
+                                  "removed by setting\nit to 'passthrough' or ``None``."
+        else:
+            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
+                                  " apply a list of transforms and a final estimator.\nIntermediate"\
+                                  " steps of the pipeline must be 'transforms', that is, they\nmust "\
+                                  "implement fit and transform methods.\nThe final estimator only "\
+                                  "needs to implement fit.\nThe transformers in the pipeline can "\
+                                  "be cached using ``memory`` argument.\n\nThe purpose of the "\
+                                  "pipeline is to assemble several steps that can be\n"\
+                                  "cross-validated together while setting different parameters."\
+                                  "\nFor this, it enables setting parameters of the various steps"\
+                                  " using their\nnames and the parameter name separated by a '__',"\
+                                  " as in the example below.\nA step's estimator may be replaced "\
+                                  "entirely by setting the parameter\nwith its name to another "\
+                                  "estimator, or a transformer removed by setting\nto None."
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -315,8 +315,9 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         self.assertEqual(serialization.name, fixture_name)
         self.assertEqual(serialization.custom_name, fixture_short_name)
-        TestBase.logger.info("\n\ntest_serialize_pipeline\n---------------------\n"
-                             "{}\n\n{}\n\n".format(serialization.description, fixture_description))
+        TestBase.logger.info("\n\ntest_serialize_pipeline\n---------------------\n{}\n"
+                             "{}\n\n{}\n\n".format(sklearn.__version__, serialization.description,
+                                                   fixture_description))
         self.assertEqual(serialization.description, fixture_description)
         self.assertDictEqual(structure, fixture_structure)
 
@@ -394,20 +395,35 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        'scaler=sklearn.preprocessing.data.StandardScaler,' \
                        'clusterer=sklearn.cluster.k_means_.KMeans)'
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,KMeans)'
-        # str obtained from self.extension._get_sklearn_description(model)
-        fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially "\
-                              "apply a list of transforms and a final estimator.\nIntermediate "\
-                              "steps of the pipeline must be 'transforms', that is, they\nmust "\
-                              "implement fit and transform methods.\nThe final estimator only "\
-                              "needs to implement fit.\nThe transformers in the pipeline can be "\
-                              "cached using ``memory`` argument.\n\nThe purpose of the pipeline is"\
-                              " to assemble several steps that can be\ncross-validated together "\
-                              "while setting different parameters.\nFor this, it enables setting "\
-                              "parameters of the various steps using their\nnames and the "\
-                              "parameter name separated by a '__', as in the example below.\nA "\
-                              "step's estimator may be replaced entirely by setting the parameter"\
-                              "\nwith its name to another estimator, or a transformer removed "\
-                              "by setting\nit to 'passthrough' or ``None``."
+
+        if version.parse(sklearn.__version__) >= version.parse("0.21.0"):
+            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially " \
+                                  "apply a list of transforms and a final estimator.\nIntermediate " \
+                                  "steps of the pipeline must be 'transforms', that is, they\nmust " \
+                                  "implement fit and transform methods.\nThe final estimator only " \
+                                  "needs to implement fit.\nThe transformers in the pipeline can be " \
+                                  "cached using ``memory`` argument.\n\nThe purpose of the pipeline is" \
+                                  " to assemble several steps that can be\ncross-validated together " \
+                                  "while setting different parameters.\nFor this, it enables setting " \
+                                  "parameters of the various steps using their\nnames and the " \
+                                  "parameter name separated by a '__', as in the example below.\nA " \
+                                  "step's estimator may be replaced entirely by setting the " \
+                                  "parameter\nwith its name to another estimator, or a transformer " \
+                                  "removed by setting\nit to 'passthrough' or ``None``."
+        else:
+            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
+                                  " apply a list of transforms and a final estimator.\nIntermediate"\
+                                  " steps of the pipeline must be 'transforms', that is, they\nmust "\
+                                  "implement fit and transform methods.\nThe final estimator only "\
+                                  "needs to implement fit.\nThe transformers in the pipeline can "\
+                                  "be cached using ``memory`` argument.\n\nThe purpose of the "\
+                                  "pipeline is to assemble several steps that can be\n"\
+                                  "cross-validated together while setting different parameters."\
+                                  "\nFor this, it enables setting parameters of the various steps"\
+                                  " using their\nnames and the parameter name separated by a '__',"\
+                                  " as in the example below.\nA step's estimator may be replaced "\
+                                  "entirely by setting the parameter\nwith its name to another "\
+                                  "estimator, or a transformer removed by setting\nto None."
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],
@@ -419,8 +435,9 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         self.assertEqual(serialization.name, fixture_name)
         self.assertEqual(serialization.custom_name, fixture_short_name)
-        TestBase.logger.info("\n\ntest_serialize_pipeline_clustering\n---------------------\n"
-                             "{}\n\n{}\n\n".format(serialization.description, fixture_description))
+        TestBase.logger.info("\n\ntest_serialize_pipeline_clustering\n---------------------\n{}\n"
+                             "{}\n\n{}\n\n".format(sklearn.__version__, serialization.description,
+                                                   fixture_description))
         self.assertEqual(serialization.description, fixture_description)
         self.assertDictEqual(structure, fixture_structure)
 

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -315,6 +315,8 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         self.assertEqual(serialization.name, fixture_name)
         self.assertEqual(serialization.custom_name, fixture_short_name)
+        TestBase.logger.info("\n\ntest_serialize_pipeline\n---------------------\n"
+                             "{}\n\n{}\n\n".format(serialization.description, fixture_description))
         self.assertEqual(serialization.description, fixture_description)
         self.assertDictEqual(structure, fixture_structure)
 
@@ -417,6 +419,8 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         self.assertEqual(serialization.name, fixture_name)
         self.assertEqual(serialization.custom_name, fixture_short_name)
+        TestBase.logger.info("\n\ntest_serialize_pipeline_clustering\n---------------------\n"
+                             "{}\n\n{}\n\n".format(serialization.description, fixture_description))
         self.assertEqual(serialization.description, fixture_description)
         self.assertDictEqual(structure, fixture_structure)
 

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -210,7 +210,8 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         fixture_description = self.extension._get_sklearn_description(model)
         fixture_subcomponent_name = 'sklearn.tree.tree.DecisionTreeClassifier'
         fixture_subcomponent_class_name = 'sklearn.tree.tree.DecisionTreeClassifier'
-        fixture_subcomponent_description = self.extension._get_sklearn_description(model.base_estimator)
+        fixture_subcomponent_description = \
+            self.extension._get_sklearn_description(model.base_estimator)
         fixture_structure = {
             fixture_name: [],
             'sklearn.tree.tree.DecisionTreeClassifier': ['base_estimator']

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -292,18 +292,8 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                                   "estimator, or a transformer removed by setting\nit to "\
                                   "'passthrough' or ``None``."
         else:
-            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
-                                  " apply a list of transforms and a final estimator.\n"\
-                                  "Intermediate steps of the pipeline must be 'transforms', that "\
-                                  "is, they\nmust implement fit and transform methods.\nThe final"\
-                                  " estimator only needs to implement fit.\n\nThe purpose of the "\
-                                  "pipeline is to assemble several steps that can be\n"\
-                                  "cross-validated together while setting different parameters."\
-                                  "\nFor this, it enables setting parameters of the various steps"\
-                                  " using their\nnames and the parameter name separated by a '__',"\
-                                  " as in the example below.\nA step's estimator may be replaced "\
-                                  "entirely by setting the parameter\nwith its name to another "\
-                                  "estimator, or a transformer removed by setting\nto None."
+            fixture_description = self.extension._get_sklearn_description(model)
+
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],
@@ -315,9 +305,6 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         self.assertEqual(serialization.name, fixture_name)
         self.assertEqual(serialization.custom_name, fixture_short_name)
-        TestBase.logger.info("\n\ntest_serialize_pipeline\n---------------------\n{}\n"
-                             "{}\n\n{}\n\n".format(sklearn.__version__, serialization.description,
-                                                   fixture_description))
         self.assertEqual(serialization.description, fixture_description)
         self.assertDictEqual(structure, fixture_structure)
 
@@ -412,18 +399,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                                   "estimator, or a transformer removed by setting\nit to "\
                                   "'passthrough' or ``None``."
         else:
-            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
-                                  " apply a list of transforms and a final estimator.\n"\
-                                  "Intermediate steps of the pipeline must be 'transforms', that "\
-                                  "is, they\nmust implement fit and transform methods.\nThe final"\
-                                  " estimator only needs to implement fit.\n\nThe purpose of the "\
-                                  "pipeline is to assemble several steps that can be\n"\
-                                  "cross-validated together while setting different parameters."\
-                                  "\nFor this, it enables setting parameters of the various steps"\
-                                  " using their\nnames and the parameter name separated by a '__',"\
-                                  " as in the example below.\nA step's estimator may be replaced "\
-                                  "entirely by setting the parameter\nwith its name to another "\
-                                  "estimator, or a transformer removed by setting\nto None."
+            fixture_description = self.extension._get_sklearn_description(model)
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],
@@ -435,9 +411,6 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         self.assertEqual(serialization.name, fixture_name)
         self.assertEqual(serialization.custom_name, fixture_short_name)
-        TestBase.logger.info("\n\ntest_serialize_pipeline_clustering\n---------------------\n{}\n"
-                             "{}\n\n{}\n\n".format(sklearn.__version__, serialization.description,
-                                                   fixture_description))
         self.assertEqual(serialization.description, fixture_description)
         self.assertDictEqual(structure, fixture_structure)
 
@@ -518,14 +491,20 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                   'numeric=sklearn.preprocessing.data.StandardScaler,' \
                   'nominal=sklearn.preprocessing._encoders.OneHotEncoder)'
         fixture_short_name = 'sklearn.ColumnTransformer'
-        # str obtained from self.extension._get_sklearn_description(model)
-        fixture_description = 'Applies transformers to columns of an array or pandas DataFrame.\n' \
-                              '\nThis estimator allows different columns or column subsets of the '\
-                              'input\nto be transformed separately and the features generated by '\
-                              'each transformer\nwill be concatenated to form a single feature '\
-                              'space.\nThis is useful for heterogeneous or columnar data, to '\
-                              'combine several\nfeature extraction mechanisms or transformations '\
-                              'into a single transformer.'
+
+        if version.parse(sklearn.__version__) >= version.parse("0.21.0"):
+            # str obtained from self.extension._get_sklearn_description(model)
+            fixture_description = 'Applies transformers to columns of an array or pandas '\
+                                  'DataFrame.\n\nThis estimator allows different columns or '\
+                                  'column subsets of the input\nto be transformed separately and '\
+                                  'the features generated by each transformer\nwill be '\
+                                  'concatenated to form a single feature space.\nThis is useful '\
+                                  'for heterogeneous or columnar data, to combine several\nfeature'\
+                                  ' extraction mechanisms or transformations into a single '\
+                                  'transformer.'
+        else:
+            fixture_description = self.extension._get_sklearn_description(model)
+
         fixture_structure = {
             fixture: [],
             'sklearn.preprocessing.data.StandardScaler': ['numeric'],
@@ -584,20 +563,25 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             fixture_name: [],
         }
 
-        # str obtained from self.extension._get_sklearn_description(model)
-        fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially "\
-                              "apply a list of transforms and a final estimator.\nIntermediate "\
-                              "steps of the pipeline must be 'transforms', that is, they\nmust "\
-                              "implement fit and transform methods.\nThe final estimator only "\
-                              "needs to implement fit.\nThe transformers in the pipeline can be "\
-                              "cached using ``memory`` argument.\n\nThe purpose of the pipeline "\
-                              "is to assemble several steps that can be\ncross-validated together "\
-                              "while setting different parameters.\nFor this, it enables setting "\
-                              "parameters of the various steps using their\nnames and the "\
-                              "parameter name separated by a '__', as in the example below.\nA "\
-                              "step's estimator may be replaced entirely by setting the parameter"\
-                              "\nwith its name to another estimator, or a transformer removed by "\
-                              "setting\nit to 'passthrough' or ``None``."
+        if version.parse(sklearn.__version__) >= version.parse("0.21.0"):
+            # str obtained from self.extension._get_sklearn_description(model)
+            fixture_description = "Pipeline of transforms with a final estimator.\n\nSequentially"\
+                                  " apply a list of transforms and a final estimator.\n"\
+                                  "Intermediate steps of the pipeline must be 'transforms', that "\
+                                  "is, they\nmust implement fit and transform methods.\nThe final"\
+                                  " estimator only needs to implement fit.\nThe transformers in "\
+                                  "the pipeline can be cached using ``memory`` argument.\n\nThe "\
+                                  "purpose of the pipeline is to assemble several steps that can "\
+                                  "be\ncross-validated together while setting different "\
+                                  "parameters.\nFor this, it enables setting parameters of the "\
+                                  "various steps using their\nnames and the parameter name "\
+                                  "separated by a '__', as in the example below.\nA step's "\
+                                  "estimator may be replaced entirely by setting the parameter\n"\
+                                  "with its name to another estimator, or a transformer removed by"\
+                                  " setting\nit to 'passthrough' or ``None``."
+        else:
+            fixture_description = self.extension._get_sklearn_description(model)
+
         serialization = self.extension.model_to_flow(model)
         structure = serialization.get_structure('name')
         self.assertEqual(serialization.name, fixture_name)

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -75,7 +75,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
             fixture_name = 'sklearn.tree.tree.DecisionTreeClassifier'
             fixture_short_name = 'sklearn.DecisionTreeClassifier'
-            fixture_description = 'Automatically created scikit-learn flow.'
+            fixture_description = self.extension._get_sklearn_description(model)
             version_fixture = 'sklearn==%s\nnumpy>=1.6.1\nscipy>=0.9' \
                               % sklearn.__version__
             # min_impurity_decrease has been introduced in 0.20
@@ -143,7 +143,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
             fixture_name = 'sklearn.cluster.k_means_.KMeans'
             fixture_short_name = 'sklearn.KMeans'
-            fixture_description = 'Automatically created scikit-learn flow.'
+            fixture_description = self.extension._get_sklearn_description(model)
             version_fixture = 'sklearn==%s\nnumpy>=1.6.1\nscipy>=0.9' \
                               % sklearn.__version__
             # n_jobs default has changed to None in 0.20
@@ -207,10 +207,10 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        '(base_estimator=sklearn.tree.tree.DecisionTreeClassifier)'
         fixture_class_name = 'sklearn.ensemble.weight_boosting.AdaBoostClassifier'
         fixture_short_name = 'sklearn.AdaBoostClassifier'
-        fixture_description = 'Automatically created scikit-learn flow.'
+        fixture_description = self.extension._get_sklearn_description(model)
         fixture_subcomponent_name = 'sklearn.tree.tree.DecisionTreeClassifier'
         fixture_subcomponent_class_name = 'sklearn.tree.tree.DecisionTreeClassifier'
-        fixture_subcomponent_description = 'Automatically created scikit-learn flow.'
+        fixture_subcomponent_description = self.extension._get_sklearn_description(model.base_estimator)
         fixture_structure = {
             fixture_name: [],
             'sklearn.tree.tree.DecisionTreeClassifier': ['base_estimator']
@@ -264,7 +264,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        'scaler=sklearn.preprocessing.data.StandardScaler,' \
                        'dummy=sklearn.dummy.DummyClassifier)'
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,DummyClassifier)'
-        fixture_description = 'Automatically created scikit-learn flow.'
+        fixture_description = self.extension._get_sklearn_description(model)
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],
@@ -353,7 +353,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                        'scaler=sklearn.preprocessing.data.StandardScaler,' \
                        'clusterer=sklearn.cluster.k_means_.KMeans)'
         fixture_short_name = 'sklearn.Pipeline(StandardScaler,KMeans)'
-        fixture_description = 'Automatically created scikit-learn flow.'
+        fixture_description = self.extension._get_sklearn_description(model)
         fixture_structure = {
             fixture_name: [],
             'sklearn.preprocessing.data.StandardScaler': ['scaler'],
@@ -445,7 +445,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                   'numeric=sklearn.preprocessing.data.StandardScaler,' \
                   'nominal=sklearn.preprocessing._encoders.OneHotEncoder)'
         fixture_short_name = 'sklearn.ColumnTransformer'
-        fixture_description = 'Automatically created scikit-learn flow.'
+        fixture_description = self.extension._get_sklearn_description(model)
         fixture_structure = {
             fixture: [],
             'sklearn.preprocessing.data.StandardScaler': ['numeric'],
@@ -504,7 +504,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             fixture_name: [],
         }
 
-        fixture_description = 'Automatically created scikit-learn flow.'
+        fixture_description = self.extension._get_sklearn_description(model)
         serialization = self.extension.model_to_flow(model)
         structure = serialization.get_structure('name')
         self.assertEqual(serialization.name, fixture_name)

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -95,7 +95,6 @@ class TestFlowFunctions(TestBase):
         # Test most important values that can be set by a user
         openml.flows.functions.assert_flows_equal(flow, flow)
         for attribute, new_value in [('name', 'Tes'),
-                                     ('description', 'Test flo'),
                                      ('external_version', '2'),
                                      ('language', 'english'),
                                      ('dependencies', 'ab'),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog!
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
Addresses #175.  

#### What does this PR implement/fix? Explain your changes.
Adds the sklearn model description to the OpenML Flow description for a flow that uses a sklearn model. Also parses the docstring and adds the data types and parameter descriptions for the `parameters_meta_info` attribute of a flow.

#### How should this PR be tested?
`import openml`
`from sklearn.linear_model import SGDClassifier`
`openml.config.start_using_configuration_for_example()`
` task = openml.tasks.get_task(403)`
`clf = SGDClassifier()`
` r, f = openml.runs.run_model_on_task(clf, task, return_flow=True)`
` print(f.description)`
`print(f.parameters_meta_info['learning_rate']['data_type'])`
`print(f.parameters_meta_info['learning_rate']['description'])` 