### PR TITLE
Mark unit test as flaky

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setuptools.setup(name="openml",
                          'pytest-xdist',
                          'pytest-timeout',
                          'nbformat',
-                         'oslo.concurrency'
+                         'oslo.concurrency',
+                         'flaky',
                      ],
                      'examples': [
                          'matplotlib',

--- a/tests/test_runs/test_run.py
+++ b/tests/test_runs/test_run.py
@@ -134,7 +134,7 @@ class TestRun(TestBase):
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
                                                             run_prime.run_id))
 
-    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.flaky()
     def test_to_from_filesystem_search(self):
 
         model = Pipeline([

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -7,6 +7,7 @@ import sys
 import unittest.mock
 
 import numpy as np
+import pytest
 
 import openml
 import openml.exceptions
@@ -826,6 +827,7 @@ class TestRun(TestBase):
         self.assertEqual(flowS.components['VarianceThreshold'].
                          parameters['threshold'], '0.05')
 
+    @pytest.mark.flaky(reruns=3)
     def test_get_run_trace(self):
         # get_run_trace is already tested implicitly in test_run_and_publish
         # this test is a bit additional.

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -827,7 +827,7 @@ class TestRun(TestBase):
         self.assertEqual(flowS.components['VarianceThreshold'].
                          parameters['threshold'], '0.05')
 
-    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.flaky()
     def test_get_run_trace(self):
         # get_run_trace is already tested implicitly in test_run_and_publish
         # this test is a bit additional.


### PR DESCRIPTION
This PR marks one constantly failing unit test as flaky which often fails under high test server load (i.e. multiple travis runs at the same time). Also, it install the flaky package which is a plugin to pytest to actually rerun the marked unit test.