### PR TITLE
Put shared logic of Publish into OpenMLBase

### DIFF
--- a/examples/30_extended/create_upload_tutorial.py
+++ b/examples/30_extended/create_upload_tutorial.py
@@ -119,8 +119,8 @@ diabetes_dataset = create_dataset(
 
 ############################################################################
 
-upload_did = diabetes_dataset.publish()
-print(f"URL for dataset: {openml.config.server}/data/{upload_did}")
+diabetes_dataset.publish()
+print(f"URL for dataset: {diabetes_dataset.openml_url}")
 
 ############################################################################
 # Dataset is a list
@@ -192,8 +192,8 @@ weather_dataset = create_dataset(
 
 ############################################################################
 
-upload_did = weather_dataset.publish()
-print(f"URL for dataset: {openml.config.server}/data/{upload_did}")
+weather_dataset.publish()
+print(f"URL for dataset: {weather_dataset.openml_url}")
 
 ############################################################################
 # Dataset is a pandas DataFrame
@@ -238,8 +238,8 @@ weather_dataset = create_dataset(
 
 ############################################################################
 
-upload_did = weather_dataset.publish()
-print(f"URL for dataset: {openml.config.server}/data/{upload_did}")
+weather_dataset.publish()
+print(f"URL for dataset: {weather_dataset.openml_url}")
 
 ############################################################################
 # Dataset is a sparse matrix
@@ -275,8 +275,8 @@ xor_dataset = create_dataset(
 
 ############################################################################
 
-upload_did = xor_dataset.publish()
-print(f"URL for dataset: {openml.config.server}/data/{upload_did}")
+xor_dataset.publish()
+print(f"URL for dataset: {xor_dataset.openml_url}")
 
 
 ############################################################################
@@ -310,8 +310,8 @@ xor_dataset = create_dataset(
 
 ############################################################################
 
-upload_did = xor_dataset.publish()
-print(f"URL for dataset: {openml.config.server}/data/{upload_did}")
+xor_dataset.publish()
+print(f"URL for dataset: {xor_dataset.openml_url}")
 
 
 ############################################################################

--- a/openml/base.py
+++ b/openml/base.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 import re
-from typing import Optional, List, Tuple, Union
+from typing import Optional, List, Tuple, Union, Dict
 import webbrowser
 
 import xmltodict
 
 import openml.config
-from .utils import _tag_openml_base
+from .utils import _tag_openml_base, _get_rest_api_type_alias
 
 
 class OpenMLBase(ABC):
@@ -103,6 +103,19 @@ class OpenMLBase(ABC):
         # <?xml version="1.0" encoding="utf-8"?>
         encoding_specification, xml_body = xml_representation.split('\n', 1)
         return xml_body
+
+    def _add_description_and_publish(self, file_elements: Dict) -> Dict:
+        file_elements['description'] = self._to_xml()
+        call = '{}/'.format(_get_rest_api_type_alias(self))
+
+        response_text = openml._api_calls._perform_api_call(
+            call, 'post', file_elements=file_elements
+        )
+        return xmltodict.parse(response_text)
+
+    @abstractmethod
+    def publish(self) -> 'OpenMLBase':
+        pass
 
     def open_in_browser(self):
         """ Opens the OpenML web page corresponding to this object in your default browser. """

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -726,16 +726,8 @@ class OpenMLDataset(OpenMLBase):
                     result.append(idx - offset)
         return result
 
-    def publish(self) -> 'OpenMLDataset':
-        """ Publish the dataset on the OpenML server.
-
-        Upload the dataset description and dataset content to OpenML.
-
-        Returns
-        -------
-        self : OpenMLDataset
-            The OpenMLDataset with the dataset_id set.
-        """
+    def _get_file_elements(self) -> Dict:
+        """ Adds the 'dataset' to file elements. """
         file_elements = {}
         path = None if self.data_file is None else os.path.abspath(self.data_file)
 
@@ -751,10 +743,11 @@ class OpenMLDataset(OpenMLBase):
                 raise ValueError("The file you have provided is not a valid arff file.")
         elif self.url is None:
             raise ValueError("No valid url/path to the data file was given.")
+        return file_elements
 
-        xml_response = self._add_description_and_publish(file_elements)
+    def _parse_publish_response(self, xml_response: Dict):
+        """ Parse the id from the xml_response and assign it to self. """
         self.dataset_id = int(xml_response['oml:upload_data_set']['oml:id'])
-        return self
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
         """ Creates a dictionary representation of self. """

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -379,15 +379,8 @@ class OpenMLFlow(OpenMLBase):
             if self.flow_id:
                 raise openml.exceptions.PyOpenMLError("Flow does not exist on the server, "
                                                       "but 'flow.flow_id' is not None.")
-            xml_description = self._to_xml()
-            file_elements = {'description': xml_description}
-            return_value = openml._api_calls._perform_api_call(
-                "flow/",
-                'post',
-                file_elements=file_elements,
-            )
-            server_response = xmltodict.parse(return_value)
-            flow_id = int(server_response['oml:upload_flow']['oml:id'])
+            xml_response = self._add_description_and_publish()
+            flow_id = int(xml_response['oml:upload_flow']['oml:id'])
         elif raise_error_if_exists:
             error_message = "This OpenMLFlow already exists with id: {}.".format(flow_id)
             raise openml.exceptions.PyOpenMLError(error_message)

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -351,6 +351,10 @@ class OpenMLFlow(OpenMLBase):
             xml_string = f.read()
         return OpenMLFlow._from_dict(xmltodict.parse(xml_string))
 
+    def _parse_publish_response(self, xml_response: Dict):
+        """ Parse the id from the xml_response and assign it to self. """
+        self.flow_id = int(xml_response['oml:upload_flow']['oml:id'])
+
     def publish(self, raise_error_if_exists: bool = False) -> 'OpenMLFlow':
         """ Publish this flow to OpenML server.
 
@@ -379,8 +383,8 @@ class OpenMLFlow(OpenMLBase):
             if self.flow_id:
                 raise openml.exceptions.PyOpenMLError("Flow does not exist on the server, "
                                                       "but 'flow.flow_id' is not None.")
-            xml_response = self._add_description_and_publish()
-            flow_id = int(xml_response['oml:upload_flow']['oml:id'])
+            super().publish()
+            flow_id = self.flow_id
         elif raise_error_if_exists:
             error_message = "This OpenMLFlow already exists with id: {}.".format(flow_id)
             raise openml.exceptions.PyOpenMLError(error_message)

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -6,7 +6,6 @@ import os
 
 import arff
 import numpy as np
-import xmltodict
 
 import openml
 import openml._api_calls

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import pickle
 import time
-from typing import Any, IO, TextIO, List, Union, Tuple, Optional  # noqa F401
+from typing import Any, IO, TextIO, List, Union, Tuple, Optional, Dict  # noqa F401
 import os
 
 import arff
@@ -428,16 +428,15 @@ class OpenMLRun(OpenMLBase):
                 scores.append(sklearn_fn(y_true, y_pred, **kwargs))
         return np.array(scores)
 
-    def publish(self) -> 'OpenMLRun':
-        """ Publish a run (and if necessary, its flow) to the OpenML server.
+    def _parse_publish_response(self, xml_response: Dict):
+        """ Parse the id from the xml_response and assign it to self. """
+        self.run_id = int(xml_response['oml:upload_run']['oml:run_id'])
 
-        Uploads the results of a run to OpenML.
-        If the run is of an unpublished OpenMLFlow, the flow will be uploaded too.
-        Sets the run_id on self.
+    def _get_file_elements(self) -> Dict:
+        """ Get file_elements to upload to the server.
 
-        Returns
-        -------
-        self : OpenMLRun
+        Derived child classes should overwrite this method as necessary.
+        The description field will be populated automatically if not provided.
         """
         if self.model is None:
             raise PyOpenMLError(
@@ -463,8 +462,7 @@ class OpenMLRun(OpenMLBase):
                 self.model,
             )
 
-        description_xml = self._to_xml()
-        file_elements = {'description': ("description.xml", description_xml)}
+        file_elements = {'description': ("description.xml", self._to_xml())}
 
         if self.error_message is None:
             predictions = arff.dumps(self._generate_arff_dict())
@@ -473,13 +471,7 @@ class OpenMLRun(OpenMLBase):
         if self.trace is not None:
             trace_arff = arff.dumps(self.trace.trace_to_arff())
             file_elements['trace'] = ("trace.arff", trace_arff)
-
-        return_value = openml._api_calls._perform_api_call(
-            "/run/", 'post', file_elements=file_elements
-        )
-        result = xmltodict.parse(return_value)
-        self.run_id = int(result['oml:upload_run']['oml:run_id'])
-        return self
+        return file_elements
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
         """ Creates a dictionary representation of self. """

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple, Union, Any
 
-import xmltodict
-
 import openml
 from openml.base import OpenMLBase
 

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -124,26 +124,17 @@ class BaseStudy(OpenMLBase):
                  "Creator", "Upload Time"]
         return [(key, fields[key]) for key in order if key in fields]
 
-    def publish(self) -> int:
-        """
-        Publish the study on the OpenML server.
+    def publish(self) -> 'BaseStudy':
+        """ Publish the study on the OpenML server.
 
         Returns
         -------
-        study_id: int
-            Id of the study uploaded to the server.
+        self : BaseStudy
+            The BaseStudy with the study_id set.
         """
-        file_elements = {
-            'description': self._to_xml()
-        }
-        return_value = openml._api_calls._perform_api_call(
-            "study/",
-            'post',
-            file_elements=file_elements,
-        )
-        study_res = xmltodict.parse(return_value)
-        self.study_id = int(study_res['oml:study_upload']['oml:id'])
-        return self.study_id
+        xml_response = self._add_description_and_publish(file_elements={})
+        self.study_id = int(xml_response['oml:study_upload']['oml:id'])
+        return self
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
         """ Creates a dictionary representation of self. """

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -122,17 +122,9 @@ class BaseStudy(OpenMLBase):
                  "Creator", "Upload Time"]
         return [(key, fields[key]) for key in order if key in fields]
 
-    def publish(self) -> 'BaseStudy':
-        """ Publish the study on the OpenML server.
-
-        Returns
-        -------
-        self : BaseStudy
-            The BaseStudy with the study_id set.
-        """
-        xml_response = self._add_description_and_publish(file_elements={})
+    def _parse_publish_response(self, xml_response: Dict):
+        """ Parse the id from the xml_response and assign it to self. """
         self.study_id = int(xml_response['oml:study_upload']['oml:id'])
-        return self
 
     def _to_dict(self) -> 'OrderedDict[str, OrderedDict]':
         """ Creates a dictionary representation of self. """

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -8,7 +8,6 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 import scipy.sparse
-import xmltodict
 
 import openml._api_calls
 from openml.base import OpenMLBase
@@ -181,30 +180,18 @@ class OpenMLTask(OpenMLBase):
 
         return task_container
 
-    def publish(self) -> int:
-        """Publish task to OpenML server.
+    def publish(self) -> 'OpenMLTask':
+        """ Publish task to OpenML server.
 
         Returns
         -------
-        task_id: int
-            Returns the id of the uploaded task
-            if successful.
-
+        self : OpenMLTask
+            The OpenMLTask with the dataset_id set.
         """
 
-        xml_description = self._to_xml()
-
-        file_elements = {'description': xml_description}
-
-        return_value = openml._api_calls._perform_api_call(
-            "task/",
-            'post',
-            file_elements=file_elements,
-        )
-
-        task_id = int(xmltodict.parse(return_value)['oml:upload_task']['oml:id'])
-
-        return task_id
+        xml_response = self._add_description_and_publish(file_elements={})
+        self.task_id = int(xml_response['oml:upload_task']['oml:id'])
+        return self
 
 
 class OpenMLSupervisedTask(OpenMLTask, ABC):

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -180,18 +180,9 @@ class OpenMLTask(OpenMLBase):
 
         return task_container
 
-    def publish(self) -> 'OpenMLTask':
-        """ Publish task to OpenML server.
-
-        Returns
-        -------
-        self : OpenMLTask
-            The OpenMLTask with the dataset_id set.
-        """
-
-        xml_response = self._add_description_and_publish(file_elements={})
+    def _parse_publish_response(self, xml_response: Dict):
+        """ Parse the id from the xml_response and assign it to self. """
         self.task_id = int(xml_response['oml:upload_task']['oml:id'])
-        return self
 
 
 class OpenMLSupervisedTask(OpenMLTask, ABC):

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -68,7 +68,8 @@ def extract_xml_tags(xml_tag_name, node, allow_none=True):
                              (xml_tag_name, str(node)))
 
 
-def _tag_openml_base(oml_object: 'OpenMLBase', tag: str, untag: bool = False):
+def _get_rest_api_type_alias(oml_object: 'OpenMLBase') -> str:
+    """ Return the alias of the openml entity as it is defined for the REST API. """
     rest_api_mapping = [
         (openml.datasets.OpenMLDataset, 'data'),
         (openml.flows.OpenMLFlow, 'flow'),
@@ -78,6 +79,11 @@ def _tag_openml_base(oml_object: 'OpenMLBase', tag: str, untag: bool = False):
     _, api_type_alias = [(python_type, api_alias)
                          for (python_type, api_alias) in rest_api_mapping
                          if isinstance(oml_object, python_type)][0]
+    return api_type_alias
+
+
+def _tag_openml_base(oml_object: 'OpenMLBase', tag: str, untag: bool = False):
+    api_type_alias = _get_rest_api_type_alias(oml_object)
     _tag_entity(api_type_alias, oml_object.id, tag, untag)
 
 

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -75,7 +75,7 @@ def _get_rest_api_type_alias(oml_object: 'OpenMLBase') -> str:
         (openml.flows.OpenMLFlow, 'flow'),
         (openml.tasks.OpenMLTask, 'task'),
         (openml.runs.OpenMLRun, 'run'),
-        (openml.study.BaseStudy, 'study')
+        ((openml.study.OpenMLStudy, openml.study.OpenMLBenchmarkSuite), 'study')
     ]
     _, api_type_alias = [(python_type, api_alias)
                          for (python_type, api_alias) in rest_api_mapping

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -74,7 +74,8 @@ def _get_rest_api_type_alias(oml_object: 'OpenMLBase') -> str:
         (openml.datasets.OpenMLDataset, 'data'),
         (openml.flows.OpenMLFlow, 'flow'),
         (openml.tasks.OpenMLTask, 'task'),
-        (openml.runs.OpenMLRun, 'run')
+        (openml.runs.OpenMLRun, 'run'),
+        (openml.study.BaseStudy, 'study')
     ]
     _, api_type_alias = [(python_type, api_alias)
                          for (python_type, api_alias) in rest_api_mapping

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -2,7 +2,7 @@ import os
 import hashlib
 import xmltodict
 import shutil
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple, Union, Type
 import warnings
 import pandas as pd
 from functools import wraps
@@ -76,7 +76,7 @@ def _get_rest_api_type_alias(oml_object: 'OpenMLBase') -> str:
         (openml.tasks.OpenMLTask, 'task'),
         (openml.runs.OpenMLRun, 'run'),
         ((openml.study.OpenMLStudy, openml.study.OpenMLBenchmarkSuite), 'study')
-    ]
+    ]  # type: List[Tuple[Union[Type, Tuple], str]]
     _, api_type_alias = [(python_type, api_alias)
                          for (python_type, api_alias) in rest_api_mapping
                          if isinstance(oml_object, python_type)][0]

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -514,10 +514,10 @@ class TestOpenMLDataset(TestBase):
             version=1,
             url="https://www.openml.org/data/download/61/dataset_61_iris.arff")
         dataset.publish()
-        TestBase._mark_entity_for_removal('data', dataset.dataset_id)
+        TestBase._mark_entity_for_removal('data', dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            dataset.dataset_id))
-        did = dataset.dataset_id
+                                                            dataset.id))
+        did = dataset.id
 
         # admin key for test server (only adminds can activate datasets.
         # all users can deactivate their own datasets)
