### PR TITLE
Fixing fetching of categorical sparse data

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -245,6 +245,7 @@ class OpenMLDataset(object):
             when converted to lower case.
 
 
+
         Returns
         -------
         dict
@@ -319,13 +320,15 @@ class OpenMLDataset(object):
         attribute_names = []
         categories_names = {}
         categorical = []
-        for name, type_ in data['attributes']:
+        for i, (name, type_) in enumerate(data['attributes']):
             # if the feature is nominal and the a sparse matrix is
             # requested, the categories need to be numeric
             if (isinstance(type_, list)
                     and self.format.lower() == 'sparse_arff'):
                 try:
-                    np.array(type_, dtype=np.float32)
+                    # checks if the strings which should be the class labels
+                    # can be encoded into integers
+                    pd.factorize(type_)[0]
                 except ValueError:
                     raise ValueError(
                         "Categorical data needs to be numeric when "

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -322,7 +322,7 @@ class OpenMLDatasetTestSparse(TestBase):
         self.assertEqual(y.shape, (600, ))
 
     def test_get_sparse_categorical_data_id_395(self):
-        dataset = openml.datasets.get_dataset(395, download_data=False)
+        dataset = openml.datasets.get_dataset(395, download_data=True)
         feature = dataset.features[3758]
         self.assertTrue(isinstance(dataset, OpenMLDataset))
         self.assertTrue(isinstance(feature, OpenMLDataFeature))

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -320,6 +320,14 @@ class OpenMLDatasetTestSparse(TestBase):
         self.assertListEqual(categorical, [False] * 19998)
         self.assertEqual(y.shape, (600, ))
 
+    def test_get_sparse_categorical_data_id_395(self):
+        dataset = openml.datasets.get_dataset(395, download_data=False)
+        feature = dataset.features[3758]
+        self.assertEqual(dataset.name, 're1.wc')
+        self.assertEqual(feature.name, 'CLASS_LABEL')
+        self.assertEqual(feature.data_type, 'nominal')
+        self.assertEqual(len(feature.nominal_values), 25)
+
 
 class OpenMLDatasetQualityTest(TestBase):
     def test__check_qualities(self):

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -9,6 +9,7 @@ from scipy import sparse
 import openml
 from openml.testing import TestBase
 from openml.exceptions import PyOpenMLError
+from openml.datasets import OpenMLDataset, OpenMLDataFeature
 
 
 class OpenMLDatasetTest(TestBase):
@@ -323,6 +324,8 @@ class OpenMLDatasetTestSparse(TestBase):
     def test_get_sparse_categorical_data_id_395(self):
         dataset = openml.datasets.get_dataset(395, download_data=False)
         feature = dataset.features[3758]
+        self.assertTrue(isinstance(dataset, OpenMLDataset))
+        self.assertTrue(isinstance(feature, OpenMLDataFeature))
         self.assertEqual(dataset.name, 're1.wc')
         self.assertEqual(feature.name, 'CLASS_LABEL')
         self.assertEqual(feature.data_type, 'nominal')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog!
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #758. 

#### What does this PR implement/fix? Explain your changes.
There was a try block checking for a numpy based conversion. Converted that to pandas categorical encoding.

#### How should this PR be tested?
`import openml`
`openml.datasets.get_dataset(395)`