### PR TITLE
Create OpenMLBase, have most OpenML objects derive from it

### DIFF
--- a/openml/base.py
+++ b/openml/base.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Tuple
 import webbrowser
 
 import openml.config
-from .utils import _tag_entity
+from .utils import _tag_openml_base
 
 
 class OpenMLBase(ABC):
@@ -104,7 +104,7 @@ class OpenMLBase(ABC):
         tag : str
             Tag to attach to the flow.
         """
-        _tag_entity('flow', self.id, tag)
+        _tag_openml_base(self, tag)
 
     def remove_tag(self, tag: str):
         """Removes a tag from this entity on the server.
@@ -114,4 +114,4 @@ class OpenMLBase(ABC):
         tag : str
             Tag to attach to the flow.
         """
-        _tag_entity('flow', self.id, tag, untag=True)
+        _tag_openml_base(self, tag, untag=True)

--- a/openml/base.py
+++ b/openml/base.py
@@ -1,0 +1,85 @@
+from typing import Optional, List, Tuple
+
+import openml.config
+from .utils import _tag_entity
+
+
+class OpenMLBase:
+    """ Base object for functionality that is shared across entities. """
+    entity_letter: str = None
+
+    def __init__(self, entity_id: Optional[int] = None):
+        self._entity_id = entity_id
+
+    def __repr__(self):
+        body_fields = self._get_repr_body_fields()
+        return self._apply_repr_template(body_fields)
+
+    @property
+    def id(self) -> Optional[int]:
+        """ The id of the entity, it is unique for its entity type. """
+        return self._entity_id
+
+    @property
+    def openml_url(self) -> Optional[str]:
+        """ The URL of the object on the server, if it was uploaded, else None. """
+        if self._entity_id is None:
+            return None
+        return self.__class__._url_for_id(self._entity_id)
+
+    @classmethod
+    def _url_for_id(cls, id_: int) -> str:
+        """ Return the OpenML URL for the object of the class entity with the given id. """
+        # Sample url for a flow: openml.org/f/123
+        base_url = "{}".format(openml.config.server[:-len('/api/v1/xml')])
+        return "{}/{}/{}".format(base_url, cls.entity_letter, id_)
+
+    def _get_repr_body_fields(self) -> List[Tuple[str, str]]:
+        """ Collect all information to display in the __repr__ body.
+
+        Returns
+        ------
+        body_fields: List[Tuple[str, str]]
+            A list of (name, value) pairs to display in the body of the __repr__.
+            E.g.: [('metric', 'accuracy'), ('dataset', 'iris')]
+        """
+        # Should be implemented in the base class.
+        return []
+
+    def _apply_repr_template(self, body_fields: List[Tuple[str, str]]) -> str:
+        """ Generates the header and formats the body for string representation of the object.
+
+         Parameters
+         ----------
+         body_fields: List[Tuple[str, str]]
+            A list of (name, value) pairs to display in the body of the __repr__.
+         """
+        # Add a space in the class name, e.g. OpenMLFlow -> OpenML Flow
+        entity_name = '{} {}'.format(self.__class__.__name__[:len('OpenML')],
+                                     self.__class__.__name__[len('OpenML'):])
+        header = '{}\n{}\n'.format(entity_name, '=' * len(entity_name))
+
+        longest_field_name_length = max(len(name) for name, value in body_fields)
+        field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)
+        body = '\n'.join(field_line_format.format(name, value) for name, value in body_fields)
+        return header + body
+
+    def push_tag(self, tag):
+        """Annotates this entity with a tag on the server.
+
+        Parameters
+        ----------
+        tag : str
+            Tag to attach to the flow.
+        """
+        _tag_entity('flow', self._entity_id, tag)
+
+    def remove_tag(self, tag):
+        """Removes a tag from this entity on the server.
+
+        Parameters
+        ----------
+        tag : str
+            Tag to attach to the flow.
+        """
+        _tag_entity('flow', self._entity_id, tag, untag=True)

--- a/openml/base.py
+++ b/openml/base.py
@@ -96,7 +96,7 @@ class OpenMLBase(ABC):
         """ Opens the OpenML web page corresponding to this object in your default browser. """
         webbrowser.open(self.openml_url)
 
-    def push_tag(self, tag):
+    def push_tag(self, tag: str):
         """Annotates this entity with a tag on the server.
 
         Parameters
@@ -106,7 +106,7 @@ class OpenMLBase(ABC):
         """
         _tag_entity('flow', self.id, tag)
 
-    def remove_tag(self, tag):
+    def remove_tag(self, tag: str):
         """Removes a tag from this entity on the server.
 
         Parameters

--- a/openml/base.py
+++ b/openml/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import re
-from typing import Optional, List, Tuple, OrderedDict
+from typing import Optional, List, Tuple
 import webbrowser
 
 import xmltodict
@@ -17,23 +17,10 @@ class OpenMLBase(ABC):
         return self._apply_repr_template(body_fields)
 
     @property
+    @abstractmethod
     def id(self) -> Optional[int]:
         """ The id of the entity, it is unique for its entity type. """