@@ -629,18 +629,18 @@ class TestOpenMLDataset(TestBase):
             paper_url='http://openml.github.io/openml-python'
         )
 
-        upload_did = dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        dataset.publish()
+        TestBase._mark_entity_for_removal('data', dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
+                                                            dataset.id))
 
         self.assertEqual(
-            _get_online_dataset_arff(upload_did),
+            _get_online_dataset_arff(dataset.id),
             dataset._dataset,
             "Uploaded arff does not match original one"
         )
         self.assertEqual(
-            _get_online_dataset_format(upload_did),
+            _get_online_dataset_format(dataset.id),
             'arff',
             "Wrong format for dataset"
         )
@@ -694,17 +694,17 @@ class TestOpenMLDataset(TestBase):
             paper_url='http://openml.github.io/openml-python'
         )
 
-        upload_did = dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        dataset.publish()
+        TestBase._mark_entity_for_removal('data', dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
+                                                            dataset.id))
         self.assertEqual(
-            _get_online_dataset_arff(upload_did),
+            _get_online_dataset_arff(dataset.id),
             dataset._dataset,
             "Uploaded ARFF does not match original one"
         )
         self.assertEqual(
-            _get_online_dataset_format(upload_did),
+            _get_online_dataset_format(dataset.id),
             'arff',
             "Wrong format for dataset"
         )
