### PR TITLE
Fix736

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -15,6 +15,7 @@ Changelog
 * ADD #783: The URL to download the predictions for a run is now stored in the run object.
 * ADD #790: Adds the uploader name and id as new filtering options for ``list_evaluations``.
 * ADD #792: New convenience function ``openml.flow.get_flow_id``.
+* ADD #861: Debug-level log information now being written to a file in the cache directory (at most 2 MB).
 * DOC #778: Introduces instructions on how to publish an extension to support other libraries
   than scikit-learn.
 * DOC #785: The examples section is completely restructured into simple simple examples, advanced
@@ -34,6 +35,7 @@ Changelog
 * DOC #834: New example showing how to plot the loss surface for a support vector machine.
 * FIX #305: Do not require the external version in the flow XML when loading an object.
 * FIX #734: Better handling of *"old"* flows.
+* FIX #736: Attach a StreamHandler to the openml logger instead of the root logger.
 * FIX #758: Fixes an error which made the client API crash when loading a sparse data with
   categorical variables.
 * FIX #779: Do not fail on corrupt pickle

--- a/examples/30_extended/configure_logging.py
+++ b/examples/30_extended/configure_logging.py
@@ -1,3 +1,10 @@
+"""
+========
+Logging
+========
+
+Explains openml-python logging, and shows how to configure it.
+"""
 ##################################################################################
 # Logging
 # ^^^^^^^

--- a/examples/30_extended/configure_logging.py
+++ b/examples/30_extended/configure_logging.py
@@ -1,0 +1,45 @@
+##################################################################################
+# Logging
+# ^^^^^^^
+# Openml-python uses the `Python logging module <https://docs.python.org/3/library/logging.html>`_
+# to provide users with log messages. Each log message is assigned a level of importance, see
+# the table in Python's logging tutorial
+# `here <https://docs.python.org/3/howto/logging.html#when-to-use-logging>`_.
+#
+# By default, openml-python will print log messages of level `WARNING` and above to console.
+# All log messages (including `DEBUG` and `INFO`) are also saved in a file, which can be
+# found in your cache directory (see also the
+# `introduction tutorial <../20_basic/introduction_tutorial.html>`_).
+# These file logs are automatically deleted if needed, and use at most 2MB of space.
+#
+# It is possible to configure what log levels to send to console and file.
+# When downloading a dataset from OpenML, a `DEBUG`-level message is written:
+
+import openml
+openml.datasets.get_dataset('iris')
+
+# With default configuration, the above example will show no output to console.
+# However, in your cache directory you should find a file named 'openml_python.log',
+# which has a DEBUG message written to it. It should be either like
+# "[DEBUG] [10:46:19:openml.datasets.dataset] Saved dataset 61: iris to file ..."
+# or like
+# "[DEBUG] [10:49:38:openml.datasets.dataset] Data pickle file already exists and is up to date."
+# , depending on whether or not you had downloaded iris before.
+# The processed log levels can be configured programmatically:
+
+import logging
+openml.config.console_log.setLevel(logging.DEBUG)
+openml.config.file_log.setLevel(logging.WARNING)
+openml.datasets.get_dataset('iris')
+
+# Now the log level that was previously written to file should also be shown in the console.
+# The message is now no longer written to file as the `file_log` was set to level `WARNING`.
+#
+# It is also possible to specify the desired log levels through the configuration file.
+# This way you will not need to set them on each script separately.
+# Add the  line **verbosity = NUMBER** and/or **file_verbosity = NUMBER** to the config file,
+# where 'NUMBER' should be one of:
+#
+# * 0: `logging.WARNING` and up.
+# * 1: `logging.INFO` and up.
+# * 2: `logging.DEBUG` and up (i.e. all messages).

