### PR TITLE
add validation for ignore_attributes and default_target_attribute at …

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -333,7 +333,7 @@ def _load_features_from_file(features_file: str) -> Dict:
         return xml_dict["oml:data_features"]
 
 
-def _expand_parameter(parameter):
+def _expand_parameter(parameter: Union[str, list]):
     expanded_parameter = []
     if isinstance(parameter, str):
         expanded_parameter = [x.strip() for x in parameter.split(",")]
@@ -342,17 +342,16 @@ def _expand_parameter(parameter):
     return expanded_parameter
 
 
-def _validated_data_attributes(attributes, data_attributes, parameter_name):
-    if attributes is not None:
-        for attribute_ in attributes:
-            is_row_id_an_attribute = any([attr[0] == attribute_ for attr in data_attributes])
-            if not is_row_id_an_attribute:
-                raise ValueError(
-                    "all attribute of '{}' should be one of the data attribute. "
-                    " Got '{}' while candidates are {}.".format(
-                        parameter_name, attribute_, [attr[0] for attr in data_attributes]
-                    )
+def _validated_data_attributes(attributes: list, data_attributes: list, parameter_name: str):
+    for attribute_ in attributes:
+        is_attribute_a_data_attribute = any([attr[0] == attribute_ for attr in data_attributes])
+        if not is_attribute_a_data_attribute:
+            raise ValueError(
+                "all attribute of '{}' should be one of the data attribute. "
+                " Got '{}' while candidates are {}.".format(
+                    parameter_name, attribute_, [attr[0] for attr in data_attributes]
                 )
+            )
 
 
 def check_datasets_active(dataset_ids: List[int]) -> Dict[int, bool]:

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -333,7 +333,7 @@ def _load_features_from_file(features_file: str) -> Dict:
         return xml_dict["oml:data_features"]
 
 
-def _expand_parameter(parameter: Union[str, list]):
+def _expand_parameter(parameter: Union[str, List[str]]) -> List[str]:
     expanded_parameter = []
     if isinstance(parameter, str):
         expanded_parameter = [x.strip() for x in parameter.split(",")]
@@ -342,7 +342,9 @@ def _expand_parameter(parameter: Union[str, list]):
     return expanded_parameter
 
 
-def _validated_data_attributes(attributes: list, data_attributes: list, parameter_name: str):
+def _validated_data_attributes(
+    attributes: List[str], data_attributes: List[str], parameter_name: str
+) -> None:
     for attribute_ in attributes:
         is_attribute_a_data_attribute = any([attr[0] == attribute_ for attr in data_attributes])
         if not is_attribute_a_data_attribute:

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -876,54 +876,6 @@ class TestOpenMLDataset(TestBase):
             "The format of the ARFF files is different",
         )
 
-    @pytest.mark.parametrize(
-        "default_target_attribute,row_id_attribute,ignore_attribute",
-        [("wrong", None, None), (None, "wrong", None), (None, None, "wrong")],
-    )
-    def test_attribute_validations(self):
-        data = [
-            ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
-            ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
-            ["c", "overcast", 83.0, 86.0, "FALSE", "yes"],
-            ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
-            ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
-        ]
-        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
-        df = pd.DataFrame(data, columns=column_names)
-        # enforce the type of each column
-        df["outlook"] = df["outlook"].astype("category")
-        df["windy"] = df["windy"].astype("bool")
-        df["play"] = df["play"].astype("category")
-        # meta-information
-        name = "%s-pandas_testing_dataset" % self._get_sentinel()
-        description = "Synthetic dataset created from a Pandas DataFrame"
-        creator = "OpenML tester"
-        collection_date = "01-01-2018"
-        language = "English"
-        licence = "MIT"
-        citation = "None"
-        original_data_url = "http://openml.github.io/openml-python"
-        paper_url = "http://openml.github.io/openml-python"
-        with self.assertRaises(ValueError):
-            _ = openml.datasets.functions.create_dataset(
-                name=name,
-                description=description,
-                creator=creator,
-                contributor=None,
-                collection_date=collection_date,
-                language=language,
-                licence=licence,
-                default_target_attribute="wrong",
-                row_id_attribute=None,
-                ignore_attribute=None,
-                citation=citation,
-                attributes="auto",
-                data=df,
-                version_label="test",
-                original_data_url=original_data_url,
-                paper_url=paper_url,
-            )
-
     def test_create_dataset_pandas(self):
         data = [
             ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
@@ -1462,4 +1414,53 @@ class TestOpenMLDataset(TestBase):
         # Check server exception when unknown dataset is provided
         self.assertRaisesRegex(
             OpenMLServerException, "Unknown dataset", fork_dataset, data_id=999999,
+        )
+
+
+@pytest.mark.parametrize(
+    "default_target_attribute,row_id_attribute,ignore_attribute",
+    [("wrong", None, None), (None, "wrong", None), (None, None, "wrong")],
+)
+def test_attribute_validations(default_target_attribute, row_id_attribute, ignore_attribute):
+    data = [
+        ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
+        ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
+        ["c", "overcast", 83.0, 86.0, "FALSE", "yes"],
+        ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
+        ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
+    ]
+    column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+    df = pd.DataFrame(data, columns=column_names)
+    # enforce the type of each column
+    df["outlook"] = df["outlook"].astype("category")
+    df["windy"] = df["windy"].astype("bool")
+    df["play"] = df["play"].astype("category")
+    # meta-information
+    name = "pandas_testing_dataset"
+    description = "Synthetic dataset created from a Pandas DataFrame"
+    creator = "OpenML tester"
+    collection_date = "01-01-2018"
+    language = "English"
+    licence = "MIT"
+    citation = "None"
+    original_data_url = "http://openml.github.io/openml-python"
+    paper_url = "http://openml.github.io/openml-python"
+    with pytest.raises(ValueError, match="should be one of the data attribute"):
+        _ = openml.datasets.functions.create_dataset(
+            name=name,
+            description=description,
+            creator=creator,
+            contributor=None,
+            collection_date=collection_date,
+            language=language,
+            licence=licence,
+            default_target_attribute=default_target_attribute,
+            row_id_attribute=row_id_attribute,
+            ignore_attribute=ignore_attribute,
+            citation=citation,
+            attributes="auto",
+            data=df,
+            version_label="test",
+            original_data_url=original_data_url,
+            paper_url=paper_url,
         )

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -875,8 +875,9 @@ class TestOpenMLDataset(TestBase):
             _get_online_dataset_format(dataset_id),
             "The format of the ARFF files is different",
         )
