### PR TITLE
Improving the performance of check_datasets_active, modifying unit test

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -11,6 +11,7 @@ Changelog
 
 0.11.0
 ~~~~~~
+* MAINT #671: Improved the performance of ``check_datasets_active`` by only querying the given list of datasets in contrast to querying all datasets. Modified the corresponding unit test.
 * ADD #753: Allows uploading custom flows to OpenML via OpenML-Python.
 * ADD #777: Allows running a flow on pandas dataframes (in addition to numpy arrays).
 * ADD #888: Allow passing a `task_id` to `run_model_on_task`.

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,10 +8,10 @@ Changelog
 
 0.11.1
 ~~~~~~
+* MAINT #671: Improved the performance of ``check_datasets_active`` by only querying the given list of datasets in contrast to querying all datasets. Modified the corresponding unit test.
 
 0.11.0
 ~~~~~~
-* MAINT #671: Improved the performance of ``check_datasets_active`` by only querying the given list of datasets in contrast to querying all datasets. Modified the corresponding unit test.
 * ADD #753: Allows uploading custom flows to OpenML via OpenML-Python.
 * ADD #777: Allows running a flow on pandas dataframes (in addition to numpy arrays).
 * ADD #888: Allow passing a `task_id` to `run_model_on_task`.

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -333,27 +333,40 @@ def _load_features_from_file(features_file: str) -> Dict:
         return xml_dict["oml:data_features"]
 
 
-def check_datasets_active(dataset_ids: List[int]) -> Dict[int, bool]:
+def check_datasets_active(
+    dataset_ids: List[int],
+    raise_error_if_not_exist: bool = True,
+) -> Dict[int, bool]:
     """
     Check if the dataset ids provided are active.
+
+    Raises an error if a dataset_id in the given list
+    of dataset_ids does not exist on the server.
 
     Parameters
     ----------
     dataset_ids : List[int]
         A list of integers representing dataset ids.
+    raise_error_if_not_exist : bool, optional (default=True)
+        Flag that if activated can raise an error, if one or more of the
+        given dataset ids do not exist on the server.
 
     Returns
     -------
     dict
         A dictionary with items {did: bool}
     """
-    dataset_list = list_datasets(status="all")
+    dataset_list = list_datasets(
+        dataset_ids=dataset_ids,
+        status="all",
+    )
     active = {}
 
     for did in dataset_ids:
         dataset = dataset_list.get(did, None)
         if dataset is None:
-            raise ValueError("Could not find dataset {} in OpenML dataset list.".format(did))
+            if raise_error_if_not_exist:
+                raise ValueError(f'Could not find dataset {did} in OpenML dataset list.')
         else:
             active[did] = dataset["status"] == "active"
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -347,7 +347,7 @@ def check_datasets_active(
     ----------
     dataset_ids : List[int]
         A list of integers representing dataset ids.
-    raise_error_if_not_exist : bool, optional (default=True)
+    raise_error_if_not_exist : bool (default=True)
         Flag that if activated can raise an error, if one or more of the
         given dataset ids do not exist on the server.
 
@@ -357,7 +357,7 @@ def check_datasets_active(
         A dictionary with items {did: bool}
     """
     dataset_list = list_datasets(
-        dataset_ids=dataset_ids,
+        data_id=dataset_ids,
         status="all",
     )
     active = {}

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -227,9 +227,13 @@ class TestOpenMLDataset(TestBase):
     def test_check_datasets_active(self):
         # Have to test on live because there is no deactivated dataset on the test server.
         openml.config.server = self.production_server
-        active = openml.datasets.check_datasets_active([2, 17])
+        active = openml.datasets.check_datasets_active(
+            [2, 17, 79],
+            raise_error_if_not_exist=False,
+        )
         self.assertTrue(active[2])
         self.assertFalse(active[17])
+        self.assertIsNone(active.get(79))
         self.assertRaisesRegex(
             ValueError,
             "Could not find dataset 79 in OpenML dataset list.",


### PR DESCRIPTION
#### Reference Issue
Fixes #671 

#### What does this PR implement/fix? Explain your changes.
Improves the performance of the function `check_datasets_active` by querying only for the given datasets, instead of all datasets.  Furthemore, the error throwing behavior can be controller by the user.


#### How should this PR be tested?
Existing unit test which was modified.

