### PR TITLE
MAINT #660

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -85,8 +85,6 @@ class OpenMLDataset(OpenMLBase):
         Link to a paper describing the dataset.
     update_comment : str, optional
         An explanation for when the dataset is uploaded.
-    status : str, optional
-        Whether the dataset is active.
     md5_checksum : str, optional
         MD5 checksum to check if the dataset is downloaded without corruption.
     data_file : str, optional


### PR DESCRIPTION
Remove a faulty entry in the argument list of datasets, which actually cannot be set via the constructor.