### PR TITLE
improve error message for dataset upload

### DIFF
--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -38,13 +38,13 @@ class OpenMLDatasetTest(TestBase):
         str(data)
 
     def test_init_string_validation(self):
-        with pytest.raises(ValueError, match="Invalid symbols in name"):
+        with pytest.raises(ValueError, match="Invalid symbols ' ' in name"):
             openml.datasets.OpenMLDataset(name="some name", description="a description")
 
-        with pytest.raises(ValueError, match="Invalid symbols in description"):
+        with pytest.raises(ValueError, match="Invalid symbols 'ï' in description"):
             openml.datasets.OpenMLDataset(name="somename", description="a descriptïon")
 
-        with pytest.raises(ValueError, match="Invalid symbols in citation"):
+        with pytest.raises(ValueError, match="Invalid symbols 'ü' in citation"):
             openml.datasets.OpenMLDataset(
                 name="somename", description="a description", citation="Something by Müller"
             )


### PR DESCRIPTION
closes #920

Given the following piece of code:
```python
import openml
import sklearn.datasets
import pandas as pd
import numpy as np

X, y = sklearn.datasets.make_classification()
data = pd.DataFrame(X)
data['y'] = y

my_dataset = openml.datasets.create_dataset(
    name="My cool dataset",
    description="foo",
    creator="bar",
    contributor=None,
    collection_date='01-01-2011',
    language='English',
    licence=None,
    default_target_attribute='label',
    row_id_attribute=None,
    ignore_attribute=None,
    citation="foo",
    attributes='auto',
    data=data,
    version_label='1.0',
)
```
the error message improves from
```
ValueError: Invalid symbols in name: My cool dataset
```
to
```
ValueError: Invalid symbols ' ' in name: My cool dataset
```