@@ -740,17 +740,17 @@ class TestOpenMLDataset(TestBase):
             version_label='test',
         )
 
-        upload_did = xor_dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        xor_dataset.publish()
+        TestBase._mark_entity_for_removal('data', xor_dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
+                                                            xor_dataset.id))
         self.assertEqual(
-            _get_online_dataset_arff(upload_did),
+            _get_online_dataset_arff(xor_dataset.id),
             xor_dataset._dataset,
             "Uploaded ARFF does not match original one"
         )
         self.assertEqual(
-            _get_online_dataset_format(upload_did),
+            _get_online_dataset_format(xor_dataset.id),
             'sparse_arff',
             "Wrong format for dataset"
         )
@@ -780,17 +780,17 @@ class TestOpenMLDataset(TestBase):
             version_label='test',
         )
 
-        upload_did = xor_dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        xor_dataset.publish()
+        TestBase._mark_entity_for_removal('data', xor_dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
+                                                            xor_dataset.id))
         self.assertEqual(
-            _get_online_dataset_arff(upload_did),
+            _get_online_dataset_arff(xor_dataset.id),
             xor_dataset._dataset,
             "Uploaded ARFF does not match original one"
         )
         self.assertEqual(
-            _get_online_dataset_format(upload_did),
+            _get_online_dataset_format(xor_dataset.id),
             'sparse_arff',
             "Wrong format for dataset"
         )