-        from openml.datasets.dataset import OpenMLDataset
-        from openml.flows.flow import OpenMLFlow
-        from openml.runs.run import OpenMLRun
-        from openml.study.study import BaseStudy
-        from openml.tasks.task import OpenMLTask
-        if isinstance(self, OpenMLDataset):
-            return self.dataset_id
-        if isinstance(self, OpenMLFlow):
-            return self.flow_id
-        if isinstance(self, OpenMLRun):
-            return self.run_id
-        if isinstance(self, BaseStudy):
-            return self.study_id
-        if isinstance(self, OpenMLTask):
-            return self.task_id
+        pass
 
     @property
     def openml_url(self) -> Optional[str]:
@@ -95,7 +82,7 @@ class OpenMLBase(ABC):
         return header + body
 
     @abstractmethod
-    def _to_dict(self) -> OrderedDict[str, OrderedDict]:
+    def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
         """ Generate a dict representation of self. """
         # Should be implemented in the base class.
         pass

--- a/openml/base.py
+++ b/openml/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 import re
 from typing import Optional, List, Tuple
 import webbrowser
@@ -33,8 +34,7 @@ class OpenMLBase(ABC):
     def url_for_id(cls, id_: int) -> str:
         """ Return the OpenML URL for the object of the class entity with the given id. """
         # Sample url for a flow: openml.org/f/123
-        base_url = "{}".format(openml.config.server[:-len('/api/v1/xml')])
-        return "{}/{}/{}".format(base_url, cls._entity_letter(), id_)
+        return "{}/{}/{}".format(openml.config.server_base_url, cls._entity_letter(), id_)
 
     @classmethod
     def _entity_letter(cls):

--- a/openml/base.py
+++ b/openml/base.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, Tuple
+import webbrowser
 
 import openml.config
 from .utils import _tag_entity
@@ -83,6 +84,10 @@ class OpenMLBase:
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)
         body = '\n'.join(field_line_format.format(name, value) for name, value in body_fields)
         return header + body