--- a/examples/30_extended/run_setup_tutorial.py
+++ b/examples/30_extended/run_setup_tutorial.py
@@ -29,7 +29,6 @@ In this tutorial we will
    connects to the test server at test.openml.org. This prevents the main
    server from crowding with example datasets, tasks, runs, and so on.
 """
-import logging
 import numpy as np
 import openml
 import sklearn.ensemble

--- a/examples/30_extended/run_setup_tutorial.py
+++ b/examples/30_extended/run_setup_tutorial.py
@@ -37,8 +37,6 @@ import sklearn.impute
 import sklearn.preprocessing
 
 
-root = logging.getLogger()
-root.setLevel(logging.INFO)
 openml.config.start_using_configuration_for_example()
 
 ###############################################################################

--- a/examples/40_paper/2018_kdd_rijn_example.py
+++ b/examples/40_paper/2018_kdd_rijn_example.py
@@ -15,16 +15,10 @@ Publication
 | In *Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining*, 2018
 | Available at https://dl.acm.org/citation.cfm?id=3220058
 """
-import logging
 import sys
 
-logger = logging.getLogger(__name__)
-console_output = logging.StreamHandler()
-console_output.setLevel(logging.INFO)
-logger.addHandler(console_output)
-
 if sys.platform == 'win32':  # noqa
-    logger.critical('The pyrfr library (requirement of fanova) can currently not be installed on Windows systems')
+    print('The pyrfr library (requirement of fanova) can currently not be installed on Windows systems')
     exit()
 
 import json
@@ -84,8 +78,8 @@ fanova_results = []
 for idx, task_id in enumerate(suite.tasks):
     if limit_nr_tasks is not None and idx >= limit_nr_tasks:
         continue
-    logger.info('Starting with task %d (%d/%d)' % (task_id, idx+1,
-                                                    len(suite.tasks) if limit_nr_tasks is None else limit_nr_tasks))
+    print('Starting with task %d (%d/%d)'
+          % (task_id, idx+1, len(suite.tasks) if limit_nr_tasks is None else limit_nr_tasks))
     # note that we explicitly only include tasks from the benchmark suite that was specified (as per the for-loop)
     evals = openml.evaluations.list_evaluations_setups(
         evaluation_measure, flow=[flow_id], task=[task_id], size=limit_per_task, output_format='dataframe')
@@ -102,7 +96,7 @@ for idx, task_id in enumerate(suite.tasks):
                                           **{performance_column: setup[performance_column]})
                                      for _, setup in evals.iterrows()])
     except json.decoder.JSONDecodeError as e:
-        logger.warning('Task %d error: %s' % (task_id, e))
+        print('Task %d error: %s' % (task_id, e))
         continue
     # apply our filters, to have only the setups that comply to the hyperparameters we want
     for filter_key, filter_value in parameter_filters.items():
@@ -131,7 +125,7 @@ for idx, task_id in enumerate(suite.tasks):
             # functional ANOVA sometimes crashes with a RuntimeError, e.g., on tasks where the performance is constant
             # for all configurations (there is no variance). We will skip these tasks (like the authors did in the
             # paper).
-            logger.warning('Task %d error: %s' % (task_id, e))
+            print('Task %d error: %s' % (task_id, e))
             continue
 
 # transform ``fanova_results`` from a list of dicts into a DataFrame

--- a/examples/40_paper/2018_kdd_rijn_example.py
+++ b/examples/40_paper/2018_kdd_rijn_example.py
@@ -24,7 +24,7 @@ console_output.setLevel(logging.INFO)
 logger.addHandler(console_output)
 
 if sys.platform == 'win32':  # noqa
-    logger.warning('The pyrfr library (requirement of fanova) can currently not be installed on Windows systems')
+    logger.critical('The pyrfr library (requirement of fanova) can currently not be installed on Windows systems')
     exit()
 
 import json

