### PR TITLE
store uint8 data in uint8 not float

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -388,6 +388,15 @@ class OpenMLDataset(OpenMLBase):
                                                     'boolean'):
                     col.append(self._unpack_categories(
                         X[column_name], categories_names[column_name]))
+                elif attribute_dtype[column_name] in ('floating',
+                                                      'integer'):
+                    X_col = X[column_name]
+                    if X_col.min() == 0 and X_col.max() == 255:
+                        X_col_uint = X_col.astype('uint8')
+                        if (X_col == X_col_uint).all():
+                            col.append(X_col_uint)
+                            continue
+                    col.append(X[column_name])
                 else:
                     col.append(X[column_name])
             X = pd.concat(col, axis=1)

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -392,10 +392,13 @@ class OpenMLDataset(OpenMLBase):
                                                       'integer'):
                     X_col = X[column_name]
                     if X_col.min() >= 0 and X_col.max() <= 255:
-                        X_col_uint = X_col.astype('uint8')
-                        if (X_col == X_col_uint).all():
-                            col.append(X_col_uint)
-                            continue
+                        try:
+                            X_col_uint = X_col.astype('uint8')
+                            if (X_col == X_col_uint).all():
+                                col.append(X_col_uint)
+                                continue
+                        except ValueError:
+                            pass
                     col.append(X[column_name])
                 else:
                     col.append(X[column_name])

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -391,7 +391,7 @@ class OpenMLDataset(OpenMLBase):
                 elif attribute_dtype[column_name] in ('floating',
                                                       'integer'):
                     X_col = X[column_name]
-                    if X_col.min() == 0 and X_col.max() == 255:
+                    if X_col.min() >= 0 and X_col.max() <= 255:
                         X_col_uint = X_col.astype('uint8')
                         if (X_col == X_col_uint).all():
                             col.append(X_col_uint)

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -352,6 +352,13 @@ class TestOpenMLDataset(TestBase):
         openml.config.server = self.production_server
         self.assertRaises(OpenMLPrivateDatasetError, openml.datasets.get_dataset, 45)
 
+    def test_get_dataset_uint8_dtype(self):
+        dataset = openml.datasets.get_dataset(1)
+        self.assertEqual(type(dataset), OpenMLDataset)
+        self.assertEqual(dataset.name, 'anneal')
+        df, _, _, _ = dataset.get_data()
+        self.assertEqual(df['carbon'].dtype, 'uint8')
+
     def test_get_dataset_lazy(self):
         dataset = openml.datasets.get_dataset(1, download_data=False)
         self.assertEqual(type(dataset), OpenMLDataset)


### PR DESCRIPTION
Fixes #891.
Most of the large datasets in cc-18 are actually "image" dataset with entries from 0-255. Storing them as uint8 will drastically remove the storage space required as well as storing and loading times.

This is special-casing but I think it's a common and important special case. The CIFAR-10 dataset pickle went from 1.4G to 176MB with this patch.