@@ -906,12 +906,12 @@ class TestOpenMLDataset(TestBase):
             original_data_url=original_data_url,
             paper_url=paper_url
         )
-        upload_did = dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        dataset.publish()
+        TestBase._mark_entity_for_removal('data', dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
+                                                            dataset.id))
         self.assertEqual(
-            _get_online_dataset_arff(upload_did),
+            _get_online_dataset_arff(dataset.id),
             dataset._dataset,
             "Uploaded ARFF does not match original one"
         )
@@ -943,17 +943,17 @@ class TestOpenMLDataset(TestBase):
             original_data_url=original_data_url,
             paper_url=paper_url
         )
-        upload_did = dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        dataset.publish()
+        TestBase._mark_entity_for_removal('data', dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
+                                                            dataset.id))
         self.assertEqual(
-            _get_online_dataset_arff(upload_did),
+            _get_online_dataset_arff(dataset.id),
             dataset._dataset,
             "Uploaded ARFF does not match original one"
         )
         self.assertEqual(
-            _get_online_dataset_format(upload_did),
+            _get_online_dataset_format(dataset.id),
             'sparse_arff',
             "Wrong format for dataset"
         )
@@ -982,11 +982,11 @@ class TestOpenMLDataset(TestBase):
             original_data_url=original_data_url,
             paper_url=paper_url
         )