+
+    def open_in_browser(self):
+        """ Opens the OpenML web page corresponding to this object in your default browser. """
+        webbrowser.open(self.openml_url)
 
     def push_tag(self, tag):
         """Annotates this entity with a tag on the server.

--- a/openml/base.py
+++ b/openml/base.py
@@ -40,13 +40,7 @@ class OpenMLBase(ABC):
     def _entity_letter(cls):
         """ Return the letter which represents the entity type in urls, e.g. 'f' for flow."""
         # We take advantage of the class naming convention (OpenMLX),
-        # which holds for all entities except studies.
-        from openml.study.study import BaseStudy
-        from openml.tasks.task import OpenMLTask
-        if issubclass(cls, BaseStudy):
-            return 's'
-        if issubclass(cls, OpenMLTask):
-            return 't'
+        # which holds for all entities except studies and tasks, which overwrite this method.
         return cls.__name__.lower()[len('OpenML'):][0]
 
     @abstractmethod

--- a/openml/base.py
+++ b/openml/base.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 import re
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, OrderedDict
 import webbrowser
+
+import xmltodict
 
 import openml.config
 from .utils import _tag_openml_base
@@ -91,6 +93,28 @@ class OpenMLBase(ABC):
         field_line_format = "{{:.<{}}}: {{}}".format(longest_field_name_length)
         body = '\n'.join(field_line_format.format(name, value) for name, value in body_fields)
         return header + body
+
+    @abstractmethod
+    def _to_dict(self) -> OrderedDict[str, OrderedDict]:
+        """ Generate a dict representation of self. """
+        # Should be implemented in the base class.
+        pass
+
+    def _to_xml(self) -> str:
+        """Generate xml representation of self for upload to server.
+
+        Returns
+        -------
+        str
+            Task represented as XML string.
+        """
+        dict_representation = self._to_dict()
+        xml_representation = xmltodict.unparse(dict_representation, pretty=True)
+
+        # A task may not be uploaded with the xml encoding specification:
+        # <?xml version="1.0" encoding="utf-8"?>
+        encoding_specification, xml_body = xml_representation.split('\n', 1)
+        return xml_body
 
     def open_in_browser(self):
         """ Opens the OpenML web page corresponding to this object in your default browser. """

--- a/openml/config.py
+++ b/openml/config.py
@@ -28,7 +28,8 @@ config_file = os.path.expanduser(os.path.join('~', '.openml', 'config'))
 
 # Default values are actually added here in the _setup() function which is
 # called at the end of this module
-server = _defaults['server']
+server = str(_defaults['server'])  # so mypy knows it is a string
+server_base_url = server[:-len('/api/v1/xml')]
 apikey = _defaults['apikey']
 # The current cache directory (without the server name)
 cache_directory = _defaults['cachedir']

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -780,7 +780,7 @@ class OpenMLDataset(OpenMLBase):
                  'citation', 'tag', 'visibility', 'original_data_url',
                  'paper_url', 'update_comment', 'md5_checksum']
 
-        data_container = OrderedDict()  # type: 'OrderedDict[str, Union[Dict, str]]'
+        data_container = OrderedDict()  # type: 'OrderedDict[str, OrderedDict]'
         data_dict = OrderedDict([('@xmlns:oml', 'http://openml.org/openml')])
         data_container['oml:data_set_description'] = data_dict
 

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -18,7 +18,6 @@ import openml._api_calls
 from openml.base import OpenMLBase
 from .data_feature import OpenMLDataFeature
 from ..exceptions import PyOpenMLError
-from ..utils import _tag_entity
 
 
 logger = logging.getLogger(__name__)

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -761,13 +761,13 @@ class OpenMLDataset(OpenMLBase):
         self.dataset_id = int(response['oml:upload_data_set']['oml:id'])
         return self.dataset_id
 
-    def _to_xml(self):
-        """ Serialize object to xml for upload
+    def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
+        """ Creates a dictionary representation of self.
 
         Returns
         -------
-        xml_dataset : str
-            XML description of the data.
+        data_container : OrderedDict[str, OrderedDict]
+            Dataset represented as OrderedDict.
         """
         props = ['id', 'name', 'version', 'description', 'format', 'creator',
                  'contributor', 'collection_date', 'upload_date', 'language',
@@ -785,14 +785,7 @@ class OpenMLDataset(OpenMLBase):
             if content is not None:
                 data_dict["oml:" + prop] = content
 
-        xml_string = xmltodict.unparse(
-            input_dict=data_container,
-            pretty=True,
-        )
-        # A flow may not be uploaded with the xml encoding specification:
-        # <?xml version="1.0" encoding="utf-8"?>
-        xml_string = xml_string.split('\n', 1)[-1]
-        return xml_string
+        return data_container
 
 
 def _check_qualities(qualities):

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -184,6 +184,10 @@ class OpenMLDataset(OpenMLBase):
         else:
             self.data_pickle_file = None
 
+    @property
+    def id(self):
+        return self.dataset_id
+
     def _get_repr_body_fields(self):
         fields = {"Name": self.name,
                   "Version": self.version,
@@ -776,7 +780,7 @@ class OpenMLDataset(OpenMLBase):
                  'citation', 'tag', 'visibility', 'original_data_url',
                  'paper_url', 'update_comment', 'md5_checksum']
 
-        data_container = OrderedDict()
+        data_container = OrderedDict()  # type: 'OrderedDict[str, Union[Dict, str]]'
         data_dict = OrderedDict([('@xmlns:oml', 'http://openml.org/openml')])
         data_container['oml:data_set_description'] = data_dict
 

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -185,10 +185,11 @@ class OpenMLDataset(OpenMLBase):
             self.data_pickle_file = None
 
     @property
-    def id(self):
+    def id(self) -> Optional[int]:
         return self.dataset_id
 
-    def _get_repr_body_fields(self):
+    def _get_repr_body_fields(self) -> List[Tuple[str, Union[str, int, List[str]]]]:
+        """ Collect all information to display in the __repr__ body. """
         fields = {"Name": self.name,
                   "Version": self.version,
                   "Format": self.format,
@@ -766,13 +767,7 @@ class OpenMLDataset(OpenMLBase):
         return self.dataset_id
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
-        """ Creates a dictionary representation of self.
-
-        Returns
-        -------
-        data_container : OrderedDict[str, OrderedDict]
-            Dataset represented as OrderedDict.
-        """
+        """ Creates a dictionary representation of self. """
         props = ['id', 'name', 'version', 'description', 'format', 'creator',
                  'contributor', 'collection_date', 'upload_date', 'language',
                  'licence', 'url', 'default_target_attribute',

--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -61,18 +61,17 @@ class OpenMLEvaluation(object):
         header = "OpenML Evaluation"
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
-        base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
         fields = {"Upload Date": self.upload_time,
                   "Run ID": self.run_id,
-                  "OpenML Run URL": "{}r/{}".format(base_url, self.run_id),
+                  "OpenML Run URL": openml.runs.OpenMLRun.url_for_id(self.run_id),
                   "Task ID": self.task_id,
-                  "OpenML Task URL": "{}t/{}".format(base_url, self.task_id),
+                  "OpenML Task URL": openml.tasks.OpenMLTask.url_for_id(self.task_id),
                   "Flow ID": self.flow_id,
-                  "OpenML Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "OpenML Flow URL": openml.flows.OpenMLFlow.url_for_id(self.flow_id),
                   "Setup ID": self.setup_id,
                   "Data ID": self.data_id,
                   "Data Name": self.data_name,
-                  "OpenML Data URL": "{}d/{}".format(base_url, self.data_id),
+                  "OpenML Data URL": openml.datasets.OpenMLDataset.url_for_id(self.data_id),
                   "Metric Used": self.function,
                   "Result": self.value}
 

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 import os
-from typing import Dict, List  # noqa: F401
+from typing import Dict, List, Union  # noqa: F401
 
 import xmltodict
 
@@ -134,6 +134,10 @@ class OpenMLFlow(OpenMLBase):
             self._extension = get_extension_by_flow(self)
         else:
             self._extension = extension
+
+    @property
+    def id(self):
+        return self.flow_id
 
     @property
     def extension(self):

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -162,23 +162,7 @@ class OpenMLFlow(OpenMLBase):
                  "Upload Date", "Dependencies"]
         return [(key, fields[key]) for key in order if key in fields]
 
-    def _to_xml(self) -> str:
-        """Generate xml representation of self for upload to server.
-
-        Returns
-        -------
-        str
-            Flow represented as XML string.
-        """
-        flow_dict = self._to_dict()
-        flow_xml = xmltodict.unparse(flow_dict, pretty=True)
-
-        # A flow may not be uploaded with the xml encoding specification:
-        # <?xml version="1.0" encoding="utf-8"?>
-        flow_xml = flow_xml.split('\n', 1)[-1]
-        return flow_xml
-
-    def _to_dict(self) -> dict:
+    def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
         """ Helper function used by _to_xml and itself.
 
         Creates a dictionary representation of self which can be serialized

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -87,7 +87,6 @@ class OpenMLFlow(OpenMLBase):
                  binary_url=None, binary_format=None,
                  binary_md5=None, uploader=None, upload_date=None,
                  flow_id=None, extension=None, version=None):
-        super().__init__(entity_id=flow_id)
         self.name = name
         self.description = description
         self.model = model

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 import os
-from typing import Dict, List, Union  # noqa: F401
+from typing import Dict, List, Union, Tuple, Optional  # noqa: F401
 
 import xmltodict
 
@@ -136,7 +136,7 @@ class OpenMLFlow(OpenMLBase):
             self._extension = extension
 
     @property
-    def id(self):
+    def id(self) -> Optional[int]:
         return self.flow_id
 
     @property
@@ -147,7 +147,8 @@ class OpenMLFlow(OpenMLBase):
             raise RuntimeError("No extension could be found for flow {}: {}"
                                .format(self.flow_id, self.name))
 
-    def _get_repr_body_fields(self):
+    def _get_repr_body_fields(self) -> List[Tuple[str, Union[str, int, List[str]]]]:
+        """ Collect all information to display in the __repr__ body. """
         fields = {"Flow Name": self.name,
                   "Flow Description": self.description,
                   "Dependencies": self.dependencies}
@@ -167,24 +168,7 @@ class OpenMLFlow(OpenMLBase):
         return [(key, fields[key]) for key in order if key in fields]
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
-        """ Helper function used by _to_xml and itself.
-
-        Creates a dictionary representation of self which can be serialized
-        to xml by the function _to_xml. Since a flow can contain subflows
-        (components) this helper function calls itself recursively to also
-        serialize these flows to dictionaries.
-
-        Uses OrderedDict to ensure consistent ordering when converting to xml.
-        The return value (OrderedDict) will be used to create the upload xml
-        file. The xml file must have the tags in exactly the order given in the
-        xsd schema of a flow (see class docstring).
-
-        Returns
-        -------
-        OrderedDict
-            Flow represented as OrderedDict.
-
-        """
+        """ Creates a dictionary representation of self. """
         flow_container = OrderedDict()  # type: 'OrderedDict[str, OrderedDict]'
         flow_dict = OrderedDict([('@xmlns:oml', 'http://openml.org/openml')])  # type: 'OrderedDict[str, Union[List, str]]'  # noqa E501
         flow_container['oml:flow'] = flow_dict

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -425,7 +425,7 @@ def assert_flows_equal(flow1: OpenMLFlow, flow2: OpenMLFlow,
                                # but the uploader has no control over them!
                                'tags']
     ignored_by_python_api = ['binary_url', 'binary_format', 'binary_md5',
-                             'model']
+                             'model', '_entity_id']
 
     for key in set(flow1.__dict__.keys()).union(flow2.__dict__.keys()):
         if key in generated_by_the_server + ignored_by_python_api:

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -96,9 +96,6 @@ class OpenMLRun(OpenMLBase):
                  "Setup ID", "Setup String", "Dataset ID", "Dataset URL"]
         return [(key, fields[key]) for key in order if key in fields]
 
-    def _repr_pretty_(self, pp, cycle):
-        pp.text(str(self))
-
     @classmethod
     def from_filesystem(cls, directory: str, expect_model: bool = True) -> 'OpenMLRun':
         """

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -87,8 +87,8 @@ class OpenMLRun(OpenMLBase):
                   "Dataset ID": self.dataset_id,
                   "Dataset URL": openml.datasets.OpenMLDataset.url_for_id(self.dataset_id)}
         if self.uploader is not None:
-            base_url = "{}".format(openml.config.server[:-len('/api/v1/xml')])
-            fields["Uploader Profile"] = "{}/u/{}".format(base_url, self.uploader)
+            fields["Uploader Profile"] = "{}/u/{}".format(openml.config.server_base_url,
+                                                          self.uploader)
         if self.run_id is not None:
             fields["Run URL"] = self.openml_url
         if self.evaluations is not None and self.task_evaluation_measure in self.evaluations:
@@ -507,7 +507,7 @@ class OpenMLRun(OpenMLBase):
         -------
         result : an array with version information of the above packages
         """  # noqa: W605
-        description = OrderedDict()
+        description = OrderedDict()  # type: 'OrderedDict'
         description['oml:run'] = OrderedDict()
         description['oml:run']['@xmlns:oml'] = 'http://openml.org/openml'
         description['oml:run']['oml:task_id'] = self.task_id

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import pickle
 import time
-from typing import Any, IO, TextIO  # noqa F401
+from typing import Any, IO, TextIO, List, Union, Tuple, Optional  # noqa F401
 import os
 
 import arff
@@ -69,10 +69,11 @@ class OpenMLRun(OpenMLBase):
         self.predictions_url = predictions_url
 
     @property
-    def id(self):
+    def id(self) -> Optional[int]:
         return self.run_id
 
-    def _get_repr_body_fields(self):
+    def _get_repr_body_fields(self) -> List[Tuple[str, Union[str, int, List[str]]]]:
+        """ Collect all information to display in the __repr__ body. """
         fields = {"Uploader Name": self.uploader_name,
                   "Metric": self.task_evaluation_measure,
                   "Run ID": self.run_id,
@@ -482,31 +483,7 @@ class OpenMLRun(OpenMLBase):
         return self
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
-        """ Creates a dictionary corresponding to the desired xml desired by openML
-
-        Parameters
-        ----------
-        taskid : int
-            the identifier of the task
-        setup_string : string
-            a CLI string which can invoke the learning with the correct parameter
-            settings
-        parameter_settings : array of dicts
-            each dict containing keys name, value and component, one per parameter
-            setting
-        tags : array of strings
-            information that give a description of the run, must conform to
-            regex ``([a-zA-Z0-9_\-\.])+``
-        fold_evaluations : dict mapping from evaluation measure to a dict mapping
-            repeat_nr to a dict mapping from fold nr to a value (double)
-        sample_evaluations : dict mapping from evaluation measure to a dict
-            mapping repeat_nr to a dict mapping from fold nr to a dict mapping to
-            a sample nr to a value (double)
-        sample_evaluations :
-        Returns
-        -------
-        result : an array with version information of the above packages
-        """  # noqa: W605
+        """ Creates a dictionary representation of self. """
         description = OrderedDict()  # type: 'OrderedDict'
         description['oml:run'] = OrderedDict()
         description['oml:run']['@xmlns:oml'] = 'http://openml.org/openml'

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -68,6 +68,10 @@ class OpenMLRun(OpenMLBase):
         self.tags = tags
         self.predictions_url = predictions_url
 
+    @property
+    def id(self):
+        return self.run_id
+
     def _get_repr_body_fields(self):
         fields = {"Uploader Name": self.uploader_name,
                   "Metric": self.task_evaluation_measure,

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -20,7 +20,6 @@ from ..tasks import (get_task,
                      OpenMLClusteringTask,
                      OpenMLRegressionTask
                      )
-from ..utils import _tag_entity
 
 
 class OpenMLRun(OpenMLBase):

--- a/openml/runs/trace.py
+++ b/openml/runs/trace.py
@@ -31,7 +31,7 @@ class OpenMLRunTrace(object):
     """
 
     def __init__(self, run_id, trace_iterations):
-        self.run_id: Optional[int] = run_id
+        self.run_id = run_id
         self.trace_iterations = trace_iterations
 
     def get_selected_iteration(self, fold: int, repeat: int) -> int:
@@ -382,7 +382,7 @@ class OpenMLRunTrace(object):
 
     def __repr__(self):
         return '[Run id: %d, %d trace iterations]'.format(
-            -1 if self.run_id is None else self.run_id,
+            -1 if self.run_id is None else int(self.run_id),
             len(self.trace_iterations),
         )
 

--- a/openml/runs/trace.py
+++ b/openml/runs/trace.py
@@ -381,8 +381,8 @@ class OpenMLRunTrace(object):
         return cls(None, merged_trace)
 
     def __repr__(self):
-        return '[Run id: %d, %d trace iterations]'.format(
-            -1 if self.run_id is None else int(self.run_id),
+        return '[Run id: {}, {} trace iterations]'.format(
+            -1 if self.run_id is None else self.run_id,
             len(self.trace_iterations),
         )
 

--- a/openml/runs/trace.py
+++ b/openml/runs/trace.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import json
 import os
-from typing import List, Tuple  # noqa F401
+from typing import List, Tuple, Optional  # noqa F401
 
 import arff
 import xmltodict
@@ -31,7 +31,7 @@ class OpenMLRunTrace(object):
     """
 
     def __init__(self, run_id, trace_iterations):
-        self.run_id = run_id
+        self.run_id: Optional[int] = run_id
         self.trace_iterations = trace_iterations
 
     def get_selected_iteration(self, fold: int, repeat: int) -> int:

--- a/openml/setups/setup.py
+++ b/openml/setups/setup.py
@@ -31,10 +31,9 @@ class OpenMLSetup(object):
         header = "OpenML Setup"
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
-        base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
         fields = {"Setup ID": self.setup_id,
                   "Flow ID": self.flow_id,
-                  "Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "Flow URL": openml.flows.OpenMLFlow.url_for_id(self.flow_id),
                   "# of Parameters": len(self.parameters)}
 
         # determines the order in which the information will be printed
@@ -86,12 +85,11 @@ class OpenMLParameter(object):
         header = "OpenML Parameter"
         header = '{}\n{}\n'.format(header, '=' * len(header))
 
-        base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
         fields = {"ID": self.id,
                   "Flow ID": self.flow_id,
                   # "Flow Name": self.flow_name,
                   "Flow Name": self.full_name,
-                  "Flow URL": "{}f/{}".format(base_url, self.flow_id),
+                  "Flow URL": openml.flows.OpenMLFlow.url_for_id(self.flow_id),
                   "Parameter Name": self.parameter_name}
         # indented prints for parameter attributes
         # indention = 2 spaces + 1 | + 2 underscores

--- a/openml/study/functions.py
+++ b/openml/study/functions.py
@@ -120,7 +120,7 @@ def _get_study(id_: Union[int, str], entity_type) -> BaseStudy:
         if 'oml:setups' in result_dict:
             setups = [int(x) for x in result_dict['oml:setups']['oml:setup_id']]
         else:
-            raise ValueError('No setups attached to study!'.format(id_))
+            raise ValueError('No setups attached to study {}!'.format(id_))
         if 'oml:runs' in result_dict:
             runs = [
                 int(x) for x in result_dict['oml:runs']['oml:run_id']
@@ -130,7 +130,7 @@ def _get_study(id_: Union[int, str], entity_type) -> BaseStudy:
                 # Legacy studies did not require runs
                 runs = None
             else:
-                raise ValueError('No runs attached to study!'.format(id_))
+                raise ValueError('No runs attached to study {}!'.format(id_))
 
         study = OpenMLStudy(
             study_id=study_id,

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple, Union, Any
 
 import xmltodict
 
@@ -90,18 +90,18 @@ class BaseStudy(OpenMLBase):
         self.runs = runs
 
     @classmethod
-    def _entity_letter(cls):
+    def _entity_letter(cls) -> str:
         return 's'
 
     @property
-    def id(self):
+    def id(self) -> Optional[int]:
         return self.study_id
 
-    def _get_repr_body_fields(self):
-        # header is provided by the sub classes
+    def _get_repr_body_fields(self) -> List[Tuple[str, Union[str, int, List[str]]]]:
+        """ Collect all information to display in the __repr__ body. """
         fields = {"Name": self.name,
                   "Status": self.status,
-                  "Main Entity Type": self.main_entity_type}
+                  "Main Entity Type": self.main_entity_type}  # type: Dict[str, Any]
         if self.study_id is not None:
             fields["ID"] = self.study_id
             fields["Study URL"] = self.openml_url
@@ -146,13 +146,7 @@ class BaseStudy(OpenMLBase):
         return self.study_id
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
-        """ Creates a dictionary representation of self.
-
-        Returns
-        -------
-        data_container : OrderedDict[str, OrderedDict]
-            Dataset represented as OrderedDict.
-        """
+        """ Creates a dictionary representation of self. """
         # some can not be uploaded, e.g., id, creator, creation_date
         simple_props = ['alias', 'main_entity_type', 'name', 'description']
         # maps from attribute name (which is used as outer tag name) to immer

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -1,4 +1,4 @@
-import collections
+from collections import OrderedDict
 from typing import Dict, List, Optional
 
 import xmltodict
@@ -88,7 +88,6 @@ class BaseStudy(OpenMLBase):
         self.flows = flows
         self.setups = setups
         self.runs = runs
-        pass
 
     def _get_repr_body_fields(self):
         # header is provided by the sub classes
@@ -139,13 +138,13 @@ class BaseStudy(OpenMLBase):
         self.study_id = int(study_res['oml:study_upload']['oml:id'])
         return self.study_id
 
-    def _to_xml(self) -> str:
-        """Serialize object to xml for upload
+    def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
+        """ Creates a dictionary representation of self.
 
         Returns
         -------
-        xml_study : str
-            XML description of the data.
+        data_container : OrderedDict[str, OrderedDict]
+            Dataset represented as OrderedDict.
         """
         # some can not be uploaded, e.g., id, creator, creation_date
         simple_props = ['alias', 'main_entity_type', 'name', 'description']
@@ -157,9 +156,9 @@ class BaseStudy(OpenMLBase):
             'runs': 'run_id',
         }
 
-        study_container = collections.OrderedDict()  # type: 'collections.OrderedDict'
+        study_container = OrderedDict()  # type: 'collections.OrderedDict'
         namespace_list = [('@xmlns:oml', 'http://openml.org/openml')]
-        study_dict = collections.OrderedDict(namespace_list)  # type: 'collections.OrderedDict'
+        study_dict = OrderedDict(namespace_list)  # type: 'collections.OrderedDict'
         study_container['oml:study'] = study_dict
 
         for prop_name in simple_props:
@@ -173,15 +172,7 @@ class BaseStudy(OpenMLBase):
                     'oml:' + inner_name: content
                 }
                 study_dict["oml:" + prop_name] = sub_dict