--- a/examples/40_paper/2018_kdd_rijn_example.py
+++ b/examples/40_paper/2018_kdd_rijn_example.py
@@ -15,13 +15,19 @@ Publication
 | In *Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining*, 2018
 | Available at https://dl.acm.org/citation.cfm?id=3220058
 """
-import json
 import logging
 import sys
 
+logger = logging.getLogger(__name__)
+console_output = logging.StreamHandler()
+console_output.setLevel(logging.INFO)
+logger.addHandler(console_output)
+
 if sys.platform == 'win32':  # noqa
-    logging.warning('The pyrfr library (requirement of fanova) can currently not be installed on Windows systems')
+    logger.warning('The pyrfr library (requirement of fanova) can currently not be installed on Windows systems')
     exit()
+
+import json
 import fanova
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -29,8 +35,6 @@ import seaborn as sns
 
 import openml
 
-root = logging.getLogger()
-root.setLevel(logging.INFO)
 
 ##############################################################################
 # With the advent of automated machine learning, automated hyperparameter
@@ -80,7 +84,7 @@ fanova_results = []
 for idx, task_id in enumerate(suite.tasks):
     if limit_nr_tasks is not None and idx >= limit_nr_tasks:
         continue
-    logging.info('Starting with task %d (%d/%d)' % (task_id, idx+1,
+    logger.info('Starting with task %d (%d/%d)' % (task_id, idx+1,
                                                     len(suite.tasks) if limit_nr_tasks is None else limit_nr_tasks))
     # note that we explicitly only include tasks from the benchmark suite that was specified (as per the for-loop)
     evals = openml.evaluations.list_evaluations_setups(
@@ -98,7 +102,7 @@ for idx, task_id in enumerate(suite.tasks):
                                           **{performance_column: setup[performance_column]})
                                      for _, setup in evals.iterrows()])
     except json.decoder.JSONDecodeError as e:
-        logging.warning('Task %d error: %s' % (task_id, e))
+        logger.warning('Task %d error: %s' % (task_id, e))
         continue
     # apply our filters, to have only the setups that comply to the hyperparameters we want
     for filter_key, filter_value in parameter_filters.items():
@@ -127,7 +131,7 @@ for idx, task_id in enumerate(suite.tasks):
             # functional ANOVA sometimes crashes with a RuntimeError, e.g., on tasks where the performance is constant
             # for all configurations (there is no variance). We will skip these tasks (like the authors did in the
             # paper).
-            logging.warning('Task %d error: %s' % (task_id, e))
+            logger.warning('Task %d error: %s' % (task_id, e))
             continue
 
 # transform ``fanova_results`` from a list of dicts into a DataFrame

--- a/openml/config.py
+++ b/openml/config.py
@@ -59,8 +59,6 @@ avoid_duplicate_runs = True if _defaults['avoid_duplicate_runs'] == 'True' else 
 # Number of retries if the connection breaks
 connection_n_retries = _defaults['connection_n_retries']
 
-configure_logging(cast(int, _defaults['verbosity']), cast(int, _defaults['file_verbosity']))
-
 
 class ConfigurationForExamples:
     """ Allows easy switching to and from a test configuration, used for examples. """
@@ -145,6 +143,8 @@ def _setup():
             'A higher number of retries than 20 is not allowed to keep the '
             'server load reasonable'
         )
+
+    configure_logging(cast(int, _defaults['verbosity']), cast(int, _defaults['file_verbosity']))
 
 
 def _parse_config():

--- a/openml/config.py
+++ b/openml/config.py
@@ -123,6 +123,13 @@ def _setup():
     global avoid_duplicate_runs
     global connection_n_retries
 
+    # read config file, create cache directory
+    try:
+        os.mkdir(os.path.expanduser(os.path.join('~', '.openml')))
+    except (IOError, OSError):
+        # TODO add debug information
+        pass
+
     config = _parse_config()
     apikey = config.get('FAKE_SECTION', 'apikey')
     server = config.get('FAKE_SECTION', 'server')
@@ -130,7 +137,7 @@ def _setup():
     short_cache_dir = config.get('FAKE_SECTION', 'cachedir')
     cache_directory = os.path.expanduser(short_cache_dir)
 
-    # read config file, create cache directory
+    # create the cache subdirectory
     try:
         os.mkdir(cache_directory)
     except (IOError, OSError):

--- a/openml/config.py
+++ b/openml/config.py
@@ -4,6 +4,7 @@ Store module level information like the API key, cache directory and the server
 import logging
 import logging.handlers
 import os
+from typing import cast
 
 from io import StringIO
 import configparser
@@ -52,13 +53,13 @@ server = str(_defaults['server'])  # so mypy knows it is a string
 server_base_url = server[:-len('/api/v1/xml')]
 apikey = _defaults['apikey']
 # The current cache directory (without the server name)
-cache_directory = _defaults['cachedir']
+cache_directory = str(_defaults['cachedir'])  # so mypy knows it is a string
 avoid_duplicate_runs = True if _defaults['avoid_duplicate_runs'] == 'True' else False
 
 # Number of retries if the connection breaks
 connection_n_retries = _defaults['connection_n_retries']
 
-configure_logging(_defaults['verbosity'], _defaults['file_verbosity'])
+configure_logging(cast(int, _defaults['verbosity']), cast(int, _defaults['file_verbosity']))
 
 
 class ConfigurationForExamples:

--- a/openml/config.py
+++ b/openml/config.py
@@ -4,7 +4,6 @@ Store module level information like the API key, cache directory and the server
 import logging
 import logging.handlers
 import os
-from typing import cast
 
 from io import StringIO
 import configparser
@@ -34,12 +33,12 @@ def configure_logging(console_output_level: int, file_output_level: int):
     openml_logger.addHandler(file_stream)
 
 
-# Default values!
+# Default values (see also https://github.com/openml/OpenML/wiki/Client-API-Standards)
 _defaults = {
     'apikey': None,
     'server': "https://www.openml.org/api/v1/xml",
-    'verbosity': logging.WARNING,
-    'file_verbosity': logging.DEBUG,
+    'verbosity': 0,  # WARNING
+    'file_verbosity': 2,  # DEBUG
     'cachedir': os.path.expanduser(os.path.join('~', '.openml', 'cache')),
     'avoid_duplicate_runs': 'True',
     'connection_n_retries': 2,

--- a/openml/config.py
+++ b/openml/config.py
@@ -122,18 +122,20 @@ def _setup():
     global cache_directory
     global avoid_duplicate_runs
     global connection_n_retries
-    # read config file, create cache directory
-    try:
-        os.mkdir(os.path.expanduser(os.path.join('~', '.openml')))
-    except (IOError, OSError):
-        # TODO add debug information
-        pass
+
     config = _parse_config()
     apikey = config.get('FAKE_SECTION', 'apikey')
     server = config.get('FAKE_SECTION', 'server')
 
     short_cache_dir = config.get('FAKE_SECTION', 'cachedir')
     cache_directory = os.path.expanduser(short_cache_dir)
+
+    # read config file, create cache directory
+    try:
+        os.mkdir(cache_directory)
+    except (IOError, OSError):
+        # TODO add debug information
+        pass
 
     avoid_duplicate_runs = config.getboolean('FAKE_SECTION',
                                              'avoid_duplicate_runs')

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -441,7 +441,7 @@ class OpenMLDataset(OpenMLBase):
             with open(self.data_pickle_file, "rb") as fh:
                 data, categorical, attribute_names = pickle.load(fh)
         except EOFError:
-            logging.warning(
+            logger.warning(
                 "Detected a corrupt cache file loading dataset %d: '%s'. "
                 "We will continue loading data from the arff-file, "
                 "but this will be much slower for big datasets. "
@@ -512,7 +512,7 @@ class OpenMLDataset(OpenMLBase):
                 return data
         else:
             data_type = "sparse-data" if scipy.sparse.issparse(data) else "non-sparse data"
-            logging.warning(
+            logger.warning(
                 "Cannot convert %s (%s) to '%s'. Returning input data."
                 % (data_type, type(data), array_format)
             )

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -34,6 +34,8 @@ from openml.tasks import (
     OpenMLRegressionTask,
 )
 
+logger = logging.getLogger(__name__)
+
 
 if sys.version_info >= (3, 5):
     from json.decoder import JSONDecodeError
@@ -271,7 +273,7 @@ class SklearnExtension(Extension):
         mixed
         """
 
