### PR TITLE
also check dependencies for sklearn string

### DIFF
--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -490,7 +490,7 @@ class SklearnExtension(Extension):
 
     @classmethod
     def _is_sklearn_flow(cls, flow: OpenMLFlow) -> bool:
-        if "sklearn" in flow.dependencies:
+        if flow.dependencies is not None and "sklearn" in flow.dependencies:
             return True
         if flow.external_version is None:
             return False

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -490,6 +490,8 @@ class SklearnExtension(Extension):
 
     @classmethod
     def _is_sklearn_flow(cls, flow: OpenMLFlow) -> bool:
+        if "sklearn" in flow.dependencies:
+            return True
         if flow.external_version is None:
             return False
         else:

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -490,7 +490,8 @@ class SklearnExtension(Extension):
 
     @classmethod
     def _is_sklearn_flow(cls, flow: OpenMLFlow) -> bool:
-        if flow.dependencies is not None and "sklearn" in flow.dependencies:
+        if (getattr(flow, 'dependencies', None) is not None
+                and "sklearn" in flow.dependencies):
             return True
         if flow.external_version is None:
             return False

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -139,6 +139,16 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
             self.assertEqual(check_dependencies_mock.call_count, 1)
 
+    def test_can_handle_flow(self):
+        openml.config.server = self.production_server
+
+        R_flow = openml.flows.get_flow(6794)
+        assert not self.extension.can_handle_flow(R_flow)
+        old_3rd_party_flow = openml.flows.get_flow(7660)
+        assert self.extension.can_handle_flow(old_3rd_party_flow)
+
+        openml.config.server = self.test_server
+
     def test_serialize_model_clustering(self):
         with mock.patch.object(self.extension, '_check_dependencies') as check_dependencies_mock:
             model = sklearn.cluster.KMeans()


### PR DESCRIPTION
Fixes the remainder of #734.

We don't have the model at this point so we can't check the model.