### PR TITLE
Re-enable unit test as server issue is resolved.

### DIFF
--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -84,8 +84,6 @@ class TestTask(TestBase):
 
         self.assertIsInstance(tasks, dict)
 
-    @unittest.skip("Server will currently incorrectly return only 99 tasks."
-                   "See https://github.com/openml/OpenML/issues/980")
     def test_list_tasks_by_tag(self):
         num_basic_tasks = 100  # number is flexible, check server if fails
         tasks = openml.tasks.list_tasks(tag='OpenML100')


### PR DESCRIPTION
With [OpenML#980](https://github.com/openml/OpenML/issues/980) closed, we can re-enable this unit test which failed due to server-side issues.