### PR TITLE
Add automatic type conversion prototype

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -123,7 +123,7 @@ class OpenMLDataset(object):
                 raise ValueError("Invalid symbols in name: {}".format(name))
         # TODO add function to check if the name is casual_string128
         # Attributes received by querying the RESTful API
-        self.dataset_id = int(dataset_id) if dataset_id is not None else None
+        self.dataset_id = dataset_id
         self.name = name
         self.version = int(version) if version is not None else None
         self.description = description


### PR DESCRIPTION
@janvanrijn @mllg these are some simple changes necessary to work with the type information added to the dataset today: `<oml:id type="xs:integer">2</oml:id>`. Will we keep it that way or will this be reverted?

