### PR TITLE
Added PEP 561 compliance (#945)

### DIFF
--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -67,11 +67,11 @@ fi
 
 # PEP 561 compliance check
 # Assumes mypy relies solely on the PEP 561 standard
-# Also assumes mypy to be available
 if ! python -m mypy -c "import openml"; then
    echo "Failed: PEP 561 compliance"
+   exit 1
 else
-   echo "Success: 561 compliance"
+   echo "Success: PEP 561 compliant"
 fi
 
 # Install scikit-learn last to make sure the openml package installation works

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -38,7 +38,7 @@ python --version
 
 if [[ "$TEST_DIST" == "true" ]]; then
     pip install twine nbconvert jupyter_client matplotlib pyarrow pytest pytest-xdist pytest-timeout \
-        nbformat oslo.concurrency flaky
+        nbformat oslo.concurrency flaky mypy
     python setup.py sdist
     # Find file which was modified last as done in https://stackoverflow.com/a/4561987
     dist=`find dist -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d" "`

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -52,6 +52,7 @@ fi
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 
+
 if [[ "$DOCPUSH" == "true" ]]; then
     conda install --yes gxx_linux-64 gcc_linux-64 swig
     pip install -e '.[examples,examples_unix]'
@@ -62,6 +63,15 @@ fi
 if [[ "$RUN_FLAKE8" == "true" ]]; then
     pip install pre-commit
     pre-commit install
+fi
+
+# PEP 561 compliance check
+# Assumes mypy relies solely on the PEP 561 standard
+# Also assumes mypy to be available
+if ! python -m mypy -c "import openml"; then
+   echo "Failed: PEP 561 compliance"
+else
+   echo "Success: 561 compliance"
 fi
 
 # Install scikit-learn last to make sure the openml package installation works

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -18,6 +18,7 @@ Changelog
 * MAINT #865: OpenML no longer bundles test files in the source distribution.
 * MAINT #897: Dropping support for Python 3.5.
 * ADD #894: Support caching of datasets using feather format as an option.
+* ADD #945: PEP 561 compliance for distributing Type information
 
 0.10.2
 ~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
     packages=setuptools.find_packages(
         include=["openml.*", "openml"], exclude=["*.tests", "*.tests.*", "tests.*", "tests"],
     ),
-    package_data={"": ["*.txt", "*.md"]},
+    package_data={"": ["*.txt", "*.md", "py.typed"]},
     python_requires=">=3.6",
     install_requires=[
         "liac-arff>=2.4.0",

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
             "pyarrow",
             "pre-commit",
             "pytest-cov",
+            "mypy",
         ],
         "examples": [
             "matplotlib",


### PR DESCRIPTION
#### Reference Issue
#945

#### What does this PR implement/fix? Explain your changes.
Implements the PEP 561 standard for Distributing and Packaging Type Information.

#### How should this PR be tested?
By using `mypy -c 'import openml'`

`mypy` should succeed and report no errors

#### Any other comments?
I'm not sure how the test result should be reported.
For now it's a simple if/else print statement in `ci_scripts/install.sh` but please point me in the right direction otherwise. 
I'm not even sure if the `ci_scripts/install.sh` script ran during any of the testing steps described in CONTRIBUTING.md but there were no errors. I tried to run it manually by it seems to be intended to run from a CI environment.

As `setup.py` does not install `mypy`, I also did a manual test by `pip install mypy` followed by `mypy -c 'import openml'` which succeeded.
```
> mypy -c 'import openml'        
Success: no issues found in 1 source file
```

I can also verify that it ran on the locally installed package by running 
```
> pip list | grep openml
openml              0.11.0.dev0 /home/skantify/opensource/openml-python
```

Lastly, as the documentation says nothing about `py.typed` contents and is assumed blank, I did not add the BSD3 clause to it. 