### PR TITLE
Allow datasets without qualities to be downloaded.

### DIFF
--- a/examples/20_basic/simple_suites_tutorial.py
+++ b/examples/20_basic/simple_suites_tutorial.py
@@ -50,7 +50,7 @@ tasks = suite.tasks
 print(tasks)
 
 ####################################################################################################
-# and iterated over for benchmarking. For speed reasons we'll only iterate over the first three tasks:
+# and iterated over for benchmarking. For speed reasons we only iterate over the first three tasks:
 
 for task_id in tasks[:3]:
     task = openml.tasks.get_task(task_id)

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -495,19 +495,18 @@ def get_dataset(
     )
 
     try:
-        qualities = _get_dataset_qualities(did_cache_dir, dataset_id)
-    except OpenMLServerException as e:
-        if not (e.code == 362 and str(e) == 'No qualities found - None'):
-            raise
-        qualities = None
-
-    try:
         remove_dataset_cache = True
         description = _get_dataset_description(did_cache_dir, dataset_id)
         features = _get_dataset_features(did_cache_dir, dataset_id)
 
-        arff_file = _get_dataset_arff(description) if download_data else None
+        try:
+            qualities = _get_dataset_qualities(did_cache_dir, dataset_id)
+        except OpenMLServerException as e:
+            if not (e.code == 362 and str(e) == 'No qualities found - None'):
+                raise
+            qualities = None
 
+        arff_file = _get_dataset_arff(description) if download_data else None
         remove_dataset_cache = False
     except OpenMLServerException as e:
         # if there was an exception,

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -495,10 +495,16 @@ def get_dataset(
     )
 
     try:
+        qualities = _get_dataset_qualities(did_cache_dir, dataset_id)
+    except OpenMLServerException as e:
+        if not (e.code == 362 and str(e) == 'No qualities found - None'):
+            raise
+        qualities = None
+
+    try:
         remove_dataset_cache = True
         description = _get_dataset_description(did_cache_dir, dataset_id)
         features = _get_dataset_features(did_cache_dir, dataset_id)
-        qualities = _get_dataset_qualities(did_cache_dir, dataset_id)
 
         arff_file = _get_dataset_arff(description) if download_data else None
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import os
 import re
 from typing import List, Dict, Union, Optional
@@ -28,6 +29,7 @@ from ..utils import (
 
 
 DATASETS_CACHE_DIR_NAME = 'datasets'
+logger = logging.getLogger(__name__)
 
 ############################################################################
 # Local getters/accessors to the cache directory
@@ -502,9 +504,11 @@ def get_dataset(
         try:
             qualities = _get_dataset_qualities(did_cache_dir, dataset_id)
         except OpenMLServerException as e:
-            if not (e.code == 362 and str(e) == 'No qualities found - None'):
+            if e.code == 362 and str(e) == 'No qualities found - None':
+                logger.warning("No qualities found for dataset {}".format(dataset_id))
+                qualities = None
+            else:
                 raise
-            qualities = None
 
         arff_file = _get_dataset_arff(description) if download_data else None
         remove_dataset_cache = False


### PR DESCRIPTION
Allow datasets without qualities to be downloaded (because of the use of the cache function, subsequent `get_dataset` calls will always check if qualities are now available on the server). I am not aware of any dataset which will have no qualities indefinitely, so I don't know how to add a unit test or if we should.