### PR TITLE
Add #737

### DIFF
--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -149,12 +149,13 @@ flow_names = evals.flow_name.unique()[:top_n]
 for i in range(top_n):
     print((flow_ids[i], flow_names[i]))
 
-###############################################################################
+#############################################################################
 # Obtaining evaluations with hyperparameter settings
-# ==========================================
+# ==================================================
 # We'll now obtain the evaluations of a task and a flow with the hyperparameters
 
-# List evaluations in desc order based on predictive_accuracy with hyperparameters
+# List evaluations in descending order based on predictive_accuracy with
+# hyperparameters
 evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy', task=[31],
                                                           size=100, sort_order='desc')
 
@@ -162,8 +163,9 @@ evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_a
 print(evals_setups.head())
 
 ""
-# Return evaluations for flow_id in desc order based on predictive_accuracy with hyperparameters
-# parameters_in_separate_columns returns parameters in separate columns
+# Return evaluations for flow_id in descending order based on predictive_accuracy
+# with hyperparameters. parameters_in_separate_columns returns parameters in
+# separate columns
 evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy',
                                                           flow=[6767],
                                                           size=100,

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -152,23 +152,24 @@ for i in range(top_n):
 ###############################################################################
 # Obtaining evaluations with hyperparameter settings
 # ==========================================
-# We'll now obtain the evaluations of a task and a flow along with the hyperparameter settings
+# We'll now obtain the evaluations of a task and a flow with the hyperparameters
 
-# Return evaluations for given task_id in descending order based on predictive_accuracy and with hyperparameter settings
-evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy', task=[31], size=100, sort_order='desc',
-                                                          parameters_in_separate_columns=False)
+# List evaluations in desc order based on predictive_accuracy with hyperparameters
+evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy', task=[31],
+                                                          size=100, sort_order='desc')
 
 ""
 print(evals_setups.head())
 
 ""
-# Return evaluations for given flow_id in descending order based on predictive_accuracy and with hyperparameter settings
-# parameters_in_separate_columns returns parameters in separate columns (works only when single flow_id is given)
-evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy', flow=[6767], size=100,
-                                                         parameters_in_separate_columns=True)
+# Return evaluations for flow_id in desc order based on predictive_accuracy with hyperparameters
+# parameters_in_separate_columns returns parameters in separate columns
+evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy',
+                                                          flow=[6767],
+                                                          size=100,
+                                                          parameters_in_separate_columns=True)
 
 ""
 print(evals_setups.head(10))
 
 ""
-

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -16,9 +16,10 @@ In this example, we shall do the following:
 * Sort the obtained results in descending order of the metric
 * Plot a cumulative distribution function for the evaluations
 * Compare the top 10 performing flows based on the evaluation performance
+* Retrieve evaluations with hyperparameter settings
 """
 
-############################################################################
+""
 import openml
 
 ############################################################################
@@ -147,3 +148,27 @@ flow_ids = evals.flow_id.unique()[:top_n]
 flow_names = evals.flow_name.unique()[:top_n]
 for i in range(top_n):
     print((flow_ids[i], flow_names[i]))
+
+###############################################################################
+# Obtaining evaluations with hyperparameter settings
+# ==========================================
+# We'll now obtain the evaluations of a task and a flow along with the hyperparameter settings
+
+# Return evaluations for given task_id in descending order based on predictive_accuracy and with hyperparameter settings
+evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy', task=[31], size=100, sort_order='desc',
+                                                          parameters_in_separate_columns=False)
+
+""
+print(evals_setups.head())
+
+""
+# Return evaluations for given flow_id in descending order based on predictive_accuracy and with hyperparameter settings
+# parameters_in_separate_columns returns parameters in separate columns (works only when single flow_id is given)
+evals_setups = openml.evaluations.list_evaluations_setups(function='predictive_accuracy', flow=[6767], size=100,
+                                                         parameters_in_separate_columns=True)
+
+""
+print(evals_setups.head(10))
+
+""
+

--- a/examples/fetch_evaluations_tutorial.py
+++ b/examples/fetch_evaluations_tutorial.py
@@ -19,7 +19,7 @@ In this example, we shall do the following:
 * Retrieve evaluations with hyperparameter settings
 """
 