-        logging.info('-%s flow_to_sklearn START o=%s, components=%s, '
+        logger.info('-%s flow_to_sklearn START o=%s, components=%s, '
                      'init_defaults=%s' % ('-' * recursion_depth, o, components,
                                            initialize_with_defaults))
         depth_pp = recursion_depth + 1  # shortcut var, depth plus plus
@@ -376,7 +378,7 @@ class SklearnExtension(Extension):
             )
         else:
             raise TypeError(o)
-        logging.info('-%s flow_to_sklearn END   o=%s, rval=%s'
+        logger.info('-%s flow_to_sklearn END   o=%s, rval=%s'
                      % ('-' * recursion_depth, o, rval))
         return rval
 
@@ -537,7 +539,7 @@ class SklearnExtension(Extension):
                 s = "{}...".format(s[:char_lim - 3])
             return s.strip()
         except ValueError:
-            logging.warning("'Read more' not found in descriptions. "
+            logger.warning("'Read more' not found in descriptions. "
                             "Trying to trim till 'Parameters' if available in docstring.")
             pass
         try:
@@ -546,7 +548,7 @@ class SklearnExtension(Extension):
             index = s.index(match_format(pattern))
         except ValueError:
             # returning full docstring
-            logging.warning("'Parameters' not found in docstring. Omitting docstring trimming.")
+            logger.warning("'Parameters' not found in docstring. Omitting docstring trimming.")
             index = len(s)
         s = s[:index]
         # trimming docstring to be within char_lim
@@ -580,7 +582,7 @@ class SklearnExtension(Extension):
             index1 = s.index(match_format("Parameters"))
         except ValueError as e:
             # when sklearn docstring has no 'Parameters' section
-            logging.warning("{} {}".format(match_format("Parameters"), e))
+            logger.warning("{} {}".format(match_format("Parameters"), e))
             return None
 
         headings = ["Attributes", "Notes", "See also", "Note", "References"]
@@ -590,7 +592,7 @@ class SklearnExtension(Extension):
                 index2 = s.index(match_format(h))
                 break
             except ValueError:
-                logging.warning("{} not available in docstring".format(h))
+                logger.warning("{} not available in docstring".format(h))
                 continue
         else:
             # in the case only 'Parameters' exist, trim till end of docstring
@@ -975,7 +977,7 @@ class SklearnExtension(Extension):
         recursion_depth: int,
         strict_version: bool = True
     ) -> Any:
-        logging.info('-%s deserialize %s' % ('-' * recursion_depth, flow.name))
+        logger.info('-%s deserialize %s' % ('-' * recursion_depth, flow.name))
         model_name = flow.class_name
         self._check_dependencies(flow.dependencies,
                                  strict_version=strict_version)
@@ -993,7 +995,7 @@ class SklearnExtension(Extension):
 
         for name in parameters:
             value = parameters.get(name)
-            logging.info('--%s flow_parameter=%s, value=%s' %
+            logger.info('--%s flow_parameter=%s, value=%s' %
                          ('-' * recursion_depth, name, value))
             rval = self._deserialize_sklearn(
                 value,
@@ -1010,7 +1012,7 @@ class SklearnExtension(Extension):
             if name not in components_:
                 continue
             value = components[name]
-            logging.info('--%s flow_component=%s, value=%s'
+            logger.info('--%s flow_component=%s, value=%s'
                          % ('-' * recursion_depth, name, value))
             rval = self._deserialize_sklearn(
                 value,

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -273,9 +273,8 @@ class SklearnExtension(Extension):
         mixed
         """
 
-        logger.info('-%s flow_to_sklearn START o=%s, components=%s, '
-                     'init_defaults=%s' % ('-' * recursion_depth, o, components,
-                                           initialize_with_defaults))
+        logger.info('-%s flow_to_sklearn START o=%s, components=%s, init_defaults=%s'
+                    % ('-' * recursion_depth, o, components, initialize_with_defaults))
         depth_pp = recursion_depth + 1  # shortcut var, depth plus plus
 
         # First, we need to check whether the presented object is a json string.
@@ -378,8 +377,7 @@ class SklearnExtension(Extension):
             )
         else:
             raise TypeError(o)
-        logger.info('-%s flow_to_sklearn END   o=%s, rval=%s'
-                     % ('-' * recursion_depth, o, rval))
+        logger.info('-%s flow_to_sklearn END   o=%s, rval=%s' % ('-' * recursion_depth, o, rval))
         return rval
 
     def model_to_flow(self, model: Any) -> 'OpenMLFlow':
@@ -540,7 +538,7 @@ class SklearnExtension(Extension):
             return s.strip()
         except ValueError:
             logger.warning("'Read more' not found in descriptions. "
-                            "Trying to trim till 'Parameters' if available in docstring.")
+                           "Trying to trim till 'Parameters' if available in docstring.")
             pass
         try:
             # if 'Read more' doesn't exist, trim till 'Parameters'
@@ -995,8 +993,7 @@ class SklearnExtension(Extension):
 
         for name in parameters:
             value = parameters.get(name)
-            logger.info('--%s flow_parameter=%s, value=%s' %
-                         ('-' * recursion_depth, name, value))
+            logger.info('--%s flow_parameter=%s, value=%s' % ('-' * recursion_depth, name, value))
             rval = self._deserialize_sklearn(
                 value,
                 components=components_,
@@ -1012,8 +1009,7 @@ class SklearnExtension(Extension):
             if name not in components_:
                 continue
             value = components[name]
-            logger.info('--%s flow_component=%s, value=%s'
-                         % ('-' * recursion_depth, name, value))
+            logger.info('--%s flow_component=%s, value=%s' % ('-' * recursion_depth, name, value))
             rval = self._deserialize_sklearn(
                 value,
                 recursion_depth=recursion_depth + 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ directory = None
 # finding the root directory of conftest.py and going up to OpenML main directory
 # exploiting the fact that conftest.py always resides in the root directory for tests
 static_dir = os.path.dirname(os.path.abspath(__file__))
-logging.info("static directory: {}".format(static_dir))
+logger.info("static directory: {}".format(static_dir))
 print("static directory: {}".format(static_dir))
 while True:
     if 'openml' in os.listdir(static_dir):
@@ -178,4 +178,4 @@ def pytest_sessionfinish() -> None:
         compare_delete_files(file_list, new_file_list)
         logger.info("Local files deleted")
 
-    logging.info("{} is killed".format(worker))
+    logger.info("{} is killed".format(worker))


### PR DESCRIPTION
Fixes #736.

 - All openml package logging is logged through the 'openml' logger (this fixes side-effects of working with the root logger that are demonstrated in the issue and code below).
 - All messages at `logging.WARNING` and up are printed to console (by default). This is in line with old behavior.
 - A file log of messages at `logging.DEBUG` and up (i.e. all of them) are logged to a file in the cache directory (by default). A new log file is created if the old log file reaches a size of 1 MB. At most one current log file and and old log file will be kept on disk at a time (i.e. at most 2 MB of openml-python logs are kept).
 - The log level defaults can be changed through the configuration file, for both channels individually. A new `file_verbosity` is introduced alongside the regular `verbosity`. 

The difference can be seen when running the following lines of code:
```
import logging

if __name__ == '__main__':
    log = logging.getLogger('mypackage')
    log.setLevel(logging.DEBUG)

    log.info("Message one")
    import openml
    log.info("Message two") 

    from openml.flows import get_flow
    f = get_flow(123)
    f.description = ''
    f._to_dict()  # logging.warning will be called due to empty description.

    from openml.datasets import get_dataset
    iris = get_dataset(61)  # since I have it in cache, a logging.debug statement is called.
```
in current `develop` we will see:
```
[INFO] [14:11:03:mypackage] Message two
[DEBUG] [14:11:03:mypackage] Message three
[WARNING] [14:11:03:openml.flows.flow] Flow 'weka.LinearRegression's empty description
```
printed in console, with no (semi-)permanent of the log is kept automatically.

With this PR, the console output becomes:
```
[WARNING] [14:12:42:openml.flows.flow] Flow 'weka.LinearRegression's empty description
```
and in my cache directory I find a file 'openml_python.log' with the following content:
```
[WARNING] [14:12:59:openml.flows.flow] Flow 'weka.LinearRegression's empty description
[DEBUG] [14:12:59:openml.datasets.dataset] Data pickle file already exists and is up to date.
```

I don't know how to unit test this, if at all.

----
A note on examples. I noticed some examples use logging (run setup and the fanova example). The generated pages do not show any logging output, so I was wondering what the purpose for the logging is. Perhaps @janvanrijn can help me here, as he seems to be the author.


