### PR TITLE
Increase unit test stability

### DIFF
--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -84,7 +84,7 @@ class TestRun(TestBase):
             if len(run.evaluations) > 0:
                 return
             else:
-                time.sleep(3)
+                time.sleep(10)
         raise RuntimeError(
             "Could not find any evaluations! Please check whether run {} was "
             "evaluated correctly on the server".format(run_id)
@@ -915,7 +915,7 @@ class TestRun(TestBase):
             run = run.publish()
             TestBase._mark_entity_for_removal("run", run.run_id)
             TestBase.logger.info("collected from test_run_functions: {}".format(run.run_id))
-            self._wait_for_processed_run(run.run_id, 200)
+            self._wait_for_processed_run(run.run_id, 400)
             run_id = run.run_id
         except openml.exceptions.OpenMLRunsExistError as e:
             # The only error we expect, should fail otherwise.

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -81,7 +81,7 @@ class TestRun(TestBase):
         start_time = time.time()
         while time.time() - start_time < max_waiting_time_seconds:
             run = openml.runs.get_run(run_id, ignore_cache=True)
-            if len(run.evaluations) > 0:
+            if len(run.evaluations) > 0 and run.trace is not None:
                 return
             else:
                 time.sleep(10)

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -81,10 +81,19 @@ class TestRun(TestBase):
         start_time = time.time()
         while time.time() - start_time < max_waiting_time_seconds:
             run = openml.runs.get_run(run_id, ignore_cache=True)
-            if len(run.evaluations) > 0 and run.trace is not None:
-                return
-            else:
+
+            try:
+                openml.runs.get_run_trace(run_id)
+            except openml.exceptions.OpenMLServerException:
                 time.sleep(10)
+                continue
+
+            if len(run.evaluations) == 0:
+                time.sleep(10)
+                continue
+
+            return
+
         raise RuntimeError(
             "Could not find any evaluations! Please check whether run {} was "
             "evaluated correctly on the server".format(run_id)


### PR DESCRIPTION
Currently, a lot of unit tests are failing because the server cannot process run traces fast enough. This PR increases the time to wait for a trace to reduce the amount of unit tests failing when using continuous integration.

