### PR TITLE
fix issue #305 by not requiring external version in the flow xml

### DIFF
--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -490,10 +490,13 @@ class SklearnExtension(Extension):
 
     @classmethod
     def _is_sklearn_flow(cls, flow: OpenMLFlow) -> bool:
-        return (
-            flow.external_version.startswith('sklearn==')
-            or ',sklearn==' in flow.external_version
-        )
+        if flow.external_version is None:
+            return False
+        else:
+            return (
+                flow.external_version.startswith('sklearn==')
+                or ',sklearn==' in flow.external_version
+            )
 
     def _get_sklearn_description(self, model: Any, char_lim: int = 1024) -> str:
         '''Fetches the sklearn function docstring for the flow description

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -295,13 +295,24 @@ class OpenMLFlow(object):
         dic = xml_dict["oml:flow"]
 
         # Mandatory parts in the xml file
-        for key in ['name', 'external_version']:
+        for key in ['name']:
             arguments[key] = dic["oml:" + key]
 
         # non-mandatory parts in the xml file
-        for key in ['uploader', 'description', 'upload_date', 'language',
-                    'dependencies', 'version', 'binary_url', 'binary_format',
-                    'binary_md5', 'class_name', 'custom_name']:
+        for key in [
+            'external_version',
+            'uploader',
+            'description',
+            'upload_date',
+            'language',
+            'dependencies',
+            'version',
+            'binary_url',
+            'binary_format',
+            'binary_md5',
+            'class_name',
+            'custom_name',
+        ]:
             arguments[key] = dic.get("oml:" + key)
 
         # has to be converted to an int if present and cannot parsed in the

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -280,6 +280,9 @@ class OpenMLFlow(object):
 
         Calls itself recursively to create :class:`OpenMLFlow` objects of
         subflows (components).
+        
+        XML definition of a flow is available at
+        https://github.com/openml/OpenML/blob/master/openml_OS/views/pages/api_new/v1/xsd/openml.implementation.upload.xsd
 
         Parameters
         ----------
@@ -290,7 +293,7 @@ class OpenMLFlow(object):
         -------
             OpenMLFlow
 
-        """
+        """  # noqa E501
         arguments = OrderedDict()
         dic = xml_dict["oml:flow"]
 

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -264,9 +264,11 @@ class TestFlowFunctions(TestBase):
         self.assertEqual(server_flow.model.categories, flow.model.categories)
 
     def test_get_flow1(self):
-        # Make sure that issue #305 doesn't pop up any more
+        # Regression test for issue #305
+        # Basically, this checks that a flow without an external version can be loaded
         openml.config.server = self.production_server
-        openml.flows.get_flow(1)
+        flow = openml.flows.get_flow(1)
+        self.assertIsNone(flow.external_version)
 
     def test_get_flow_reinstantiate_model(self):
         model = ensemble.RandomForestClassifier(n_estimators=33)

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -263,6 +263,11 @@ class TestFlowFunctions(TestBase):
         self.assertEqual(server_flow.parameters['categories'], '[[0, 1], [0, 1]]')
         self.assertEqual(server_flow.model.categories, flow.model.categories)
 
+    def test_get_flow1(self):
+        # Make sure that issue #305 doesn't pop up any more
+        openml.config.server = self.production_server
+        openml.flows.get_flow(1)
+
     def test_get_flow_reinstantiate_model(self):
         model = ensemble.RandomForestClassifier(n_estimators=33)
         extension = openml.extensions.get_extension_by_model(model)


### PR DESCRIPTION
Closes #305 

Apparently, the `external_version` is not a required field of a flow: https://github.com/openml/OpenML/blob/master/openml_OS/views/pages/api_new/v1/xsd/openml.implementation.upload.xsd This PR removes this assumption from the Python package and thereby allows loading flow number 1.