-        upload_did = dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        dataset.publish()
+        TestBase._mark_entity_for_removal('data', dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
-        downloaded_data = _get_online_dataset_arff(upload_did)
+                                                            dataset.id))
+        downloaded_data = _get_online_dataset_arff(dataset.id)
         self.assertEqual(
             downloaded_data,
             dataset._dataset,
@@ -1139,14 +1139,14 @@ class TestOpenMLDataset(TestBase):
         )
 
         # publish dataset
-        upload_did = dataset.publish()
-        TestBase._mark_entity_for_removal('data', upload_did)
+        dataset.publish()
+        TestBase._mark_entity_for_removal('data', dataset.id)
         TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                            upload_did))
+                                                            dataset.id))
         # test if publish was successful
-        self.assertIsInstance(upload_did, int)
+        self.assertIsInstance(dataset.id, int)
 
-        dataset = None
+        downloaded_dataset = None
         # fetching from server
         # loop till timeout or fetch not successful
         max_waiting_time_seconds = 400
@@ -1154,17 +1154,17 @@ class TestOpenMLDataset(TestBase):
         start_time = time.time()
         while time.time() - start_time < max_waiting_time_seconds:
             try:
-                dataset = openml.datasets.get_dataset(upload_did)
+                downloaded_dataset = openml.datasets.get_dataset(dataset.id)
                 break
             except Exception as e:
                 # returned code 273: Dataset not processed yet
                 # returned code 362: No qualities found
