### PR TITLE
Rename argument to be more intuitive

### DIFF
--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -15,10 +15,10 @@ def list_evaluations(
     function: str,
     offset: Optional[int] = None,
     size: Optional[int] = None,
-    id: Optional[List] = None,
     task: Optional[List] = None,
     setup: Optional[List] = None,
     flow: Optional[List] = None,
+    run: Optional[List] = None,
     uploader: Optional[List] = None,
     tag: Optional[str] = None,
     per_fold: Optional[bool] = None,
@@ -38,13 +38,14 @@ def list_evaluations(
     size : int, optional
         the maximum number of runs to show
 
-    id : list, optional
-
     task : list, optional
 
     setup: list, optional
 
     flow : list, optional
+
+    run : list, optional
+
 
     uploader : list, optional
 
@@ -78,10 +79,10 @@ def list_evaluations(
                                   function=function,
                                   offset=offset,
                                   size=size,
-                                  id=id,
                                   task=task,
                                   setup=setup,
                                   flow=flow,
+                                  run=run,
                                   uploader=uploader,
                                   tag=tag,
                                   sort_order=sort_order,
@@ -90,10 +91,10 @@ def list_evaluations(
 
 def _list_evaluations(
     function: str,
-    id: Optional[List] = None,
     task: Optional[List] = None,
     setup: Optional[List] = None,
     flow: Optional[List] = None,
+run: Optional[List] = None,
     uploader: Optional[List] = None,
     sort_order: Optional[str] = None,
     output_format: str = 'object',
@@ -110,13 +111,14 @@ def _list_evaluations(
     function : str
         the evaluation function. e.g., predictive_accuracy
 
-    id : list, optional
-
     task : list, optional
 
     setup: list, optional
 
     flow : list, optional
+
+    run : list, optional
+
 
     uploader : list, optional
 
@@ -143,14 +145,14 @@ def _list_evaluations(
     if kwargs is not None:
         for operator, value in kwargs.items():
             api_call += "/%s/%s" % (operator, value)
-    if id is not None:
-        api_call += "/run/%s" % ','.join([str(int(i)) for i in id])
     if task is not None:
         api_call += "/task/%s" % ','.join([str(int(i)) for i in task])
     if setup is not None:
         api_call += "/setup/%s" % ','.join([str(int(i)) for i in setup])
     if flow is not None:
         api_call += "/flow/%s" % ','.join([str(int(i)) for i in flow])
+    if run is not None:
+        api_call += "/run/%s" % ','.join([str(int(i)) for i in run])
     if uploader is not None:
         api_call += "/uploader/%s" % ','.join([str(int(i)) for i in uploader])
     if sort_order is not None:

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -46,7 +46,6 @@ def list_evaluations(
 
     run : list, optional
 
-
     uploader : list, optional
 
     tag : str, optional
@@ -118,7 +117,6 @@ run: Optional[List] = None,
     flow : list, optional
 
     run : list, optional
-
 
     uploader : list, optional
 

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -93,7 +93,7 @@ def _list_evaluations(
     task: Optional[List] = None,
     setup: Optional[List] = None,
     flow: Optional[List] = None,
-run: Optional[List] = None,
+    run: Optional[List] = None,
     uploader: Optional[List] = None,
     sort_order: Optional[str] = None,
     output_format: str = 'object',
@@ -256,10 +256,10 @@ def list_evaluations_setups(
         function: str,
         offset: Optional[int] = None,
         size: Optional[int] = None,
-        id: Optional[List] = None,
         task: Optional[List] = None,
         setup: Optional[List] = None,
         flow: Optional[List] = None,
+        run: Optional[List] = None,
         uploader: Optional[List] = None,
         tag: Optional[str] = None,
         per_fold: Optional[bool] = None,
@@ -279,16 +279,16 @@ def list_evaluations_setups(
         the number of runs to skip, starting from the first
     size : int, optional
         the maximum number of runs to show
-    id : list[int], optional
-        the list of evaluation ID's
     task : list[int], optional
-        the list of task ID's
+        the list of task IDs
     setup: list[int], optional
-        the list of setup ID's
+        the list of setup IDs
     flow : list[int], optional
-        the list of flow ID's
+        the list of flow IDs
+    run : list[int], optional
+        the list of run IDs
     uploader : list[int], optional
-        the list of uploader ID's
+        the list of uploader IDs
     tag : str, optional
         filter evaluation based on given tag
     per_fold : bool, optional
@@ -312,7 +312,7 @@ def list_evaluations_setups(
                          "only for single flow_id")
 
     # List evaluations
-    evals = list_evaluations(function=function, offset=offset, size=size, id=id, task=task,
+    evals = list_evaluations(function=function, offset=offset, size=size, run=run, task=task,
                              setup=setup, flow=flow, uploader=uploader, tag=tag,
                              per_fold=per_fold, sort_order=sort_order, output_format='dataframe')
 

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -97,7 +97,7 @@ class TestEvaluationFunctions(TestBase):
         run_id = 12
 
         evaluations = openml.evaluations.list_evaluations("predictive_accuracy",
-                                                          id=[run_id])
+                                                          run=[run_id])
 
         self.assertEqual(len(evaluations), 1)
         for run_id in evaluations.keys():


### PR DESCRIPTION
### What does this PR implement/fix? Explain your changes.

Renames argument `id` of function `openml.evaluations.list_evaluations` to `run` to make it clearer that the IDs are for the run.

#### How should this PR be tested?

There is an existing unit test for this functionality. I updated at to reflect the changed argument name.
