### PR TITLE
Fix 838

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.10.0
 ~~~~~~
+* FIX #838: Fix list_evaluations_setups to work when evaluations are not a 100 multiple.
 * ADD #737: Add list_evaluations_setups to return hyperparameters along with list of evaluations.
 * FIX #261: Test server is cleared of all files uploaded during unit testing.
 * FIX #447: All files created by unit tests no longer persist in local.

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -324,14 +324,15 @@ def list_evaluations_setups(
     evals = list_evaluations(function=function, offset=offset, size=size, run=run, task=task,
                              setup=setup, flow=flow, uploader=uploader, tag=tag,
                              per_fold=per_fold, sort_order=sort_order, output_format='dataframe')
-
+    print("evals done")
     # List setups
     # Split setups in evals into chunks of N setups as list_setups does not support large size
     df = pd.DataFrame()
     if len(evals) != 0:
         N = 100
-        setup_chunks = np.split(evals['setup_id'].unique(),
+        setup_chunks = np.array_split(evals['setup_id'].unique(),
                                 ((len(evals['setup_id'].unique()) - 1) // N) + 1)
+        print( len(evals['setup_id'].unique()),((len(evals['setup_id'].unique()) - 1) // N) + 1)
         setups = pd.DataFrame()
         for setup in setup_chunks:
             result = pd.DataFrame(openml.setups.list_setups(setup=setup, output_format='dataframe'))
@@ -353,6 +354,7 @@ def list_evaluations_setups(
     if parameters_in_separate_columns:
         df = pd.concat([df.drop('parameters', axis=1),
                         df['parameters'].apply(pd.Series)], axis=1)
+    print("done")
 
     if output_format == 'dataframe':
         return df

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -331,8 +331,7 @@ def list_evaluations_setups(
     if len(evals) != 0:
         N = 100
         setup_chunks = np.array_split(evals['setup_id'].unique(),
-                                ((len(evals['setup_id'].unique()) - 1) // N) + 1)
-        print( len(evals['setup_id'].unique()),((len(evals['setup_id'].unique()) - 1) // N) + 1)
+                                      ((len(evals['setup_id'].unique()) - 1) // N) + 1)
         setups = pd.DataFrame()
         for setup in setup_chunks:
             result = pd.DataFrame(openml.setups.list_setups(setup=setup, output_format='dataframe'))
@@ -354,7 +353,6 @@ def list_evaluations_setups(
     if parameters_in_separate_columns:
         df = pd.concat([df.drop('parameters', axis=1),
                         df['parameters'].apply(pd.Series)], axis=1)
-    print("done")
 
     if output_format == 'dataframe':
         return df

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -324,7 +324,6 @@ def list_evaluations_setups(
     evals = list_evaluations(function=function, offset=offset, size=size, run=run, task=task,
                              setup=setup, flow=flow, uploader=uploader, tag=tag,
                              per_fold=per_fold, sort_order=sort_order, output_format='dataframe')
-    print("evals done")
     # List setups
     # Split setups in evals into chunks of N setups as list_setups does not support large size
     df = pd.DataFrame()

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -195,4 +195,3 @@ class TestEvaluationFunctions(TestBase):
         task_id = [6]
         size = 121
         self._check_list_evaluation_setups(task=task_id, size=size)
-

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -193,11 +193,6 @@ class TestEvaluationFunctions(TestBase):
     def test_list_evaluations_setups_filter_task(self):
         openml.config.server = self.production_server
         task_id = [6]
-        size = 100
+        size = 121
         self._check_list_evaluation_setups(task=task_id, size=size)
 
-    def test_list_evaluations_setups_not_100_multiple(self):
-        openml.config.server = self.production_server
-        task_id = [37]
-        flow_id = [5891]
-        self._check_list_evaluation_setups(task=task_id, flow=flow_id)

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -6,18 +6,20 @@ from openml.testing import TestBase
 class TestEvaluationFunctions(TestBase):
     _multiprocess_can_split_ = True
 
-    def _check_list_evaluation_setups(self, size, **kwargs):
+    def _check_list_evaluation_setups(self, **kwargs):
         evals_setups = openml.evaluations.list_evaluations_setups("predictive_accuracy",
-                                                                  **kwargs, size=size,
+                                                                  **kwargs,
                                                                   sort_order='desc',
                                                                   output_format='dataframe')
         evals = openml.evaluations.list_evaluations("predictive_accuracy",
-                                                    **kwargs, size=size,
+                                                    **kwargs,
                                                     sort_order='desc',
                                                     output_format='dataframe')
 
         # Check if list is non-empty
         self.assertGreater(len(evals_setups), 0)
+        # Check if length is accurate
+        self.assertEqual(len(evals_setups), len(evals))
         # Check if output from sort is sorted in the right order
         self.assertSequenceEqual(sorted(evals_setups['value'].tolist(), reverse=True),
                                  evals_setups['value'].tolist())
@@ -176,7 +178,7 @@ class TestEvaluationFunctions(TestBase):
         openml.config.server = self.production_server
         flow_id = [405]
         size = 100
-        evals = self._check_list_evaluation_setups(size, flow=flow_id)
+        evals = self._check_list_evaluation_setups(flow=flow_id, size=size)
         # check if parameters in separate columns works
         evals_cols = openml.evaluations.list_evaluations_setups("predictive_accuracy",
                                                                 flow=flow_id, size=size,
@@ -192,4 +194,10 @@ class TestEvaluationFunctions(TestBase):
         openml.config.server = self.production_server
         task_id = [6]
         size = 100
-        self._check_list_evaluation_setups(size, task=task_id)
+        self._check_list_evaluation_setups(task=task_id, size=size)
+
+    def test_list_evaluations_setups_not_100_multiple(self):
+        openml.config.server = self.production_server
+        task_id = [37]
+        flow_id = [5891]
+        self._check_list_evaluation_setups(task=task_id, flow=flow_id)


### PR DESCRIPTION

#### Reference Issue
Fixes #838 


#### What does this PR implement/fix? Explain your changes.
fix list_evaluations_setups to work for evaluations that are not a 100 multiple

#### How should this PR be tested?
```
df = openml.evaluations.list_evaluations_setups(function='predictive_accuracy', flow=[5891], task=[37], output_format='dataframe', parameters_in_separate_columns=True)

len(df) #2429

```
#### Any other comments?
changed the existing test to get a size that is not a multiple of 100
