### PR TITLE
More robust handling of openml_url

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -101,7 +101,7 @@ def get_server_base_url() -> str:
     =======
     str
     """
-    return server[:-len('/api/v1/xml')]
+    return server.split("/api")[0]
 
 
 apikey = _defaults['apikey']


### PR DESCRIPTION
#### What does this PR implement/fix? Explain your changes.
I ran into issues when the openml server config is not exactly 'https://www.openml.org/api/v1/xml', e.g. I had 'https://www.openml.org/api/v1'.
I only noticed when getting a bad dataset url.

This edit makes the API more robust against how exactly the server URL is set in the config.

#### How should this PR be tested?
set config to:
server=https://www.openml.org/api/v1

And run
```
d = openml.datasets.get_dataset(1)
d.openml_url
```

The URL should be correct.

