### PR TITLE
Adding option to print logs during an api call

### DIFF
--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -53,9 +53,9 @@ def _perform_api_call(call, request_method, data=None, file_elements=None):
     else:
         response = _read_url(url, request_method, data)
     logging.info(
-        '%.7fs taken for [%s] request for the URL %s', 
-        time.time() - start, 
-        request_method, 
+        '%.7fs taken for [%s] request for the URL %s',
+        time.time() - start,
+        request_method,
         url,
     )
     return response

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -43,13 +43,17 @@ def _perform_api_call(call, request_method, data=None, file_elements=None):
     url += call
 
     url = url.replace('=', '%3d')
-    logging.info('[%s] %s'.format(request_method, url))
+    logging.info('Starting [%s] request for the URL %s', request_method, url)
+    start = time.time()
     if file_elements is not None:
         if request_method != 'post':
             raise ValueError('request method must be post when file elements '
                              'are present')
-        return _read_url_files(url, data=data, file_elements=file_elements)
-    return _read_url(url, request_method, data)
+        response = _read_url_files(url, data=data, file_elements=file_elements)
+    else:
+        response = _read_url(url, request_method, data)
+    logging.info('%.7fs taken for [%s] request for the URL %s', time.time() - start, request_method, url)
+    return response
 
 
 def _file_id_to_url(file_id, filename=None):
@@ -74,14 +78,12 @@ def _read_url_files(url, data=None, file_elements=None):
         file_elements = {}
     # Using requests.post sets header 'Accept-encoding' automatically to
     # 'gzip,deflate'
-    start = time.time()
     response = send_request(
         request_method='post',
         url=url,
         data=data,
         files=file_elements,
     )
-    logging.info("Time for POST request: {:.7f}s".format(time.time() - start))
     if response.status_code != 200:
         raise _parse_server_exception(response, url)
     if 'Content-Encoding' not in response.headers or \
@@ -96,9 +98,7 @@ def _read_url(url, request_method, data=None):
     if config.apikey is not None:
         data['api_key'] = config.apikey
 
-    start = time.time()
     response = send_request(request_method=request_method, url=url, data=data)
-    logging.info("Time for {} request: {:.7f}s".format(request_method, time.time() - start))
     if response.status_code != 200:
         raise _parse_server_exception(response, url)
     if 'Content-Encoding' not in response.headers or \

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -43,7 +43,7 @@ def _perform_api_call(call, request_method, data=None, file_elements=None):
     url += call
 
     url = url.replace('=', '%3d')
-    logging.info('[%s] %s' % (request_method, url))
+    logging.info('[%s] %s'.format(request_method, url))
     if file_elements is not None:
         if request_method != 'post':
             raise ValueError('request method must be post when file elements '
@@ -74,12 +74,14 @@ def _read_url_files(url, data=None, file_elements=None):
         file_elements = {}
     # Using requests.post sets header 'Accept-encoding' automatically to
     # 'gzip,deflate'
+    start = time.time()
     response = send_request(
         request_method='post',
         url=url,
         data=data,
         files=file_elements,
     )
+    logging.info("Time for POST request: {:.7f}s".format(time.time() - start))
     if response.status_code != 200:
         raise _parse_server_exception(response, url)
     if 'Content-Encoding' not in response.headers or \
@@ -94,7 +96,9 @@ def _read_url(url, request_method, data=None):
     if config.apikey is not None:
         data['api_key'] = config.apikey
 
+    start = time.time()
     response = send_request(request_method=request_method, url=url, data=data)
+    logging.info("Time for {} request: {:.7f}s".format(request_method, time.time() - start))
     if response.status_code != 200:
         raise _parse_server_exception(response, url)
     if 'Content-Encoding' not in response.headers or \

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -1,4 +1,5 @@
 import time
+import logging
 import requests
 import warnings
 
@@ -42,7 +43,7 @@ def _perform_api_call(call, request_method, data=None, file_elements=None):
     url += call
 
     url = url.replace('=', '%3d')
-
+    logging.info('[%s] %s' % (request_method, url))
     if file_elements is not None:
         if request_method != 'post':
             raise ValueError('request method must be post when file elements '

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -52,7 +52,12 @@ def _perform_api_call(call, request_method, data=None, file_elements=None):
         response = _read_url_files(url, data=data, file_elements=file_elements)
     else:
         response = _read_url(url, request_method, data)
-    logging.info('%.7fs taken for [%s] request for the URL %s', time.time() - start, request_method, url)
+    logging.info(
+        '%.7fs taken for [%s] request for the URL %s', 
+        time.time() - start, 
+        request_method, 
+        url,
+    )
     return response
 
 


### PR DESCRIPTION
#### What does this PR implement/fix? Explain your changes.
Adds a `logger.info` which can be used to track what is happening during wait times for a long api call.


