### PR TITLE
To handle non-actionable steps in sklearn

### DIFF
--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -754,7 +754,7 @@ class SklearnExtension(Extension):
     def _get_external_version_string(
         self,
         model: Any,
-        sub_components: Dict[str, Union[OpenMLFlow, str, None]],
+        sub_components: Dict[str, OpenMLFlow],
     ) -> str:
         # Create external version string for a flow, given the model and the
         # already parsed dictionary of sub_components. Retrieves the external
@@ -785,9 +785,9 @@ class SklearnExtension(Extension):
     def _check_multiple_occurence_of_component_in_flow(
         self,
         model: Any,
-        sub_components: Dict[str, Union[OpenMLFlow, str, None]],
+        sub_components: Dict[str, OpenMLFlow],
     ) -> None:
-        to_visit_stack = []  # type: List[Union[OpenMLFlow, str, None]]
+        to_visit_stack = []  # type: List[OpenMLFlow]
         to_visit_stack.extend(sub_components.values())
         known_sub_components = set()  # type: Set[str]
 
@@ -810,7 +810,7 @@ class SklearnExtension(Extension):
     ) -> Tuple[
         'OrderedDict[str, Optional[str]]',
         'OrderedDict[str, Optional[Dict]]',
-        'OrderedDict[str, Union[OpenMLFlow, str, None]]',
+        'OrderedDict[str, OpenMLFlow]',
         Set,
     ]:
         # This function contains four "global" states and is quite long and
@@ -820,7 +820,7 @@ class SklearnExtension(Extension):
         # separate class methods
 
         # stores all entities that should become subcomponents
-        sub_components = OrderedDict()  # type: OrderedDict[str, Union[OpenMLFlow, str, None]]
+        sub_components = OrderedDict()  # type: OrderedDict[str, OpenMLFlow]
         # stores the keys of all subcomponents that should become
         sub_components_explicit = set()
         parameters = OrderedDict()  # type: OrderedDict[str, Optional[str]]

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -880,8 +880,8 @@ class SklearnExtension(Extension):
                         else:
                             pass
                     elif isinstance(sub_component, type(None)):
-                        msg = 'Cannot serialize objects of None type. Please replace with a '\
-                              'relevant placeholder. Note that empty sklearn estimators can be '\
+                        msg = 'Cannot serialize objects of None type. Please use a valid ' \
+                              'placeholder for None. Note that empty sklearn estimators can be '\
                               'replaced with \'drop\' or \'passthrough\'.'
                         raise ValueError(msg)
                     elif not isinstance(sub_component, OpenMLFlow):

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -698,8 +698,6 @@ class SklearnExtension(Extension):
                 name = subcomponents[key].name
             elif isinstance(subcomponents[key], str):  # 'drop', 'passthrough' can be passed
                 name = subcomponents[key]
-            elif subcomponents[key] is None:
-                name = "None"
             if key in subcomponents_explicit:
                 sub_components_names += "," + key + "=" + name
             else:
@@ -776,7 +774,7 @@ class SklearnExtension(Extension):
         external_versions.add(sklearn_version)
         for visitee in sub_components.values():
             # 'drop', 'passthrough', None can be passed as estimators
-            if isinstance(visitee, str) or visitee is None:
+            if isinstance(visitee, str):
                 continue
             for external_version in visitee.external_version.split(','):
                 external_versions.add(external_version)
@@ -795,8 +793,6 @@ class SklearnExtension(Extension):
             visitee = to_visit_stack.pop()
             if isinstance(visitee, str):  # 'drop', 'passthrough' can be passed as estimators
                 known_sub_components.add(visitee)
-            elif visitee is None:  # a None step can be included in a Pipeline
-                known_sub_components.add(str(visitee))
             elif visitee.name in known_sub_components:
                 raise ValueError('Found a second occurence of component %s when '
                                  'trying to serialize %s.' % (visitee.name, model))
@@ -883,7 +879,12 @@ class SklearnExtension(Extension):
                             raise ValueError(msg)
                         else:
                             pass
