### PR TITLE
Fix edit api

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.11.0
 ~~~~~~
+* ADD #929: Fix data edit API
 * ADD #929: Add data edit API
 * FIX #873: Fixes an issue which resulted in incorrect URLs when printing OpenML objects after
   switching the server.

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,7 +8,6 @@ Changelog
 
 0.11.0
 ~~~~~~
-* ADD #929: Fix data edit API
 * ADD #929: Add data edit API
 * FIX #873: Fixes an issue which resulted in incorrect URLs when printing OpenML objects after
   switching the server.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this PR implement/fix? Explain your changes.
the get_arff function is not reliable and sometimes causes errors for dense vs sparse datasets.
I have fixed this by using get_data instead.
The get_arff did not work for some dense datasets. When we use the data returned by get_arff to construct the new dataset, it resulted in errors during dataset publish.

#### How should this PR be tested?


#### Any other comments?
This api is going to change based on server changes in future. We are going to get rid of the cloning except when data itself changes
