### PR TITLE
Changes proposed in #885. Don't register handlers by default.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
   # Install the build and runtime dependencies of the project.
   - "cd C:\\projects\\openml-python"
   - "pip install .[examples,test]"
-  - conda install --quiet --yes scikit-learn=0.22
+  - conda install --quiet --yes scikit-learn=0.21
 
 
 # Not a .NET project, we build scikit-learn in the install step instead

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
   # Install the build and runtime dependencies of the project.
   - "cd C:\\projects\\openml-python"
   - "pip install .[examples,test]"
-  - conda install --quiet --yes scikit-learn=0.20.0
+  - conda install --quiet --yes scikit-learn=0.22
 
 
 # Not a .NET project, we build scikit-learn in the install step instead

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
   # Install the build and runtime dependencies of the project.
   - "cd C:\\projects\\openml-python"
   - "pip install .[examples,test]"
-  - conda install --quiet --yes scikit-learn=0.21
+  - "pip install scikit-learn==0.21"
 
 
 # Not a .NET project, we build scikit-learn in the install step instead

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -11,6 +11,8 @@ Changelog
 
 * FIX #873: Fixes an issue which resulted in incorrect URLs when printing OpenML objects after
   switching the server
+* FIX #885: Logger no longer registered by default. Added utility functions to easily register
+  logging to console and file.
 * MAINT #767: Source distribution installation is now unit-tested.
 * MAINT #865: OpenML no longer bundles test files in the source distribution.
 

--- a/openml/config.py
+++ b/openml/config.py
@@ -22,6 +22,10 @@ file_handler = None
 def _create_log_handlers():
     """ Creates but does not attach the log handlers. """
     global console_handler, file_handler
+    if console_handler is not None or file_handler is not None:
+        logger.debug("Requested to create log handlers, but they are already created.")
+        return
+
     message_format = '[%(levelname)s] [%(asctime)s:%(name)s] %(message)s'
     output_formatter = logging.Formatter(message_format, datefmt='%H:%M:%S')
 

--- a/openml/config.py
+++ b/openml/config.py
@@ -7,7 +7,7 @@ Store module level information like the API key, cache directory and the server
 import logging
 import logging.handlers
 import os
-from typing import cast, Optional, Tuple, Any
+from typing import Optional, Tuple
 
 from io import StringIO
 import configparser
@@ -48,11 +48,7 @@ def _convert_log_levels(log_level: int) -> Tuple[int, int]:
     return openml_level, python_level
 
 
-def _set_level_register_and_store(
-        handler: logging.Handler,
-        log_level: int,
-        store_under_key: Optional[str] = None
-):
+def _set_level_register_and_store(handler: logging.Handler, log_level: int):
     """ Set handler log level, register it if needed, save setting to config file if specified. """
     oml_level, py_level = _convert_log_levels(log_level)
     handler.setLevel(py_level)