-                print("Failed to fetch dataset:{} with '{}'.".format(upload_did, str(e)))
+                print("Failed to fetch dataset:{} with '{}'.".format(dataset.id, str(e)))
                 time.sleep(10)
                 continue
-        if dataset is None:
-            raise ValueError("TIMEOUT: Failed to fetch uploaded dataset - {}".format(upload_did))
-        self.assertEqual(dataset.ignore_attribute, ignore_attribute)
+        if downloaded_dataset is None:
+            raise ValueError("TIMEOUT: Failed to fetch uploaded dataset - {}".format(dataset.id))
+        self.assertEqual(downloaded_dataset.ignore_attribute, ignore_attribute)
 
     def test_create_dataset_row_id_attribute_error(self):
         # meta-information
@@ -1254,11 +1254,11 @@ class TestOpenMLDataset(TestBase):
                 paper_url=paper_url
             )
             self.assertEqual(dataset.row_id_attribute, output_row_id)
-            upload_did = dataset.publish()
-            TestBase._mark_entity_for_removal('data', upload_did)
+            dataset.publish()
+            TestBase._mark_entity_for_removal('data', dataset.id)
             TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                                upload_did))
-            arff_dataset = arff.loads(_get_online_dataset_arff(upload_did))
+                                                                dataset.id))
+            arff_dataset = arff.loads(_get_online_dataset_arff(dataset.id))
             arff_data = np.array(arff_dataset['data'], dtype=object)
             # if we set the name of the index then the index will be added to
             # the data

