### PR TITLE
Add additional part of OpenML error message to exception message

### DIFF
--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -52,3 +52,5 @@ fi
 # Install scikit-learn last to make sure the openml package installation works
 # from a clean environment without scikit-learn.
 pip install scikit-learn==$SKLEARN_VERSION
+
+conda list

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -155,9 +155,9 @@ def _parse_server_exception(response, url):
         # 512 for runs, 372 for datasets, 500 for flows
         # 482 for tasks, 542 for evaluations, 674 for setups
         return OpenMLServerNoResult(code, message, additional_information)
+    full_message = '{} - {}'.format(message, additional_information)
     return OpenMLServerException(
         code=code,
-        message=message,
-        additional=additional_information,
+        message=full_message,
         url=url
     )

--- a/openml/exceptions.py
+++ b/openml/exceptions.py
@@ -19,9 +19,10 @@ class OpenMLServerException(OpenMLServerError):
     # Code needs to be optional to allow the exceptino to be picklable:
     # https://stackoverflow.com/questions/16244923/how-to-make-a-custom-exception-class-with-multiple-init-args-pickleable  # noqa: E501
     def __init__(self, message: str, code: str = None, additional: str = None, url: str = None):
+        if additional is not None:
+            message = message + ' - ' + additional
         self.message = message
         self.code = code
-        self.additional = additional
         self.url = url
         super().__init__(message)
 

--- a/openml/exceptions.py
+++ b/openml/exceptions.py
@@ -18,9 +18,7 @@ class OpenMLServerException(OpenMLServerError):
 
     # Code needs to be optional to allow the exceptino to be picklable:
     # https://stackoverflow.com/questions/16244923/how-to-make-a-custom-exception-class-with-multiple-init-args-pickleable  # noqa: E501
-    def __init__(self, message: str, code: str = None, additional: str = None, url: str = None):
-        if additional is not None:
-            message = message + ' - ' + additional
+    def __init__(self, message: str, code: str = None, url: str = None):
         self.message = message
         self.code = code
         self.url = url

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -420,7 +420,7 @@ class TestRun(TestBase):
                     fold=0,
                 )
             except openml.exceptions.OpenMLServerException as e:
-                e.additional = "%s; run_id %d" % (e.additional, run.run_id)
+                e.message = "%s; run_id %d" % (e.message, run.run_id)
                 raise e
 
             self._rerun_model_and_compare_predictions(run.run_id, model_prime,


### PR DESCRIPTION
This allows us to see the error message given by OpenML to simplify debugging.