### PR TITLE
warn if there's an empty flow description

### DIFF
--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -226,7 +226,7 @@ class OpenMLFlow(object):
 
         if not self.description:
             logger = logging.getLogger(__name__)
-            logger.warn("Flow {} has empty description".format(self.name))
+            logger.warn("Flow % has empty description", self.name)
 
         flow_parameters = []
         for key in self.parameters:

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import os
 from typing import Dict, List, Union  # noqa: F401
+import logging
 
 import xmltodict
 
@@ -222,6 +223,10 @@ class OpenMLFlow(object):
                           "upload_date", "language", "dependencies"]:
             _add_if_nonempty(flow_dict, 'oml:{}'.format(attribute),
                              getattr(self, attribute))
+
+        if not self.description:
+            logger = logging.getLogger(__name__)
+            logger.warn("Flow {} has empty description".format(self.name))
 
         flow_parameters = []
         for key in self.parameters:


### PR DESCRIPTION
This will raise a hard-to-debug XSD error when uploading. Catching this here allows identifying which flow it was.