-                    elif not isinstance(sub_component, (OpenMLFlow, type(None))):
+                    elif isinstance(sub_component, type(None)):
+                        msg = 'Cannot serialize objects of None type. Please replace with a '\
+                              'relevant placeholder. Note that empty sklearn estimators can be '\
+                              'replaced with \'drop\' or \'passthrough\'.'
+                        raise ValueError(msg)
+                    elif not isinstance(sub_component, OpenMLFlow):
                         msg = 'Second item of tuple does not match assumptions. ' \
                               'Expected OpenMLFlow, got %s' % type(sub_component)
                         raise TypeError(msg)

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -867,7 +867,7 @@ class SklearnExtension(Extension):
                 for i, sub_component_tuple in enumerate(rval):
                     identifier = sub_component_tuple[0]
                     sub_component = sub_component_tuple[1]
-                    sub_component_type = type(sub_component_tuple)
+                    # sub_component_type = type(sub_component_tuple)
                     if not 2 <= len(sub_component_tuple) <= 3:
                         # length 2 is for {VotingClassifier.estimators,
                         # Pipeline.steps, FeatureUnion.transformer_list}
@@ -896,33 +896,18 @@ class SklearnExtension(Extension):
                                                         identifier)
                         raise PyOpenMLError(msg)
 
-                    if sub_component is None:
-                        # In a FeatureUnion, Pipeline it is legal to have a None step
-
-                        pv = [identifier, None]
-                        if sub_component_type is tuple:
-                            parameter_value.append(tuple(pv))
-                        else:
-                            parameter_value.append(pv)
-                        sub_components_explicit.add(identifier)
-                        sub_components[identifier] = sub_component
-
-                    else:
-                        # Add the component to the list of components, add a
-                        # component reference as a placeholder to the list of
-                        # parameters, which will be replaced by the real component
-                        # when deserializing the parameter
-                        sub_components_explicit.add(identifier)
-                        sub_components[identifier] = sub_component
-                        component_reference = OrderedDict()  # type: Dict[str, Union[str, Dict]]
-                        component_reference['oml-python:serialized_object'] = 'component_reference'
-                        cr_value = OrderedDict()  # type: Dict[str, Any]
-                        cr_value['key'] = identifier
-                        cr_value['step_name'] = identifier
-                        if len(sub_component_tuple) == 3:
-                            cr_value['argument_1'] = sub_component_tuple[2]
-                        component_reference['value'] = cr_value
-                        parameter_value.append(component_reference)
+                    # when deserializing the parameter
+                    sub_components_explicit.add(identifier)
+                    sub_components[identifier] = sub_component
+                    component_reference = OrderedDict()  # type: Dict[str, Union[str, Dict]]
+                    component_reference['oml-python:serialized_object'] = 'component_reference'
+                    cr_value = OrderedDict()  # type: Dict[str, Any]
+                    cr_value['key'] = identifier
+                    cr_value['step_name'] = identifier
+                    if len(sub_component_tuple) == 3:
+                        cr_value['argument_1'] = sub_component_tuple[2]
+                    component_reference['value'] = cr_value
+                    parameter_value.append(component_reference)
 
                 # Here (and in the elif and else branch below) are the only
                 # places where we encode a value as json to make sure that all

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -28,7 +28,6 @@ import sklearn.pipeline
 import sklearn.preprocessing
 import sklearn.tree
 import sklearn.cluster
-from sklearn.impute import SimpleImputer
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
@@ -38,7 +37,7 @@ from openml.exceptions import PyOpenMLError
 from openml.flows import OpenMLFlow
 from openml.flows.functions import assert_flows_equal
 from openml.runs.trace import OpenMLRunTrace
-from openml.testing import TestBase
+from openml.testing import TestBase, SimpleImputer
 
 
 this_directory = os.path.dirname(os.path.abspath(__file__))
@@ -1780,8 +1779,9 @@ class TestSklearnExtensionRunFunctions(TestBase):
         self.assertEqual("weka.IsolationForest",
                          SklearnExtension.trim_flow_name("weka.IsolationForest"))
 