-
-        xml_string = xmltodict.unparse(
-            input_dict=study_container,
-            pretty=True,
-        )
-        # A flow may not be uploaded with the xml encoding specification:
-        # <?xml version="1.0" encoding="utf-8"?>
-        xml_string = xml_string.split('\n', 1)[-1]
-        return xml_string
+        return study_container
 
     def push_tag(self, tag: str):
         raise NotImplementedError("Tags for studies is not (yet) supported.")

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -102,8 +102,7 @@ class BaseStudy(OpenMLBase):
             fields["ID"] = self.study_id
             fields["Study URL"] = self.openml_url
         if self.creator is not None:
-            base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-            fields["Creator"] = "{}u/{}".format(base_url, self.creator)
+            fields["Creator"] = "{}/u/{}".format(openml.config.server_base_url, self.creator)
         if self.creation_date is not None:
             fields["Upload Time"] = self.creation_date.replace('T', ' ')
         if self.data is not None:
@@ -160,9 +159,9 @@ class BaseStudy(OpenMLBase):
             'runs': 'run_id',
         }
 
-        study_container = OrderedDict()  # type: 'collections.OrderedDict'
+        study_container = OrderedDict()  # type: 'OrderedDict'
         namespace_list = [('@xmlns:oml', 'http://openml.org/openml')]
