### PR TITLE
Fork api

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.11.0
 ~~~~~~
+* ADD #929: Add fork API
 * ADD #929: Add data edit API
 * FIX #873: Fixes an issue which resulted in incorrect URLs when printing OpenML objects after
   switching the server.

--- a/examples/30_extended/datasets_tutorial.py
+++ b/examples/30_extended/datasets_tutorial.py
@@ -11,7 +11,7 @@ How to list and download datasets.
 
 import openml
 import pandas as pd
-from openml.datasets.functions import edit_dataset, get_dataset
+from openml.datasets.functions import edit_dataset, get_dataset, fork_dataset
 
 ############################################################################
 # Exercise 0
@@ -143,5 +143,15 @@ new_attributes = [
 ]
 data_id = edit_dataset(564, attributes=new_attributes)
 print(f"Edited dataset ID: {data_id}")
+
+############################################################################
+# Fork an existing dataset
+# =================================================
+# This example continues to use the test server, to avoid creating multiple copies on main server.
+############################################################################
+
+forked_did, forked_dataset = fork_dataset(68)
+print(f"Forked dataset ID: {forked_did}")
+print(forked_dataset)
 
 openml.config.stop_using_configuration_for_example()

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -27,6 +27,7 @@ from openml.utils import _tag_entity, _create_cache_directory_for_id
 from openml.datasets.functions import (
     create_dataset,
     edit_dataset,
+    fork_dataset,
     attributes_arff_from_df,
     _get_cached_dataset,
     _get_cached_dataset_features,
@@ -1409,4 +1410,24 @@ class TestOpenMLDataset(TestBase):
             edit_dataset,
             data_id=564,
             description="xor data",
+        )
+
+    def test_data_fork(self):
+        # Dense dataset fork
+        did = 20
+        old_dataset = openml.datasets.get_dataset(did)
+        forked_id, forked_dataset = fork_dataset(did)
+        self.assertEqual(old_dataset.description, forked_dataset.description)
+        self.assertNotEqual(forked_id, did)
+
+        # Sparse dataset fork
+        did = 564
+        old_dataset = openml.datasets.get_dataset(did)
+        forked_id, forked_dataset = fork_dataset(did)
+        self.assertEqual(old_dataset.description, forked_dataset.description)
+        self.assertNotEqual(forked_id, did)
+
+        # Check server exception when unknown dataset is provided
+        self.assertRaisesRegex(
+            OpenMLServerException, "Unknown dataset", fork_dataset, data_id=100000,
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
#929 


#### What does this PR implement/fix? Explain your changes.
Fork API to clone a dataset. 

There are some changes to the edit-api as well, as it was using a function get_arff which was a protected member and also, it did not work well for all datasets. Now its replaced with get_data.

#### How should this PR be tested?
```
id, forked_dataset = fork_dataset(did)
time.sleep(60)
dataset = get_dataset(id)
print(dataset.features)
```

#### Any other comments?
For the testing, I have just compared the did. Ideally we want to check if the cloned data==old data and cloned features == old features.  But the time taken for the status of the dataset to change to active varies (may be 1 min).
time.sleep(60) should work most of the time, but I am not sure if the tests may fail at some point.
Let me know if it is a good idea to add this to the test. Something like:
```
old_dataset = get_dataset(did)
id, forked_dataset = fork_dataset(did)
time.sleep(60)
forked_dataset = get_dataset(id)
assertEqual(old_dataset.features == old_dataset.features)
```