-
-    def test_create_dataset_default_target_attribute_validation(self):
+    @pytest.mark.parametrize("default_target_attribute,row_id_attribute,ignore_attribute", 
+    [("wrong", None,None), (None,"wrong",None), (None,None,"wrong")])
+    def test_attribute_validations(self):
         data = [
             ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
             ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
@@ -912,50 +913,6 @@ class TestOpenMLDataset(TestBase):
                 default_target_attribute="wrong",
                 row_id_attribute=None,
                 ignore_attribute=None,
-                citation=citation,
-                attributes="auto",
-                data=df,
-                version_label="test",
-                original_data_url=original_data_url,
-                paper_url=paper_url,
-            )
-
-    def test_create_dataset_ignore_attribute_validation(self):
-        data = [
-            ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
-            ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
-            ["c", "overcast", 83.0, 86.0, "FALSE", "yes"],
-            ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
-            ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
-        ]
-        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
-        df = pd.DataFrame(data, columns=column_names)
-        # enforce the type of each column
-        df["outlook"] = df["outlook"].astype("category")
-        df["windy"] = df["windy"].astype("bool")
-        df["play"] = df["play"].astype("category")
-        # meta-information
-        name = "%s-pandas_testing_dataset" % self._get_sentinel()
-        description = "Synthetic dataset created from a Pandas DataFrame"
-        creator = "OpenML tester"
-        collection_date = "01-01-2018"
-        language = "English"
-        licence = "MIT"
-        citation = "None"
-        original_data_url = "http://openml.github.io/openml-python"
-        paper_url = "http://openml.github.io/openml-python"
-        with self.assertRaises(ValueError):
-            _ = openml.datasets.functions.create_dataset(
-                name=name,
-                description=description,
-                creator=creator,
-                contributor=None,
-                collection_date=collection_date,
-                language=language,
-                licence=licence,
-                default_target_attribute="play",
-                row_id_attribute=None,
-                ignore_attribute=["rnd_str", "wrong"],
                 citation=citation,
                 attributes="auto",
                 data=df,

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1419,9 +1419,11 @@ class TestOpenMLDataset(TestBase):
 
 @pytest.mark.parametrize(
     "default_target_attribute,row_id_attribute,ignore_attribute",
-    [("wrong", None, None), (None, "wrong", None), (None, None, "wrong")],
+    [("wrong", None, None), (None, "wrong", None), (None, None, "wrong"),
+    ("wrong,sunny", None, None),(None, None, "wrong,sunny"),
+    (["wrong","sunny"], None, None), (None, None, ["wrong","sunny"])],
 )
-def test_attribute_validations(default_target_attribute, row_id_attribute, ignore_attribute):
+def test_invalid_attribute_validations(default_target_attribute, row_id_attribute, ignore_attribute):
     data = [
         ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
         ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
@@ -1464,3 +1466,52 @@ def test_attribute_validations(default_target_attribute, row_id_attribute, ignor
             original_data_url=original_data_url,
             paper_url=paper_url,
         )
+
+@pytest.mark.parametrize(
+    "default_target_attribute,row_id_attribute,ignore_attribute",
+    [("outlook", None, None), (None, "outlook", None), (None, None, "outlook"),
+    ("outlook,windy", None, None), (None, None, "outlook,windy"),
+    (["outlook","windy"], None, None), (None, None, ["outlook","windy"])],
+)
+def test_valid_attribute_validations(default_target_attribute, row_id_attribute, ignore_attribute):
+    data = [
+        ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
+        ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
+        ["c", "overcast", 83.0, 86.0, "FALSE", "yes"],
+        ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
+        ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
+    ]
+    column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+    df = pd.DataFrame(data, columns=column_names)
+    # enforce the type of each column
+    df["outlook"] = df["outlook"].astype("category")
+    df["windy"] = df["windy"].astype("bool")
+    df["play"] = df["play"].astype("category")
+    # meta-information
+    name = "pandas_testing_dataset"
+    description = "Synthetic dataset created from a Pandas DataFrame"
+    creator = "OpenML tester"
+    collection_date = "01-01-2018"
+    language = "English"
+    licence = "MIT"
+    citation = "None"
+    original_data_url = "http://openml.github.io/openml-python"
+    paper_url = "http://openml.github.io/openml-python"
+    _ = openml.datasets.functions.create_dataset(
+        name=name,
+        description=description,
+        creator=creator,
+        contributor=None,
+        collection_date=collection_date,
+        language=language,
+        licence=licence,
+        default_target_attribute=default_target_attribute,
+        row_id_attribute=row_id_attribute,
+        ignore_attribute=ignore_attribute,
+        citation=citation,
+        attributes="auto",
+        data=df,
+        version_label="test",
+        original_data_url=original_data_url,
+        paper_url=paper_url,
+    )

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -875,8 +875,11 @@ class TestOpenMLDataset(TestBase):
             _get_online_dataset_format(dataset_id),
             "The format of the ARFF files is different",
         )
-    @pytest.mark.parametrize("default_target_attribute,row_id_attribute,ignore_attribute", 
-    [("wrong", None,None), (None,"wrong",None), (None,None,"wrong")])
+
+    @pytest.mark.parametrize(
+        "default_target_attribute,row_id_attribute,ignore_attribute",
+        [("wrong", None, None), (None, "wrong", None), (None, None, "wrong")],
+    )
     def test_attribute_validations(self):
         data = [
             ["a", "sunny", 85.0, 85.0, "FALSE", "no"],

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1419,11 +1419,19 @@ class TestOpenMLDataset(TestBase):
 
 @pytest.mark.parametrize(
     "default_target_attribute,row_id_attribute,ignore_attribute",
-    [("wrong", None, None), (None, "wrong", None), (None, None, "wrong"),
-    ("wrong,sunny", None, None),(None, None, "wrong,sunny"),
-    (["wrong","sunny"], None, None), (None, None, ["wrong","sunny"])],
+    [
+        ("wrong", None, None),
+        (None, "wrong", None),
+        (None, None, "wrong"),
+        ("wrong,sunny", None, None),
+        (None, None, "wrong,sunny"),
+        (["wrong", "sunny"], None, None),
+        (None, None, ["wrong", "sunny"]),
+    ],
 )
-def test_invalid_attribute_validations(default_target_attribute, row_id_attribute, ignore_attribute):
+def test_invalid_attribute_validations(
+    default_target_attribute, row_id_attribute, ignore_attribute
+):
     data = [
         ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
         ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
@@ -1467,11 +1475,18 @@ def test_invalid_attribute_validations(default_target_attribute, row_id_attribut
             paper_url=paper_url,
         )
 
+
 @pytest.mark.parametrize(
     "default_target_attribute,row_id_attribute,ignore_attribute",
-    [("outlook", None, None), (None, "outlook", None), (None, None, "outlook"),
-    ("outlook,windy", None, None), (None, None, "outlook,windy"),
-    (["outlook","windy"], None, None), (None, None, ["outlook","windy"])],
+    [
+        ("outlook", None, None),
+        (None, "outlook", None),
+        (None, None, "outlook"),
+        ("outlook,windy", None, None),
+        (None, None, "outlook,windy"),
+        (["outlook", "windy"], None, None),
+        (None, None, ["outlook", "windy"]),
+    ],
 )
 def test_valid_attribute_validations(default_target_attribute, row_id_attribute, ignore_attribute):
     data = [

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -876,6 +876,94 @@ class TestOpenMLDataset(TestBase):
             "The format of the ARFF files is different",
         )
 
+    def test_create_dataset_default_target_attribute_validation(self):
+        data = [
+            ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
+            ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
+            ["c", "overcast", 83.0, 86.0, "FALSE", "yes"],
+            ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
+            ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
+        ]
+        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+        df = pd.DataFrame(data, columns=column_names)
+        # enforce the type of each column
+        df["outlook"] = df["outlook"].astype("category")
+        df["windy"] = df["windy"].astype("bool")
+        df["play"] = df["play"].astype("category")
+        # meta-information
+        name = "%s-pandas_testing_dataset" % self._get_sentinel()
+        description = "Synthetic dataset created from a Pandas DataFrame"
+        creator = "OpenML tester"
+        collection_date = "01-01-2018"
+        language = "English"
+        licence = "MIT"
+        citation = "None"
+        original_data_url = "http://openml.github.io/openml-python"
+        paper_url = "http://openml.github.io/openml-python"
+        with self.assertRaises(ValueError):
+            _ = openml.datasets.functions.create_dataset(
+                name=name,
+                description=description,
+                creator=creator,
+                contributor=None,
+                collection_date=collection_date,
+                language=language,
+                licence=licence,
+                default_target_attribute="wrong",
+                row_id_attribute=None,
+                ignore_attribute=None,
+                citation=citation,
+                attributes="auto",
+                data=df,
+                version_label="test",
+                original_data_url=original_data_url,
+                paper_url=paper_url,
+            )
+
+    def test_create_dataset_ignore_attribute_validation(self):
+        data = [
+            ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
+            ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
+            ["c", "overcast", 83.0, 86.0, "FALSE", "yes"],
+            ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
+            ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
+        ]
+        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+        df = pd.DataFrame(data, columns=column_names)
+        # enforce the type of each column
+        df["outlook"] = df["outlook"].astype("category")
+        df["windy"] = df["windy"].astype("bool")
+        df["play"] = df["play"].astype("category")
+        # meta-information
+        name = "%s-pandas_testing_dataset" % self._get_sentinel()
+        description = "Synthetic dataset created from a Pandas DataFrame"
+        creator = "OpenML tester"
+        collection_date = "01-01-2018"
+        language = "English"
+        licence = "MIT"
+        citation = "None"
+        original_data_url = "http://openml.github.io/openml-python"
+        paper_url = "http://openml.github.io/openml-python"
+        with self.assertRaises(ValueError):
+            _ = openml.datasets.functions.create_dataset(
+                name=name,
+                description=description,
+                creator=creator,
+                contributor=None,
+                collection_date=collection_date,
+                language=language,
+                licence=licence,
+                default_target_attribute="play",
+                row_id_attribute=None,
+                ignore_attribute=["rnd_str", "wrong"],
+                citation=citation,
+                attributes="auto",
+                data=df,
+                version_label="test",
+                original_data_url=original_data_url,
+                paper_url=paper_url,
+            )
+
     def test_create_dataset_pandas(self):
         data = [
             ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
@@ -897,7 +985,6 @@ class TestOpenMLDataset(TestBase):
         collection_date = "01-01-2018"
         language = "English"
         licence = "MIT"
-        default_target_attribute = "play"
         citation = "None"
         original_data_url = "http://openml.github.io/openml-python"
         paper_url = "http://openml.github.io/openml-python"
@@ -909,7 +996,7 @@ class TestOpenMLDataset(TestBase):
             collection_date=collection_date,
             language=language,
             licence=licence,
-            default_target_attribute=default_target_attribute,
+            default_target_attribute="play",
             row_id_attribute=None,
             ignore_attribute=None,
             citation=citation,
@@ -944,7 +1031,7 @@ class TestOpenMLDataset(TestBase):
             collection_date=collection_date,
             language=language,
             licence=licence,
-            default_target_attribute=default_target_attribute,
+            default_target_attribute="y",
             row_id_attribute=None,
             ignore_attribute=None,
             citation=citation,
@@ -980,7 +1067,7 @@ class TestOpenMLDataset(TestBase):
             collection_date=collection_date,
             language=language,
             licence=licence,
-            default_target_attribute=default_target_attribute,
+            default_target_attribute="rnd_str",
             row_id_attribute=None,
             ignore_attribute=None,
             citation=citation,


### PR DESCRIPTION
…craete_dataset

<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
#964

##### What does this PR implement/fix? Explain your changes.

1. First for ignore_attributes and default_target_attribute expand to list if they are comma sperated strings.
2. check for both attributes that all values are ie columns.

#### How should this PR be tested?

on call of create_dataset , we can try values for ignore_attributes and default_target_attribute that are part of the columns and some values that are not.

#### Any other comments?

