### PR TITLE
Fix 779

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -414,7 +414,7 @@ class OpenMLDataset(object):
         return data_pickle_file
 
     def _load_data(self):
-        """ Load data from pickle or, if needed, arff. Download data first if not present on disk. """
+        """ Load data from pickle or arff. Download data first if not present on disk. """
         if self.data_pickle_file is None:
             if self.data_file is None:
                 self._download_data()

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -237,7 +237,9 @@ class OpenMLDataset(object):
 
         Reads the file referenced in self.data_file.
 
-        :param format: str
+        Parameters
+        ----------
+        format : str
             Format of the ARFF file.
             Must be one of 'arff' or 'sparse_arff' or a string that will be either of those
             when converted to lower case.
@@ -288,9 +290,14 @@ class OpenMLDataset(object):
     ) -> Tuple[Union[pd.DataFrame, scipy.sparse.csr_matrix], List[bool], List[str]]:
         """ Parse all required data from arff file.
 
-        :param arff_file_path: str
+        Parameters
+        ----------
+        arff_file_path : str
             Path to the file on disk.
-        :return: Tuple[Union[pd.DataFrame, scipy.sparse.csr_matrix], List[bool], List[str]]
+
+        Returns
+        -------
+        Tuple[Union[pd.DataFrame, scipy.sparse.csr_matrix], List[bool], List[str]]
             DataFrame or csr_matrix: dataset
             List[bool]: List indicating which columns contain categorical variables.
             List[str]: List of column names.
@@ -387,7 +394,7 @@ class OpenMLDataset(object):
                     data, categorical, attribute_names = pickle.load(fh)
                 except EOFError:
                     # The file is likely corrupt, see #780.
-                    # We deal with this when loading the data in `_load_data_from_disk`.
+                    # We deal with this when loading the data in `_load_data`.
                     return data_pickle_file
 
             # Between v0.8 and v0.9 the format of pickled data changed from
@@ -424,13 +431,13 @@ class OpenMLDataset(object):
             with open(self.data_pickle_file, "rb") as fh:
                 data, categorical, attribute_names = pickle.load(fh)
         except EOFError:
-            warn(
-                "Detected a corrupt cache file loading dataset {did}: '{path}'. "
+            logging.warning(
+                "Detected a corrupt cache file loading dataset %d: '%s'. "
                 "We will continue loading data from the arff-file, "
                 "but this will be much slower for big datasets. "
                 "Please manually delete the cache file if you want openml-python "
                 "to attempt to reconstruct it."
-                "".format(did=self.dataset_id, path=self.data_pickle_file)
+                "" % (self.dataset_id, self.data_pickle_file)
             )
             data, categorical, attribute_names = self._parse_data_from_arff(self.data_file)
         except FileNotFoundError:

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -260,7 +260,8 @@ class OpenMLDataset(object):
         # if it exceeds 120mb (slightly more than covtype dataset size)
         # This number is somewhat arbitrary.
         if bits != 64 and os.path.getsize(filename) > 120000000:
-            return NotImplementedError("File too big")
+            raise NotImplementedError("File {} too big for {}-bit system ({} bytes)."
+                                      .format(filename, os.path.getsize(filename), bits))
 
         if format.lower() == 'arff':
             return_type = arff.DENSE

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -490,10 +490,6 @@ class OpenMLDataset(object):
                 else returns data as is
 
         """
-        if ((array_format == "dataframe" and isinstance(data, pd.DataFrame))
-                or (array_format == "array" and isinstance(data, np.ndarray))):
-            # No conversion or warning required.
-            return data
 
         if array_format == "array" and not scipy.sparse.issparse(data):
             # We encode the categories such that they are integer to be able
@@ -523,7 +519,10 @@ class OpenMLDataset(object):
             return pd.SparseDataFrame(data, columns=attribute_names)
         else:
             data_type = "sparse-data" if scipy.sparse.issparse(data) else "non-sparse data"
-            warn("Cannot convert {} to '{}'. Returning input data.".format(data_type, array_format))
+            logging.warning(
+                "Cannot convert %s (%s) to '%s'. Returning input data."
+                % (data_type, type(data), array_format)
+            )
         return data
 
     @staticmethod

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -482,6 +482,11 @@ class OpenMLDataset(object):
                 else returns data as is
 
         """
+        if ((array_format == "dataframe" and isinstance(data, pd.DataFrame))
+                or (array_format == "array" and isinstance(data, np.ndarray))):
+            # No conversion or warning required.
+            return data
+
         if array_format == "array" and not scipy.sparse.issparse(data):
             # We encode the categories such that they are integer to be able
             # to make a conversion to numeric for backward compatibility

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -26,6 +26,7 @@ class OpenMLDatasetTest(TestBase):
         # these datasets have some boolean features
         self.pc4 = openml.datasets.get_dataset(1049, download_data=False)
         self.jm1 = openml.datasets.get_dataset(1053, download_data=False)
+        self.iris = openml.datasets.get_dataset(61, download_data=False)
 
     def test_get_data_array(self):
         # Basic usage
@@ -189,6 +190,20 @@ class OpenMLDatasetTest(TestBase):
         self.assertEqual(np.max(y), 5)
         # Check that no label is mapped to 3, since it is reserved for label '4'.
         self.assertEqual(np.sum(y == 3), 0)
+
+    def test_get_data_corrupt_pickle(self):
+        # lazy loaded dataset, populate cache
+        self.iris.get_data()
+        # corrupt pickle file, overwrite as empty.
+        with open(self.iris.data_pickle_file, "w") as fh:
+            fh.write("")
+
+        with catch_warnings():
+            filterwarnings('error')
+            self.assertRaises(
+                UserWarning,
+                self.iris.get_data
+            )
 
 
 class OpenMLDatasetTestOnTestServer(TestBase):

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -192,18 +192,16 @@ class OpenMLDatasetTest(TestBase):
         self.assertEqual(np.sum(y == 3), 0)
 
     def test_get_data_corrupt_pickle(self):
-        # lazy loaded dataset, populate cache
+        # Lazy loaded dataset, populate cache.
         self.iris.get_data()
-        # corrupt pickle file, overwrite as empty.
+        # Corrupt pickle file, overwrite as empty.
         with open(self.iris.data_pickle_file, "w") as fh:
             fh.write("")
-
-        with catch_warnings():
-            filterwarnings('error')
-            self.assertRaises(
-                UserWarning,
-                self.iris.get_data
-            )
+        # Despite the corrupt file, the data should be loaded from the ARFF file.
+        # A warning message is written to the python logger.
+        xy, _, _, _ = self.iris.get_data()
+        self.assertIsInstance(xy, pd.DataFrame)
+        self.assertEqual(xy.shape, (150, 5))
 
 
 class OpenMLDatasetTestOnTestServer(TestBase):


### PR DESCRIPTION
Fixes #779. If the pickle file is corrupt, data will be loaded from arff instead.

Also:
 - refactor some of the data loading flow
 - prevent `_convert_array_format` from issuing warnings on `np.ndarray -> np.ndarray` and `pd.DataFrame -> pd.DataFrame`  conversions.