-        study_dict = OrderedDict(namespace_list)  # type: 'collections.OrderedDict'
+        study_dict = OrderedDict(namespace_list)  # type: 'OrderedDict'
         study_container['oml:study'] = study_dict
 
         for prop_name in simple_props:

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -89,6 +89,10 @@ class BaseStudy(OpenMLBase):
         self.setups = setups
         self.runs = runs
 
+    @classmethod
+    def _entity_letter(cls):
+        return 's'
+
     @property
     def id(self):
         return self.study_id

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -89,6 +89,10 @@ class BaseStudy(OpenMLBase):
         self.setups = setups
         self.runs = runs
 
+    @property
+    def id(self):
+        return self.study_id
+
     def _get_repr_body_fields(self):
         # header is provided by the sub classes
         fields = {"Name": self.name,

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -171,23 +171,6 @@ class OpenMLTask(OpenMLBase):
 
         return task_container
 
-    def _to_xml(self) -> str:
-        """Generate xml representation of self for upload to server.
-
-        Returns
-        -------
-        str
-            Task represented as XML string.
-        """
-        task_dict = self._to_dict()
-        task_xml = xmltodict.unparse(task_dict, pretty=True)
-
-        # A task may not be uploaded with the xml encoding specification:
-        # <?xml version="1.0" encoding="utf-8"?>
-        task_xml = task_xml.split('\n', 1)[-1]
-
-        return task_xml
-
     def publish(self) -> int:
         """Publish task to OpenML server.
 

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -57,7 +57,8 @@ class OpenMLTask(OpenMLBase):
         self.split = None  # type: Optional[OpenMLSplit]
 
     def _get_repr_body_fields(self):
-        fields = {"Task Type": self.task_type}
+        base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
+        fields = {"Task Type Description": '{}tt/{}'.format(base_url, self.task_type_id)}
         if self.task_id is not None:
             fields["Task ID"] = self.task_id
             fields["Task URL"] = self.openml_url
@@ -73,8 +74,8 @@ class OpenMLTask(OpenMLBase):
                 fields["Cost Matrix"] = "Available"
 
         # determines the order in which the information will be printed
-        order = ["Task Type", "Task ID", "Task URL", "Estimation Procedure", "Evaluation Measure",
-                 "Target Feature", "# of Classes", "Cost Matrix"]
+        order = ["Task Type Description", "Task ID", "Task URL", "Estimation Procedure",
+                 "Evaluation Measure", "Target Feature", "# of Classes", "Cost Matrix"]
         return [(key, fields[key]) for key in order if key in fields]
 
     def get_dataset(self) -> datasets.OpenMLDataset:

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -2,7 +2,7 @@ from abc import ABC
 from collections import OrderedDict
 import io
 import os
-from typing import Union, Tuple, Dict, List, Optional
+from typing import Union, Tuple, Dict, List, Optional, Any
 from warnings import warn
 
 import numpy as np
@@ -57,16 +57,17 @@ class OpenMLTask(OpenMLBase):
         self.split = None  # type: Optional[OpenMLSplit]
 
     @classmethod
-    def _entity_letter(cls):
+    def _entity_letter(cls) -> str:
         return 't'
 
     @property
-    def id(self):
+    def id(self) -> Optional[int]:
         return self.task_id
 
-    def _get_repr_body_fields(self):
-        fields = {"Task Type Description": '{}/tt/{}'.format(openml.config.server_base_url,
-                                                             self.task_type_id)}
+    def _get_repr_body_fields(self) -> List[Tuple[str, Union[str, int, List[str]]]]:
+        """ Collect all information to display in the __repr__ body. """
+        fields = {"Task Type Description": '{}/tt/{}'.format(
+            openml.config.server_base_url, self.task_type_id)}  # type: Dict[str, Any]
         if self.task_id is not None:
             fields["Task ID"] = self.task_id
             fields["Task URL"] = self.openml_url
@@ -146,7 +147,7 @@ class OpenMLTask(OpenMLBase):
         return self.split.repeats, self.split.folds, self.split.samples
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
-
+        """ Creates a dictionary representation of self. """
         task_container = OrderedDict()  # type: OrderedDict[str, OrderedDict]
         task_dict = OrderedDict([
             ('@xmlns:oml', 'http://openml.org/openml')

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -56,6 +56,10 @@ class OpenMLTask(OpenMLBase):
         self.estimation_procedure_id = estimation_procedure_id
         self.split = None  # type: Optional[OpenMLSplit]
 
+    @property
+    def id(self):
+        return self.task_id
+
     def _get_repr_body_fields(self):
         base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
         fields = {"Task Type Description": '{}tt/{}'.format(base_url, self.task_type_id)}

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -75,10 +75,10 @@ class OpenMLTask(OpenMLBase):
             fields["Evaluation Measure"] = self.evaluation_measure
         if self.estimation_procedure is not None:
             fields["Estimation Procedure"] = self.estimation_procedure['type']
-        if self.target_name is not None:
-            fields["Target Feature"] = self.target_name
+        if getattr(self, 'target_name', None) is not None:
+            fields["Target Feature"] = getattr(self, 'target_name')
             if hasattr(self, 'class_labels'):
-                fields["# of Classes"] = len(self.class_labels)
+                fields["# of Classes"] = len(getattr(self, 'class_labels'))
             if hasattr(self, 'cost_matrix'):
                 fields["Cost Matrix"] = "Available"
 

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -61,8 +61,8 @@ class OpenMLTask(OpenMLBase):
         return self.task_id
 
     def _get_repr_body_fields(self):
-        base_url = "{}".format(openml.config.server[:-len('api/v1/xml')])
-        fields = {"Task Type Description": '{}tt/{}'.format(base_url, self.task_type_id)}
+        fields = {"Task Type Description": '{}/tt/{}'.format(openml.config.server_base_url,
+                                                             self.task_type_id)}
         if self.task_id is not None:
             fields["Task ID"] = self.task_id
             fields["Task URL"] = self.openml_url

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -56,6 +56,10 @@ class OpenMLTask(OpenMLBase):
         self.estimation_procedure_id = estimation_procedure_id
         self.split = None  # type: Optional[OpenMLSplit]
 
+    @classmethod
+    def _entity_letter(cls):
+        return 't'
+
     @property
     def id(self):
         return self.task_id

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -68,7 +68,7 @@ def extract_xml_tags(xml_tag_name, node, allow_none=True):
                              (xml_tag_name, str(node)))
 
 
-def _tag_openml_base(oml_object: OpenMLBase, tag: str, untag: bool=False):
+def _tag_openml_base(oml_object: 'OpenMLBase', tag: str, untag: bool=False):
     rest_api_mapping = [
         (openml.datasets.OpenMLDataset, 'data'),
         (openml.flows.OpenMLFlow, 'flow'),

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -2,6 +2,7 @@ import os
 import hashlib
 import xmltodict
 import shutil
+from typing import TYPE_CHECKING
 import warnings
 import pandas as pd
 from functools import wraps
@@ -10,6 +11,11 @@ import collections
 import openml._api_calls
 import openml.exceptions
 from . import config
+
+# Avoid import cycles: https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+if TYPE_CHECKING:
+    from openml.base import OpenMLBase
+
 
 oslo_installed = False
 try:
@@ -60,6 +66,18 @@ def extract_xml_tags(xml_tag_name, node, allow_none=True):
         else:
             raise ValueError("Could not find tag '%s' in node '%s'" %
                              (xml_tag_name, str(node)))
+
+
+def _tag_openml_base(oml_object: OpenMLBase, tag: str, untag: bool=False):
+    rest_api_mapping = [
+        (openml.datasets.OpenMLDataset, 'data'),
+        (openml.flows.OpenMLFlow, 'flow'),
+        (openml.tasks.OpenMLTask, 'task'),
+        (openml.runs.OpenMLRun, 'run')
+    ]
+    _, api_type_alias = [(python_type, api_alias)
+                         for (python_type, api_alias) in rest_api_mapping][0]
+    _tag_entity(api_type_alias, oml_object.id, tag, untag)
 
 
 def _tag_entity(entity_type, entity_id, tag, untag=False):

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -68,7 +68,7 @@ def extract_xml_tags(xml_tag_name, node, allow_none=True):
                              (xml_tag_name, str(node)))
 
 
-def _tag_openml_base(oml_object: 'OpenMLBase', tag: str, untag: bool=False):
+def _tag_openml_base(oml_object: 'OpenMLBase', tag: str, untag: bool = False):
     rest_api_mapping = [
         (openml.datasets.OpenMLDataset, 'data'),
         (openml.flows.OpenMLFlow, 'flow'),

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -76,7 +76,8 @@ def _tag_openml_base(oml_object: 'OpenMLBase', tag: str, untag: bool=False):
         (openml.runs.OpenMLRun, 'run')
     ]
     _, api_type_alias = [(python_type, api_alias)
-                         for (python_type, api_alias) in rest_api_mapping][0]
+                         for (python_type, api_alias) in rest_api_mapping
+                         if isinstance(oml_object, python_type)][0]
     _tag_entity(api_type_alias, oml_object.id, tag, untag)
 
 

--- a/tests/test_runs/test_run.py
+++ b/tests/test_runs/test_run.py
@@ -46,8 +46,8 @@ class TestRun(TestBase):
                 other = getattr(run_prime, dictionary)
                 if other is not None:
                     self.assertDictEqual(other, dict())
-        self.assertEqual(run._create_description_xml(),
-                         run_prime._create_description_xml())
+        self.assertEqual(run._to_xml(),
+                         run_prime._to_xml())
 
         numeric_part = \
             np.array(np.array(run.data_content)[:, 0:-2], dtype=float)

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -206,7 +206,7 @@ class TestRun(TestBase):
 
         # This is only a smoke check right now
         # TODO add a few asserts here
-        run._create_description_xml()
+        run._to_xml()
         if run.trace is not None:
             # This is only a smoke check right now
             # TODO add a few asserts here


### PR DESCRIPTION
Several OpenML entities are sharing a lot of code in theory, but have copy paste duplicate code in practice. This PR introduces a base class from which OpenML entities can derive and share common logic. In this draft some bare basics are implemented and OpenMLFlow derives from it.

This will be further extended to make the other main entities (Dataset, Task, Run and Study) derive from the base class.
I will take a look at a few other functions shared between some or all of those types such as `_to_xml` and `publish`.

edit: looks like unit tests fail due to illegal type annotation for Py3.6, please ignore. The Flow unit tests worked locally, will fix it to be Py3.6 compatible.

edit: Also fixes #433 