### PR TITLE
only check strings for new datasets

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -109,17 +109,18 @@ class OpenMLDataset(object):
                  paper_url=None, update_comment=None,
                  md5_checksum=None, data_file=None, features=None,
                  qualities=None, dataset=None):
-        if description and not re.match("^[\x00-\x7F]*$", description):
-            # not basiclatin (XSD complains)
-            raise ValueError("Invalid symbols in description: {}".format(
-                description))
-        if citation and not re.match("^[\x00-\x7F]*$", citation):
-            # not basiclatin (XSD complains)
-            raise ValueError("Invalid symbols in citation: {}".format(
-                citation))
-        if not re.match("^[a-zA-Z0-9_\\-\\.\\(\\),]+$", name):
-            # regex given by server in error message
-            raise ValueError("Invalid symbols in name: {}".format(name))
+        if dataset_id is None:
+            if description and not re.match("^[\x00-\x7F]*$", description):
+                # not basiclatin (XSD complains)
+                raise ValueError("Invalid symbols in description: {}".format(
+                    description))
+            if citation and not re.match("^[\x00-\x7F]*$", citation):
+                # not basiclatin (XSD complains)
+                raise ValueError("Invalid symbols in citation: {}".format(
+                    citation))
+            if not re.match("^[a-zA-Z0-9_\\-\\.\\(\\),]+$", name):
+                # regex given by server in error message
+                raise ValueError("Invalid symbols in name: {}".format(name))
         # TODO add function to check if the name is casual_string128
         # Attributes received by querying the RESTful API
         self.dataset_id = int(dataset_id) if dataset_id is not None else None


### PR DESCRIPTION
Follow up on #822: old datasets violate this restriction (thought I guess not the restrictions for the name?)

Does that need a test? It would maybe be easiest to roll back the schema to what it was?