--- a/tests/test_study/test_study_functions.py
+++ b/tests/test_study/test_study_functions.py
@@ -76,14 +76,14 @@ class TestStudyFunctions(TestBase):
             description=fixture_descr,
             task_ids=fixture_task_ids
         )
-        study_id = study.publish()
-        TestBase._mark_entity_for_removal('study', study_id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1], study_id))
+        study.publish()
+        TestBase._mark_entity_for_removal('study', study.id)
+        TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1], study.id))
 
-        self.assertGreater(study_id, 0)
+        self.assertGreater(study.id, 0)
 
         # verify main meta data
-        study_downloaded = openml.study.get_suite(study_id)
+        study_downloaded = openml.study.get_suite(study.id)
         self.assertEqual(study_downloaded.alias, fixture_alias)
         self.assertEqual(study_downloaded.name, fixture_name)
         self.assertEqual(study_downloaded.description, fixture_descr)
@@ -98,20 +98,20 @@ class TestStudyFunctions(TestBase):
 
         # attach more tasks
         tasks_additional = [4, 5, 6]
-        openml.study.attach_to_study(study_id, tasks_additional)
-        study_downloaded = openml.study.get_suite(study_id)
+        openml.study.attach_to_study(study.id, tasks_additional)
+        study_downloaded = openml.study.get_suite(study.id)
         # verify again
         self.assertSetEqual(set(study_downloaded.tasks),
                             set(fixture_task_ids + tasks_additional))
         # test detach function
-        openml.study.detach_from_study(study_id, fixture_task_ids)
-        study_downloaded = openml.study.get_suite(study_id)
+        openml.study.detach_from_study(study.id, fixture_task_ids)
+        study_downloaded = openml.study.get_suite(study.id)
         self.assertSetEqual(set(study_downloaded.tasks),
                             set(tasks_additional))
 
         # test status update function
-        openml.study.update_suite_status(study_id, 'deactivated')
-        study_downloaded = openml.study.get_suite(study_id)
+        openml.study.update_suite_status(study.id, 'deactivated')
+        study_downloaded = openml.study.get_suite(study.id)
         self.assertEqual(study_downloaded.status, 'deactivated')
         # can't delete study, now it's not longer in preparation
 
@@ -134,11 +134,11 @@ class TestStudyFunctions(TestBase):
             description=fixt_descr,
             run_ids=list(run_list.keys())
         )
-        study_id = study.publish()
+        study.publish()
         # not tracking upload for delete since _delete_entity called end of function
         # asserting return status from openml.study.delete_study()
-        self.assertGreater(study_id, 0)
-        study_downloaded = openml.study.get_study(study_id)
+        self.assertGreater(study.id, 0)
+        study_downloaded = openml.study.get_study(study.id)
         self.assertEqual(study_downloaded.alias, fixt_alias)
         self.assertEqual(study_downloaded.name, fixt_name)
         self.assertEqual(study_downloaded.description, fixt_descr)
@@ -150,34 +150,34 @@ class TestStudyFunctions(TestBase):
         self.assertSetEqual(set(study_downloaded.tasks), set(fixt_task_ids))
 
         # test whether the list run function also handles study data fine
-        run_ids = openml.runs.list_runs(study=study_id)
+        run_ids = openml.runs.list_runs(study=study.id)
         self.assertSetEqual(set(run_ids), set(study_downloaded.runs))
 
         # test whether the list evaluation function also handles study data fine
-        run_ids = openml.evaluations.list_evaluations('predictive_accuracy', study=study_id)
+        run_ids = openml.evaluations.list_evaluations('predictive_accuracy', study=study.id)
         self.assertSetEqual(set(run_ids), set(study_downloaded.runs))
 
         # attach more runs
         run_list_additional = openml.runs.list_runs(size=10, offset=10)
