### PR TITLE
change edit_api to reflect server

### DIFF
--- a/examples/30_extended/datasets_tutorial.py
+++ b/examples/30_extended/datasets_tutorial.py
@@ -21,7 +21,7 @@ from openml.datasets.functions import edit_dataset, get_dataset
 #
 #   * Use the output_format parameter to select output type
 #   * Default gives 'dict' (other option: 'dataframe', see below)
-
+#
 openml_list = openml.datasets.list_datasets()  # returns a dict
 
 # Show a nice table with some key data properties
@@ -117,15 +117,19 @@ _ = pd.plotting.scatter_matrix(
 # This example uses the test server, to avoid editing a dataset on the main server.
 openml.config.start_using_configuration_for_example()
 ############################################################################
-# Changes to these field edits existing version: allowed only for dataset owner
+# Change the non-critical fields
+desc = (
+    "This data sets consists of 3 different types of irises' "
+    "(Setosa, Versicolour, and Virginica) petal and sepal length,"
+    " stored in a 150x4 numpy.ndarray"
+)
+did = 128
 data_id = edit_dataset(
-    564,
-    description="xor dataset represents XOR operation",
-    contributor="",
-    collection_date="2019-10-29 17:06:18",
-    original_data_url="https://www.kaggle.com/ancientaxe/and-or-xor",
-    paper_url="",
-    citation="kaggle",
+    did,
+    description=desc,
+    creator="R.A.Fisher",
+    collection_date="1937",
+    citation="The use of multiple measurements in taxonomic problems",
     language="English",
 )
 edited_dataset = get_dataset(data_id)
@@ -133,15 +137,11 @@ print(f"Edited dataset ID: {data_id}")
 
 
 ############################################################################
-# Changes to these fields: attributes, default_target_attribute,
-# row_id_attribute, ignore_attribute generates a new edited version: allowed for anyone
-
-new_attributes = [
-    ("x0", "REAL"),
-    ("x1", "REAL"),
-    ("y", "REAL"),
-]
-data_id = edit_dataset(564, attributes=new_attributes)
+# Changes to these fields: default_target_attribute, row_id_attribute,
+# ignore_attribute can only be performed by owner
+# To edit critical fields of a dataset owned by you, configure the API key:
+# openml.config.apikey = 'FILL_IN_OPENML_API_KEY'
+data_id = edit_dataset(564, default_target_attribute="y")
 print(f"Edited dataset ID: {data_id}")
 
 openml.config.stop_using_configuration_for_example()

--- a/examples/30_extended/datasets_tutorial.py
+++ b/examples/30_extended/datasets_tutorial.py
@@ -117,7 +117,9 @@ _ = pd.plotting.scatter_matrix(
 # This example uses the test server, to avoid editing a dataset on the main server.
 openml.config.start_using_configuration_for_example()
 ############################################################################
-# Change the non-critical fields
+# Edit non-critical fields, allowed for all authorized users:
+# description, creator, contributor, collection_date, language, citation,
+# row_id_attribute, original_data_url,paper_url
 desc = (
     "This data sets consists of 3 different types of irises' "
     "(Setosa, Versicolour, and Virginica) petal and sepal length,"
@@ -137,8 +139,8 @@ print(f"Edited dataset ID: {data_id}")
 
 
 ############################################################################
-# Changes to these fields: default_target_attribute, row_id_attribute,
-# ignore_attribute can only be performed by owner
+# Edit critical fields, allowed only for owners of the dataset:
+# default_target_attribute, row_id_attribute, ignore_attribute
 # To edit critical fields of a dataset owned by you, configure the API key:
 # openml.config.apikey = 'FILL_IN_OPENML_API_KEY'
 data_id = edit_dataset(564, default_target_attribute="y")

--- a/examples/30_extended/datasets_tutorial.py
+++ b/examples/30_extended/datasets_tutorial.py
@@ -119,7 +119,7 @@ openml.config.start_using_configuration_for_example()
 ############################################################################
 # Edit non-critical fields, allowed for all authorized users:
 # description, creator, contributor, collection_date, language, citation,
-# row_id_attribute, original_data_url,paper_url
+# original_data_url, paper_url
 desc = (
     "This data sets consists of 3 different types of irises' "
     "(Setosa, Versicolour, and Virginica) petal and sepal length,"

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1343,16 +1343,18 @@ class TestOpenMLDataset(TestBase):
     def test_data_edit(self):
         # Case 1
         # All users can edit non-critical fields of datasets
-        desc = "xor dataset representing XOR operation"
-        did = 564
+        desc = (
+            "This data sets consists of 3 different types of irises' "
+            "(Setosa, Versicolour, and Virginica) petal and sepal length,"
+            " stored in a 150x4 numpy.ndarray"
+        )
+        did = 128
         result = edit_dataset(
             did,
             description=desc,
-            contributor="xxx",
-            collection_date="2019-10-29 17:06:18",
-            original_data_url="https://www.kaggle.com/ancientaxe/and-or-xor",
-            paper_url="",
-            citation="kaggle",
+            creator="R.A.Fisher",
+            collection_date="1937",
+            citation="The use of multiple measurements in taxonomic problems",
             language="English",
         )
         self.assertEqual(did, result)
@@ -1360,20 +1362,15 @@ class TestOpenMLDataset(TestBase):
         self.assertEqual(edited_dataset.description, desc)
 
         # Case 2
-        # only admins or owners can edit all critical fields of datasets
-        # admin key for test server
-        openml.config.apikey = "d488d8afd93b32331cf6ea9d7003d4c3"
-        desc = "xor dataset represents XOR operation"
-        did = 565
-        result = edit_dataset(did, default_target_attribute="y", ignore_attribute="input1")
+        # only owners (or admin) can edit all critical fields of datasets
+        # this is a dataset created by CI, so it is editable by this test
+        did = 315
+        result = edit_dataset(did, default_target_attribute="col_1", ignore_attribute="col_2")
         self.assertEqual(did, result)
         edited_dataset = openml.datasets.get_dataset(did)
-        self.assertEqual(edited_dataset.ignore_attribute, ["input1"])
+        self.assertEqual(edited_dataset.ignore_attribute, ["col_2"])
 
     def test_data_edit_errors(self):
-
-        # admin key for test server (only admins or owners can edit datasets).
-        openml.config.apikey = "d488d8afd93b32331cf6ea9d7003d4c3"
         # Check server exception when no field to edit is provided
         self.assertRaisesRegex(
             OpenMLServerException,
@@ -1398,16 +1395,15 @@ class TestOpenMLDataset(TestBase):
             "Critical features default_target_attribute, row_id_attribute and ignore_attribute "
             "can only be edited for datasets without any tasks.",
             edit_dataset,
-            data_id=1,
+            data_id=223,
             default_target_attribute="y",
         )
         # Check server exception when a non-owner or non-admin tries to edit critical features
-        openml.config.apikey = "5f0b74b33503e4ad4a7181a91e28719f"
         self.assertRaisesRegex(
             OpenMLServerException,
             "Critical features default_target_attribute, row_id_attribute and ignore_attribute "
             "can be edited only by the owner. Fork the dataset if changes are required.",
             edit_dataset,
-            data_id=564,
+            data_id=128,
             default_target_attribute="y",
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
#929 


#### What does this PR implement/fix? Explain your changes.
The server has made changes to the edit_api. Refer https://github.com/openml/OpenML/pull/1058.
Summary of the changes:
**Edit API** - Edit **non-critical data fields** for everyone. Edit **critical fields** only for the owner, provided there are no tasks. If the owner already created a task, we will just throw an error.

**Fork API** - Clone the row as such with change in dataset ID and uploader ID.


#### How should this PR be tested?

#### Any other comments?

1. Fork API changes will be made in a new PR. This is more urgent as it is breaking the openml-python build.
2. Note that  "data" changes are not supported. If the data itself requires changes, the user has to create a new dataset. We will not be doing this through edit API or fork API, as it changes the arff file. 
3. In future we want to support versioning for descriptions (For now we allow direct changes without any version history.)