-""
+############################################################################
 import openml
 
 ############################################################################

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -329,9 +329,11 @@ def list_evaluations_setups(
 
     if parameters_in_separate_columns:
         if flow and len(flow) == 1:
-            df = pd.concat([df.drop('parameters', axis=1), df['parameters'].apply(pd.Series)], axis=1)
+            df = pd.concat([df.drop('parameters', axis=1), df['parameters'].apply(pd.Series)],
+                           axis=1)
         else:
-            raise ValueError("Can set parameters_in_separate_columns to true only for single flow_id")
+            raise ValueError("Can set parameters_in_separate_columns to true only "
+                             "for single flow_id")
 
     if output_format == 'dataframe':
         return df

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -332,8 +332,8 @@ def list_evaluations_setups(
         df = pd.merge(evals, setups, on='setup_id', how='left')
 
     if parameters_in_separate_columns:
-        df = pd.concat([df.drop('parameters', axis=1), df['parameters'].apply(pd.Series)],
-                           axis=1)
+        df = pd.concat([df.drop('parameters', axis=1),
+                        df['parameters'].apply(pd.Series)], axis=1)
 
     if output_format == 'dataframe':
         return df

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -255,7 +255,7 @@ def list_evaluations_setups(
         per_fold: Optional[bool] = None,
         sort_order: Optional[str] = None,
         output_format: str = 'dataframe',
-        parameters_in_separate_columns: Optional[bool]= False
+        parameters_in_separate_columns: Optional[bool] = False
 ) -> Union[Dict, pd.DataFrame]:
     """
     List all run-evaluation pairs matching all of the given filters
@@ -328,10 +328,10 @@ def list_evaluations_setups(
         df = pd.merge(evals, setups, on='setup_id', how='left')
 
     if parameters_in_separate_columns:
-    	if flow and len(flow) == 1:
-    		df = pd.concat([df.drop('parameters', axis=1), df['parameters'].apply(pd.Series)], axis=1)
-    	else:
-    		raise ValueError("Can set parameters_in_separate_columns to true only for single flow_id")
+        if flow and len(flow) == 1:
+            df = pd.concat([df.drop('parameters', axis=1), df['parameters'].apply(pd.Series)], axis=1)
+        else:
+            raise ValueError("Can set parameters_in_separate_columns to true only for single flow_id")
 
     if output_format == 'dataframe':
         return df

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -255,7 +255,7 @@ def list_evaluations_setups(
         per_fold: Optional[bool] = None,
         sort_order: Optional[str] = None,
         output_format: str = 'dataframe',
-        parameters_in_separate_columns: Optional[bool] = False
+        parameters_in_separate_columns: bool = False
 ) -> Union[Dict, pd.DataFrame]:
     """
     List all run-evaluation pairs matching all of the given filters
@@ -297,6 +297,10 @@ def list_evaluations_setups(
     -------
     dict or dataframe with hyperparameter settings as a list of tuples.
     """
+    if parameters_in_separate_columns and (flow is None or len(flow) != 1):
+        raise ValueError("Can set parameters_in_separate_columns to true "
+                         "only for single flow_id")
+
     # List evaluations
     evals = list_evaluations(function=function, offset=offset, size=size, id=id, task=task,
                              setup=setup, flow=flow, uploader=uploader, tag=tag,
@@ -328,12 +332,8 @@ def list_evaluations_setups(
         df = pd.merge(evals, setups, on='setup_id', how='left')
 
     if parameters_in_separate_columns:
-        if flow and len(flow) == 1:
-            df = pd.concat([df.drop('parameters', axis=1), df['parameters'].apply(pd.Series)],
+        df = pd.concat([df.drop('parameters', axis=1), df['parameters'].apply(pd.Series)],
                            axis=1)
-        else:
-            raise ValueError("Can set parameters_in_separate_columns to true only "
-                             "for single flow_id")
 
     if output_format == 'dataframe':
         return df

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -172,16 +172,16 @@ class TestEvaluationFunctions(TestBase):
         openml.config.server = self.production_server
         flow_id = [405]
         size = 100
-        evals_setups = self._check_list_evaluation_setups(size, flow=flow_id)
+        evals = self._check_list_evaluation_setups(size, flow=flow_id)
         # check if parameters in separate columns works
-        evals_setups_cols = openml.evaluations.list_evaluations_setups("predictive_accuracy",
-                                                                       flow=flow_id, size=size,
-                                                                       sort_order='desc',
-                                                                       output_format='dataframe',
-                                                                       parameters_in_separate_columns=True
-                                                                       )
-        columns = (list(evals_setups_cols.columns))
-        keys = (list(evals_setups['parameters'].values[0].keys()))
+        evals_cols = openml.evaluations.list_evaluations_setups("predictive_accuracy",
+                                                                flow=flow_id, size=size,
+                                                                sort_order='desc',
+                                                                output_format='dataframe',
+                                                                parameters_in_separate_columns=True
+                                                                )
+        columns = (list(evals_cols.columns))
+        keys = (list(evals['parameters'].values[0].keys()))
         self.assertTrue(all(elem in columns for elem in keys))
 
     def test_list_evaluations_setups_filter_task(self):

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -27,8 +27,9 @@ class TestEvaluationFunctions(TestBase):
         # Check if the hyper-parameter column is as accurate and flow_id
         for index, row in evals_setups.iterrows():
             params = openml.runs.get_run(row['run_id']).parameter_settings
-            hyper_params = [tuple([param['oml:name'], param['oml:value']]) for param in params]
-            self.assertTrue(sorted(row['parameters']) == sorted(hyper_params))
+            hyper_params = {param['oml:name']: param['oml:value'] for param in params}
+            self.assertTrue(sorted(row['parameters'].values()) == sorted(hyper_params.values()))
+        return evals_setups
 
     def test_evaluation_list_filter_task(self):
         openml.config.server = self.production_server
@@ -171,7 +172,18 @@ class TestEvaluationFunctions(TestBase):
         openml.config.server = self.production_server
         flow_id = [405]
         size = 100
-        self._check_list_evaluation_setups(size, flow=flow_id)
+        evals_setups = self._check_list_evaluation_setups(size, flow=flow_id)
+        # check if parameters in separate columns works
+        evals_setups_separate_cols = openml.evaluations.list_evaluations_setups("predictive_accuracy",
+                                                                                flow=flow_id, size=size,
+                                                                                sort_order='desc',
+                                                                                output_format='dataframe',
+                                                                                parameters_in_separate_columns=True
+                                                                                )
+        columns = (list(evals_setups_separate_cols.columns))
+        keys = (list(evals_setups['parameters'].values[0].keys()))
+        # check if all keys in parameter_dict of evals_setups are present in evals_setups_separate_cols
+        self.assertTrue(all(elem in columns for elem in keys))
 
     def test_list_evaluations_setups_filter_task(self):
         openml.config.server = self.production_server

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -27,10 +27,10 @@ class TestEvaluationFunctions(TestBase):
         # Check if the hyper-parameter column is as accurate and flow_id
         for index, row in evals_setups.iterrows():
             params = openml.runs.get_run(row['run_id']).parameter_settings
-            hyper_params = {param['oml:name']: param['oml:value'] for param in params}
-            list1 = list(hyper_params.values())
+            list1 = [param['oml:value'] for param in params]
             list2 = list(row['parameters'].values())
-            self.assertTrue(all(elem in list2 for elem in list1))
+            # check if all values are equal
+            self.assertSequenceEqual(list1, list2)
         return evals_setups
 
     def test_evaluation_list_filter_task(self):

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -30,7 +30,7 @@ class TestEvaluationFunctions(TestBase):
             list1 = [param['oml:value'] for param in params]
             list2 = list(row['parameters'].values())
             # check if all values are equal
-            self.assertSequenceEqual(list1, list2)
+            self.assertSequenceEqual(sorted(list1), sorted(list2))
         return evals_setups
 
     def test_evaluation_list_filter_task(self):

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -174,15 +174,14 @@ class TestEvaluationFunctions(TestBase):
         size = 100
         evals_setups = self._check_list_evaluation_setups(size, flow=flow_id)
         # check if parameters in separate columns works
-        evals_setups_separate_cols = openml.evaluations.list_evaluations_setups("predictive_accuracy",
-                                                                                flow=flow_id, size=size,
-                                                                                sort_order='desc',
-                                                                                output_format='dataframe',
-                                                                                parameters_in_separate_columns=True
-                                                                                )
-        columns = (list(evals_setups_separate_cols.columns))
+        evals_setups_cols = openml.evaluations.list_evaluations_setups("predictive_accuracy",
+                                                                       flow=flow_id, size=size,
+                                                                       sort_order='desc',
+                                                                       output_format='dataframe',
+                                                                       parameters_in_separate_columns=True
+                                                                       )
+        columns = (list(evals_setups_cols.columns))
         keys = (list(evals_setups['parameters'].values[0].keys()))
-        # check if all keys in parameter_dict of evals_setups are present in evals_setups_separate_cols
         self.assertTrue(all(elem in columns for elem in keys))
 
     def test_list_evaluations_setups_filter_task(self):

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -28,7 +28,9 @@ class TestEvaluationFunctions(TestBase):
         for index, row in evals_setups.iterrows():
             params = openml.runs.get_run(row['run_id']).parameter_settings
             hyper_params = {param['oml:name']: param['oml:value'] for param in params}
-            self.assertTrue(sorted(row['parameters'].values()) == sorted(hyper_params.values()))
+            list1 = list(hyper_params.values())
+            list2 = list(row['parameters'].values())
+            self.assertTrue(all(elem in list2 for elem in list1))
         return evals_setups
 
     def test_evaluation_list_filter_task(self):


### PR DESCRIPTION
<!--

 ### Reference Issue
< Fixes #737  -->


#### What does this PR implement/fix? Explain your changes.
Changes to #737  from parameter_name to full name and added option to get parameters in separate columns in case single flow is supplied

#### How should this PR be tested

`evaluations.list_evaluations_setups(function=function,flow=[flow_id], sort_order=sort_order,size=size, output_format='dataframe')`

`evaluations.list_evaluations_setups(function=function,flow=[flow_id], sort_order=sort_order,size=size, output_format='dataframe', parameters_in_separate_columns = True)` 


#### Any other comments?
Previous PR for #737 - https://github.com/openml/openml-python/pull/747