-    @unittest.skipIf(LooseVersion(sklearn.__version__) < "0.20",
-                     reason="SimpleImputer, ColumnTransformer available only after 0.19")
+    @unittest.skipIf(LooseVersion(sklearn.__version__) < "0.21",
+                     reason="SimpleImputer, ColumnTransformer available only after 0.19 and "
+                            "Pipeline till 0.20 doesn't support indexing and 'passthrough'")
     def test_run_on_model_with_empty_steps(self):
         from sklearn.compose import ColumnTransformer
         # testing 'drop', 'passthrough', None as non-actionable sklearn estimators

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -28,10 +28,9 @@ import sklearn.pipeline
 import sklearn.preprocessing
 import sklearn.tree
 import sklearn.cluster
-from sklearn.pipeline import make_pipeline
-from sklearn.compose import ColumnTransformer
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn.impute import SimpleImputer
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 import openml
 from openml.extensions.sklearn import SklearnExtension
@@ -1782,8 +1781,9 @@ class TestSklearnExtensionRunFunctions(TestBase):
                          SklearnExtension.trim_flow_name("weka.IsolationForest"))
 
     @unittest.skipIf(LooseVersion(sklearn.__version__) < "0.20",
-                     reason="SimpleImputer available only after 0.19")
+                     reason="SimpleImputer, ColumnTransformer available only after 0.19")
     def test_run_on_model_with_empty_steps(self):
+        from sklearn.compose import ColumnTransformer
         # testing 'drop', 'passthrough', None as non-actionable sklearn estimators
         dataset = openml.datasets.get_dataset(128)
         task = openml.tasks.get_task(59)
@@ -1829,7 +1829,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
 
         # de-serializing flow to a model with non-actionable step
         model = self.extension.flow_to_model(flow)
-
+        model.fit(X, y)
         self.assertEqual(type(model), type(clf))
         self.assertNotEqual(model, clf)
         self.assertEqual(len(model.named_steps), 4)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
Addresses #825 and #480. 

#### What does this PR implement/fix? Explain your changes.
The serialization expects each step to be a sklearn module and eventually an OpenMLFlow or a None. For ColumnTransform operations, a _drop_ or _passthrough_ can be specified to include a step in a pipeline but not execute it. The changes in this PR incorporates this additional string handling of the keywords _drop_ and _passthrough_ in a ColumnTransformer call.

#### How should this PR be tested?
```python
import openml
import numpy as np
import pandas as pd
from sklearn.pipeline import make_pipeline
from sklearn.compose import ColumnTransformer
from sklearn.preprocessing import OneHotEncoder, StandardScaler
from sklearn.impute import SimpleImputer
from sklearn.tree import DecisionTreeClassifier

dataset_id = 61
dataset = openml.datasets.get_dataset(dataset_id)

task = openml.tasks.get_task(59)

X, y, categorical_ind, feature_names = dataset.get_data(target=dataset.default_target_attribute, dataset_format='array')
categorical_ind = np.array(categorical_ind)
cat_idx, = np.where(categorical_ind)
cont_idx, = np.where(~categorical_ind)

clf = make_pipeline(ColumnTransformer([('cat', make_pipeline(SimpleImputer(strategy='most_frequent'), OneHotEncoder()), cat_idx.tolist()),
                                       ('cont', make_pipeline(SimpleImputer(strategy='median'), StandardScaler()), cont_idx.tolist())])          
                , DecisionTreeClassifier(max_depth=1))
if not categorical_ind.any():
    clf[0].set_params(cat='drop')
if not (~categorical_ind).any():
    clf[0].set_params(cont='drop')
hotencoded = clf[:-1].fit_transform(X)

bla = openml.runs.run_model_on_task(model=clf, task=task, return_flow=True)
```

#### Any other comments?
This PR handles the specific case of a ColumnTransform. I'm not sure if there are other such keywords which should be handled equivalently. We can then maintain a keyword listing, based on the sklearn version under extension.py and handle them with a similar logic. 
If there are more diverse cases that may arise, some examples would help in designing a generalized solution in that case.
Would need to accordingly design relevant unit tests too.