-        openml.study.attach_to_study(study_id,
+        openml.study.attach_to_study(study.id,
                                      list(run_list_additional.keys()))
-        study_downloaded = openml.study.get_study(study_id)
+        study_downloaded = openml.study.get_study(study.id)
         # verify again
         all_run_ids = set(run_list_additional.keys()) | set(run_list.keys())
         self.assertSetEqual(set(study_downloaded.runs), all_run_ids)
 
         # test detach function
-        openml.study.detach_from_study(study_id, list(run_list.keys()))
-        study_downloaded = openml.study.get_study(study_id)
+        openml.study.detach_from_study(study.id, list(run_list.keys()))
+        study_downloaded = openml.study.get_study(study.id)
         self.assertSetEqual(set(study_downloaded.runs),
                             set(run_list_additional.keys()))
 
         # test status update function
-        openml.study.update_study_status(study_id, 'deactivated')
-        study_downloaded = openml.study.get_study(study_id)
+        openml.study.update_study_status(study.id, 'deactivated')
+        study_downloaded = openml.study.get_study(study.id)
         self.assertEqual(study_downloaded.status, 'deactivated')
 
-        res = openml.study.delete_study(study_id)
+        res = openml.study.delete_study(study.id)
         self.assertTrue(res)
 
     def test_study_attach_illegal(self):
@@ -193,21 +193,21 @@ class TestStudyFunctions(TestBase):
             description='none',
             run_ids=list(run_list.keys())
         )
-        study_id = study.publish()
-        TestBase._mark_entity_for_removal('study', study_id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1], study_id))
-        study_original = openml.study.get_study(study_id)
+        study.publish()
+        TestBase._mark_entity_for_removal('study', study.id)
+        TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1], study.id))
+        study_original = openml.study.get_study(study.id)
 
         with self.assertRaisesRegex(openml.exceptions.OpenMLServerException,
                                     'Problem attaching entities.'):
             # run id does not exists
-            openml.study.attach_to_study(study_id, [0])
+            openml.study.attach_to_study(study.id, [0])
 
         with self.assertRaisesRegex(openml.exceptions.OpenMLServerException,
                                     'Problem attaching entities.'):
             # some runs already attached
-            openml.study.attach_to_study(study_id, list(run_list_more.keys()))
-        study_downloaded = openml.study.get_study(study_id)
+            openml.study.attach_to_study(study.id, list(run_list_more.keys()))
+        study_downloaded = openml.study.get_study(study.id)
         self.assertListEqual(study_original.runs, study_downloaded.runs)
 
     def test_study_list(self):

--- a/tests/test_tasks/test_clustering_task.py
+++ b/tests/test_tasks/test_clustering_task.py
@@ -40,10 +40,10 @@ class OpenMLClusteringTaskTest(OpenMLTaskTest):
                     dataset_id=dataset_id,
                     estimation_procedure_id=self.estimation_procedure
                 )
-                task_id = task.publish()
-                TestBase._mark_entity_for_removal('task', task_id)
+                task = task.publish()
+                TestBase._mark_entity_for_removal('task', task.id)
                 TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                                    task_id))
+                                                                    task.id))
                 # success
                 break
             except OpenMLServerException as e:

--- a/tests/test_tasks/test_task.py
+++ b/tests/test_tasks/test_task.py
@@ -57,10 +57,10 @@ class OpenMLTaskTest(TestBase):
                     estimation_procedure_id=self.estimation_procedure
                 )
 
-                task_id = task.publish()
-                TestBase._mark_entity_for_removal('task', task_id)
+                task.publish()
+                TestBase._mark_entity_for_removal('task', task.id)
                 TestBase.logger.info("collected from {}: {}".format(__file__.split('/')[-1],
-                                                                    task_id))
+                                                                    task.id))
                 # success
                 break
             except OpenMLServerException as e:


### PR DESCRIPTION
Also unifies the return value of OpenMLBase.publish to return the OpenMLBase object (before it was either that *or* id)