### PR TITLE
FIX assign study's id to `study_id` instead of `id`

### DIFF
--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -72,7 +72,7 @@ class BaseStudy(object):
         setups: Optional[List[int]],
     ):
 
-        self.id = study_id
+        self.study_id = study_id
         self.alias = alias
         self.main_entity_type = main_entity_type
         self.benchmark_suite = benchmark_suite
@@ -95,9 +95,9 @@ class BaseStudy(object):
         fields = {"Name": self.name,
                   "Status": self.status,
                   "Main Entity Type": self.main_entity_type}
-        if self.id is not None:
-            fields["ID"] = self.id
-            fields["Study URL"] = "{}s/{}".format(base_url, self.id)
+        if self.study_id is not None:
+            fields["ID"] = self.study_id
+            fields["Study URL"] = "{}s/{}".format(base_url, self.study_id)
         if self.creator is not None:
             fields["Creator"] = "{}u/{}".format(base_url, self.creator)
         if self.creation_date is not None:

--- a/tests/test_study/test_study_functions.py
+++ b/tests/test_study/test_study_functions.py
@@ -34,7 +34,7 @@ class TestStudyFunctions(TestBase):
         self.assertIsInstance(study, openml.study.OpenMLBenchmarkSuite)
         study_2 = openml.study.get_suite('OpenML100')
         self.assertIsInstance(study_2, openml.study.OpenMLBenchmarkSuite)
-        self.assertEqual(study.id, study_2.id)
+        self.assertEqual(study.study_id, study_2.study_id)
 
     def test_get_study_error(self):
         openml.config.server = self.production_server


### PR DESCRIPTION
A study's id would be assigned to `id` on initialization, and to `study_id` after publish. Now it is uniformly always `study_id`, following the other openml-python objects (e.g. `run.run_id`).