@@ -63,32 +59,17 @@ def _set_level_register_and_store(
     if handler not in openml_logger.handlers:
         openml_logger.addHandler(handler)
 
-    if store_under_key is not None:
-        _save_setting_to_configuration(store_under_key, oml_level)
 
-
-def set_console_log_level(
-        console_output_level: Optional[int] = None,
-        save_as_default: bool = False
-):
+def set_console_log_level(console_output_level: Optional[int] = None):
     """ Set console output to the desired level and register it with openml logger if needed. """
     global console_handler
-    store_under_key = 'verbosity' if save_as_default else None
-    _set_level_register_and_store(console_handler, console_output_level, store_under_key)
+    _set_level_register_and_store(console_handler, console_output_level)
 
 
-def set_file_log_level(
-        file_output_level: Optional[int] = None,
-        save_as_default: bool = False
-):
+def set_file_log_level(file_output_level: Optional[int] = None):
     """ Set file output to the desired level and register it with openml logger if needed. """
     global file_handler
-    store_under_key = 'file_verbosity' if save_as_default else None
-    _set_level_register_and_store(file_handler, file_output_level, store_under_key)
-
-
-def _save_setting_to_configuration(key: str, value: Any):
-    raise NotImplementedError("Storing values not yet supported.")
+    _set_level_register_and_store(file_handler, file_output_level)
 
 
 # Default values (see also https://github.com/openml/OpenML/wiki/Client-API-Standards)
@@ -223,9 +204,7 @@ def _setup():
 
 
 def _parse_config():
-    """Parse the config file, set up defaults.
-    """
-
+    """ Parse the config file, set up defaults. """
     config = configparser.RawConfigParser(defaults=_defaults)
 
     if not os.path.exists(config_file):
@@ -303,14 +282,4 @@ __all__ = [
 ]
 
 _setup()
-
-
 _create_log_handlers()
-_config = _parse_config()
-
-if _config['FAKE_SECTION'].get('verbosity', None) is not None:
-    _console_log_level = int(_config.get('FAKE_SECTION', 'verbosity'))
-    set_console_log_level(_console_log_level)
-if _config['FAKE_SECTION'].get('file_verbosity', None) is not None:
-    _file_log_level = int(_config.get('FAKE_SECTION', 'file_verbosity'))
-    set_file_log_level(_file_log_level)

--- a/openml/config.py
+++ b/openml/config.py
@@ -286,4 +286,4 @@ __all__ = [
 ]
 
 _setup()
-# _create_log_handlers()
+_create_log_handlers()

--- a/openml/config.py
+++ b/openml/config.py
@@ -7,47 +7,92 @@ Store module level information like the API key, cache directory and the server
 import logging
 import logging.handlers
 import os
-from typing import cast
+from typing import cast, Optional, Tuple, Any
 
 from io import StringIO
 import configparser
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+openml_logger = logging.getLogger('openml')
+console_handler = None
+file_handler = None
 
 
-def configure_logging(console_output_level: int, file_output_level: int):
-    """ Sets the OpenML logger to DEBUG, with attached Stream- and FileHandler. """
-    # Verbosity levels as defined (https://github.com/openml/OpenML/wiki/Client-API-Standards)
-    # don't match Python values directly:
-    verbosity_map = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
-
-    openml_logger = logging.getLogger('openml')
-    openml_logger.setLevel(logging.DEBUG)
+def _create_log_handlers():
+    """ Creates but does not attach the log handlers. """
+    global console_handler, file_handler
     message_format = '[%(levelname)s] [%(asctime)s:%(name)s] %(message)s'
     output_formatter = logging.Formatter(message_format, datefmt='%H:%M:%S')
 
-    console_stream = logging.StreamHandler()
-    console_stream.setFormatter(output_formatter)
-    console_stream.setLevel(verbosity_map[console_output_level])
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(output_formatter)
 
-    one_mb = 2**20
+    one_mb = 2 ** 20
     log_path = os.path.join(cache_directory, 'openml_python.log')
-    file_stream = logging.handlers.RotatingFileHandler(log_path, maxBytes=one_mb, backupCount=1)
-    file_stream.setLevel(verbosity_map[file_output_level])
-    file_stream.setFormatter(output_formatter)
+    file_handler = logging.handlers.RotatingFileHandler(log_path, maxBytes=one_mb, backupCount=1)
+    file_handler.setFormatter(output_formatter)
 
-    openml_logger.addHandler(console_stream)
-    openml_logger.addHandler(file_stream)
-    return console_stream, file_stream
+
+def _convert_log_levels(log_level: int) -> Tuple[int, int]:
+    """ Converts a log level that's either defined by OpenML/Python to both specifications. """
+    # OpenML verbosity level don't match Python values directly:
+    openml_to_python = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    python_to_openml = {logging.DEBUG: 2, logging.INFO: 1, logging.WARNING: 0,
+                        logging.CRITICAL: 0, logging.ERROR: 0}
+    # Because the dictionaries share no keys, we use `get` to convert as necessary:
+    openml_level = python_to_openml.get(log_level, log_level)
+    python_level = openml_to_python.get(log_level, log_level)
+    return openml_level, python_level
+
+
+def _set_level_register_and_store(
+        handler: logging.Handler,
+        log_level: int,
+        store_under_key: Optional[str] = None
+):
+    """ Set handler log level, register it if needed, save setting to config file if specified. """
+    oml_level, py_level = _convert_log_levels(log_level)
+    handler.setLevel(py_level)
+
+    if openml_logger.level > py_level or openml_logger.level == logging.NOTSET:
+        openml_logger.setLevel(py_level)
+
+    if handler not in openml_logger.handlers:
+        openml_logger.addHandler(handler)
+
+    if store_under_key is not None:
+        _save_setting_to_configuration(store_under_key, oml_level)
+
+
+def set_console_log_level(
+        console_output_level: Optional[int] = None,
+        save_as_default: bool = False
+):
+    """ Set console output to the desired level and register it with openml logger if needed. """
+    global console_handler
+    store_under_key = 'verbosity' if save_as_default else None
+    _set_level_register_and_store(console_handler, console_output_level, store_under_key)
+
+
+def set_file_log_level(
+        file_output_level: Optional[int] = None,
+        save_as_default: bool = False
+):
+    """ Set file output to the desired level and register it with openml logger if needed. """
+    global file_handler
+    store_under_key = 'file_verbosity' if save_as_default else None
+    _set_level_register_and_store(file_handler, file_output_level, store_under_key)
+
+
+def _save_setting_to_configuration(key: str, value: Any):
+    raise NotImplementedError("Storing values not yet supported.")
 
 
 # Default values (see also https://github.com/openml/OpenML/wiki/Client-API-Standards)
 _defaults = {
     'apikey': None,
     'server': "https://www.openml.org/api/v1/xml",
-    'verbosity': 0,  # WARNING
-    'file_verbosity': 2,  # DEBUG
     'cachedir': os.path.expanduser(os.path.join('~', '.openml', 'cache')),
     'avoid_duplicate_runs': 'True',
     'connection_n_retries': 2,
@@ -189,6 +234,7 @@ def _parse_config():
                     "create an empty file there." % config_file)
 
     try:
+        # The ConfigParser requires a [SECTION_HEADER], which we do not expect in our config file.
         # Cheat the ConfigParser module by adding a fake section header
         config_file_ = StringIO()
         config_file_.write("[FAKE_SECTION]\n")
@@ -256,6 +302,12 @@ __all__ = [
 
 _setup()
 
-_console_log_level = cast(int, _defaults['verbosity'])
-_file_log_level = cast(int, _defaults['file_verbosity'])
-console_log, file_log = configure_logging(_console_log_level, _file_log_level)
+
+_create_log_handlers()
+
+if 'verbosity' in _defaults:
+    _console_log_level = cast(int, _defaults['verbosity'])
+    set_console_log_level(_console_log_level)
+if 'file_verbosity' in _defaults:
+    _file_log_level = cast(int, _defaults['file_verbosity'])
+    set_file_log_level(_file_log_level)

--- a/openml/config.py
+++ b/openml/config.py
@@ -7,7 +7,7 @@ Store module level information like the API key, cache directory and the server
 import logging
 import logging.handlers
 import os
-from typing import Optional, Tuple
+from typing import Tuple, cast
 
 from io import StringIO
 import configparser
@@ -64,16 +64,16 @@ def _set_level_register_and_store(handler: logging.Handler, log_level: int):
         openml_logger.addHandler(handler)
 
 
-def set_console_log_level(console_output_level: Optional[int] = None):
+def set_console_log_level(console_output_level: int):
     """ Set console output to the desired level and register it with openml logger if needed. """
     global console_handler
-    _set_level_register_and_store(console_handler, console_output_level)
+    _set_level_register_and_store(cast(logging.Handler, console_handler), console_output_level)
 
 
-def set_file_log_level(file_output_level: Optional[int] = None):
+def set_file_log_level(file_output_level: int):
     """ Set file output to the desired level and register it with openml logger if needed. """
     global file_handler
-    _set_level_register_and_store(file_handler, file_output_level)
+    _set_level_register_and_store(cast(logging.Handler, file_handler), file_output_level)
 
 
 # Default values (see also https://github.com/openml/OpenML/wiki/Client-API-Standards)

--- a/openml/config.py
+++ b/openml/config.py
@@ -286,4 +286,4 @@ __all__ = [
 ]
 
 _setup()
-_create_log_handlers()
+# _create_log_handlers()

--- a/openml/config.py
+++ b/openml/config.py
@@ -30,7 +30,9 @@ def _create_log_handlers():
 
     one_mb = 2 ** 20
     log_path = os.path.join(cache_directory, 'openml_python.log')
-    file_handler = logging.handlers.RotatingFileHandler(log_path, maxBytes=one_mb, backupCount=1)
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_path, maxBytes=one_mb, backupCount=1, delay=True
+    )
     file_handler.setFormatter(output_formatter)
 
 
@@ -304,10 +306,11 @@ _setup()
 
 
 _create_log_handlers()
+_config = _parse_config()
 
-if 'verbosity' in _defaults:
-    _console_log_level = cast(int, _defaults['verbosity'])
+if _config['FAKE_SECTION'].get('verbosity', None) is not None:
+    _console_log_level = int(_config.get('FAKE_SECTION', 'verbosity'))
     set_console_log_level(_console_log_level)
-if 'file_verbosity' in _defaults:
-    _file_log_level = cast(int, _defaults['file_verbosity'])
+if _config['FAKE_SECTION'].get('file_verbosity', None) is not None:
+    _file_log_level = int(_config.get('FAKE_SECTION', 'file_verbosity'))
     set_file_log_level(_file_log_level)


### PR DESCRIPTION
Fixes #885.

First implementation of changes suggested in #885:
 - don't register log handlers by default
 - don't set openml logger log level by default

A user can now specify the console and file log levels through `set_console_log_level` and `set_file_log_level` respectively. As input they expect the log level (both OpenML's 0/1/2 and Python log levels are accepted), and a bool `save_as_default`.  Actually saving to the config file is right now not supported (and will raise a `NotImplementedError`). Calling these functions registers the respective handler if it wasn't yet, set/change it to the appropriate value, and ensures the openml logger is set to the right log level.

Consider this code:

```python
import logging

if __name__ == '__main__':
    log = logging.getLogger('mypackage')
    log.setLevel(logging.DEBUG)

    log.info("Message one")
    # 1: just import OpenML
    import openml
    # 2: Specify console log
    # openml.config.set_console_log_level(logging.DEBUG)
    # 3: Specify file log
    # openml.config.set_file_log_level(logging.DEBUG)
    log.info("Message two")

    from openml.flows import get_flow
    f = get_flow(123)
    f.description = ''
    f._to_dict()  # logging.warning will be called due to empty description.

    from openml.datasets import get_dataset
    iris = get_dataset(61)  # since I have it in cache, a logging.debug statement is called.

```

The output we get, uncommenting respective lines for scenario '2' and '3':

1: `Flow 'weka.LinearRegression's empty description` to console only. This is default behavior for warning level messages. The debug message from the last line is ignored.
2: 
```
[WARNING] [11:51:24:openml.flows.flow] Flow 'weka.LinearRegression's empty description
[DEBUG] [11:51:24:openml.datasets.dataset] Data pickle file already exists and is up to date.
``` 
to console only.

3 (the line specifying console output was commented out again): 
```
[WARNING] [11:53:46:openml.flows.flow] Flow 'weka.LinearRegression's empty description
[DEBUG] [11:53:46:openml.datasets.dataset] Data pickle file already exists and is up to date.
```
written to file, no console output. Note that the warning message is now also not printed to console. 

---
This does not include changes to where the config/cache directories are located.

Writing to the config file is not yet supported. I noticed we hack our way around the configparser module. If we want to support writing to the log file from the python module (which I'm for), we need to look at other options or implement our own (our log file definition is very simple). In fact, 
I would further propose refactoring the openml.config module into smaller submodules as a lot of different things are going on within the same module now (loading, logging, test configuration).

I'm willing to do the above refactoring, but it might take a few weeks (I'm very busy until the holidays).
