### PR TITLE
Improve unit tests

### DIFF
--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run tests
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
-        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread -sv $codecov
+        pytest -n 4 --random-order-bucket=global --durations=20 --timeout=600 --timeout-method=thread -sv $codecov
     - name: Check for files left behind by test
       if: ${{ always() }}
       run: |

--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run tests
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
-        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread -sv $codecov
+        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov
     - name: Check for files left behind by test
       if: ${{ always() }}
       run: |

--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run tests
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
-        pytest -n 4 --random-order-bucket=global --durations=20 --timeout=600 --timeout-method=thread -sv $codecov
+        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread -sv $codecov
     - name: Check for files left behind by test
       if: ${{ always() }}
       run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,4 +45,4 @@ build: false
 
 test_script:
   - "cd C:\\projects\\openml-python"
-  - "%CMD_IN_ENV% pytest -n 4 --timeout=600 --timeout-method=thread -sv"
+  - "%CMD_IN_ENV% pytest -n 4 --timeout=600 --timeout-method=thread --random-order-bucket=global -sv"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,4 +45,4 @@ build: false
 
 test_script:
   - "cd C:\\projects\\openml-python"
-  - "%CMD_IN_ENV% pytest -n 4 --timeout=600 --timeout-method=thread -sv"
+  - "%CMD_IN_ENV% pytest -n 4 --timeout=600 --timeout-method=thread --dist load -sv"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,4 +45,4 @@ build: false
 
 test_script:
   - "cd C:\\projects\\openml-python"
-  - "%CMD_IN_ENV% pytest -n 4 --timeout=600 --timeout-method=thread --random-order-bucket=global -sv"
+  - "%CMD_IN_ENV% pytest -n 4 --timeout=600 --timeout-method=thread -sv"

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -34,7 +34,7 @@ class OpenMLDataset(OpenMLBase):
         Name of the dataset.
     description : str
         Description of the dataset.
-    format : str
+    data_format : str
         Format of the dataset which can be either 'arff' or 'sparse_arff'.
     cache_format : str
         Format for caching the dataset which can be either 'feather' or 'pickle'.
@@ -456,12 +456,11 @@ class OpenMLDataset(OpenMLBase):
                     col.append(
                         self._unpack_categories(X[column_name], categories_names[column_name])
                     )
-                elif attribute_dtype[column_name] in ('floating',
-                                                      'integer'):
+                elif attribute_dtype[column_name] in ("floating", "integer"):
                     X_col = X[column_name]
                     if X_col.min() >= 0 and X_col.max() <= 255:
                         try:
-                            X_col_uint = X_col.astype('uint8')
+                            X_col_uint = X_col.astype("uint8")
                             if (X_col == X_col_uint).all():
                                 col.append(X_col_uint)
                                 continue

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -176,7 +176,8 @@ class OpenMLDataset(OpenMLBase):
             )
 
         self.cache_format = cache_format
-        self.data_format = data_format
+        # Has to be called format, otherwise there will be an XML upload error
+        self.format = data_format
         self.creator = creator
         self.contributor = contributor
         self.collection_date = collection_date
@@ -244,7 +245,7 @@ class OpenMLDataset(OpenMLBase):
         fields = {
             "Name": self.name,
             "Version": self.version,
-            "Format": self.data_format,
+            "Format": self.format,
             "Licence": self.licence,
             "Download URL": self.url,
             "Data file": self.data_file,
@@ -377,7 +378,7 @@ class OpenMLDataset(OpenMLBase):
             List[str]: List of column names.
         """
         try:
-            data = self._get_arff(self.data_format)
+            data = self._get_arff(self.format)
         except OSError as e:
             logger.critical(
                 "Please check that the data file {} is "
@@ -398,7 +399,7 @@ class OpenMLDataset(OpenMLBase):
         for i, (name, type_) in enumerate(data["attributes"]):
             # if the feature is nominal and a sparse matrix is
             # requested, the categories need to be numeric
-            if isinstance(type_, list) and self.data_format.lower() == "sparse_arff":
+            if isinstance(type_, list) and self.format.lower() == "sparse_arff":
                 try:
                     # checks if the strings which should be the class labels
                     # can be encoded into integers
@@ -408,7 +409,7 @@ class OpenMLDataset(OpenMLBase):
                         "Categorical data needs to be numeric when " "using sparse ARFF."
                     )
             # string can only be supported with pandas DataFrame
-            elif type_ == "STRING" and self.data_format.lower() == "sparse_arff":
+            elif type_ == "STRING" and self.format.lower() == "sparse_arff":
                 raise ValueError("Dataset containing strings is not supported " "with sparse ARFF.")
 
             # infer the dtype from the ARFF header
@@ -431,12 +432,12 @@ class OpenMLDataset(OpenMLBase):
                 attribute_dtype[name] = ARFF_DTYPES_TO_PD_DTYPE[type_]
             attribute_names.append(name)
 
-        if self.data_format.lower() == "sparse_arff":
+        if self.format.lower() == "sparse_arff":
             X = data["data"]
             X_shape = (max(X[1]) + 1, max(X[2]) + 1)
             X = scipy.sparse.coo_matrix((X[0], (X[1], X[2])), shape=X_shape, dtype=np.float32)
             X = X.tocsr()
-        elif self.data_format.lower() == "arff":
+        elif self.format.lower() == "arff":
             X = pd.DataFrame(data["data"], columns=attribute_names)
 
             col = []
@@ -460,7 +461,7 @@ class OpenMLDataset(OpenMLBase):
                     col.append(X[column_name])
             X = pd.concat(col, axis=1)
         else:
-            raise ValueError("Dataset format '{}' is not a valid format.".format(self.data_format))
+            raise ValueError("Dataset format '{}' is not a valid format.".format(self.format))
 
         return X, categorical, attribute_names
 

--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -1748,7 +1748,7 @@ class SklearnExtension(Extension):
                         proba_y.shape[1], len(task.class_labels),
                     )
                     warnings.warn(message)
-                    openml.config.logger.warn(message)
+                    openml.config.logger.warning(message)
 
                     for i, col in enumerate(task.class_labels):
                         # adding missing columns with 0 probability

--- a/openml/flows/flow.py
+++ b/openml/flows/flow.py
@@ -229,7 +229,7 @@ class OpenMLFlow(OpenMLBase):
 
         if not self.description:
             logger = logging.getLogger(__name__)
-            logger.warn("Flow % has empty description", self.name)
+            logger.warning("Flow % has empty description", self.name)
 
         flow_parameters = []
         for key in self.parameters:

--- a/openml/study/functions.py
+++ b/openml/study/functions.py
@@ -58,7 +58,7 @@ def get_study(
             "of things have changed since then. Please use `get_suite('OpenML100')` instead."
         )
         warnings.warn(message, DeprecationWarning)
-        openml.config.logger.warn(message)
+        openml.config.logger.warning(message)
         study = _get_study(study_id, entity_type="task")
         return cast(OpenMLBenchmarkSuite, study)  # type: ignore
     else:

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
             "pyarrow",
             "pre-commit",
             "pytest-cov",
+            "pytest-random-order",
             "mypy",
         ],
         "examples": [

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setuptools.setup(
             "pyarrow",
             "pre-commit",
             "pytest-cov",
-            "pytest-random-order",
             "mypy",
         ],
         "examples": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def delete_remote_files(tracker) -> None:
                 openml.utils._delete_entity(entity_type, entity)
                 logger.info("Deleted ({}, {})".format(entity_type, entity))
             except Exception as e:
-                logger.warn("Cannot delete ({},{}): {}".format(entity_type, entity, e))
+                logger.warning("Cannot delete ({},{}): {}".format(entity_type, entity, e))
 
 
 def pytest_sessionstart() -> None:

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -120,11 +120,11 @@ class OpenMLDatasetTest(TestBase):
 
     def _check_expected_type(self, dtype, is_cat, col):
         if is_cat:
-            expected_type = 'category'
-        elif not col.isna().any() and (col.astype('uint8') == col).all():
-            expected_type = 'uint8'
+            expected_type = "category"
+        elif not col.isna().any() and (col.astype("uint8") == col).all():
+            expected_type = "uint8"
         else:
-            expected_type = 'float64'
+            expected_type = "float64"
 
         self.assertEqual(dtype.name, expected_type)
 
@@ -197,7 +197,7 @@ class OpenMLDatasetTest(TestBase):
         with catch_warnings():
             filterwarnings("error")
             self.assertRaises(
-                DeprecationWarning, openml.OpenMLDataset, "Test", "Test", format="arff"
+                DeprecationWarning, openml.OpenMLDataset, "Test", "Test", data_format="arff"
             )
 
     def test_get_data_with_nonexisting_class(self):

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -1,7 +1,6 @@
 # License: BSD 3-Clause
 
 from time import time
-from warnings import filterwarnings, catch_warnings
 
 import numpy as np
 import pandas as pd
@@ -191,14 +190,6 @@ class OpenMLDatasetTest(TestBase):
             self._check_expected_type(dtype, is_cat, rval[col])
         self.assertEqual(rval.shape, (898, 38))
         self.assertEqual(len(categorical), 38)
-
-    def test_dataset_format_constructor(self):
-
-        with catch_warnings():
-            filterwarnings("error")
-            self.assertRaises(
-                DeprecationWarning, openml.OpenMLDataset, "Test", "Test", data_format="arff"
-            )
 
     def test_get_data_with_nonexisting_class(self):
         # This class is using the anneal dataset with labels [1, 2, 3, 4, 5, 'U']. However,

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -373,9 +373,9 @@ class TestOpenMLDataset(TestBase):
     def test_get_dataset_uint8_dtype(self):
         dataset = openml.datasets.get_dataset(1)
         self.assertEqual(type(dataset), OpenMLDataset)
-        self.assertEqual(dataset.name, 'anneal')
+        self.assertEqual(dataset.name, "anneal")
         df, _, _, _ = dataset.get_data()
-        self.assertEqual(df['carbon'].dtype, 'uint8')
+        self.assertEqual(df["carbon"].dtype, "uint8")
 
     def test_get_dataset(self):
         # This is the only non-lazy load to ensure default behaviour works.
@@ -1157,7 +1157,7 @@ class TestOpenMLDataset(TestBase):
         downloaded_dataset = None
         # fetching from server
         # loop till timeout or fetch not successful
-        max_waiting_time_seconds = 400
+        max_waiting_time_seconds = 600
         # time.time() works in seconds
         start_time = time.time()
         while time.time() - start_time < max_waiting_time_seconds:

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -860,7 +860,7 @@ class TestOpenMLDataset(TestBase):
         decoder = arff.ArffDecoder()
         # check if the arff from the dataset is
         # the same as the arff from _get_arff function
-        d_format = (dataset.format).lower()
+        d_format = (dataset.data_format).lower()
 
         self.assertEqual(
             dataset._get_arff(d_format),
@@ -879,7 +879,7 @@ class TestOpenMLDataset(TestBase):
         dataset = openml.datasets.get_dataset(dataset_id, download_data=False)
 
         self.assertEqual(
-            (dataset.format).lower(),
+            (dataset.data_format).lower(),
             _get_online_dataset_format(dataset_id),
             "The format of the ARFF files is different",
         )

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1352,7 +1352,7 @@ class TestOpenMLDataset(TestBase):
         self.assertEqual(len(categorical), X.shape[1])
         self.assertEqual(len(attribute_names), X.shape[1])
 
-    def test_data_edit(self):
+    def test_data_edit_non_critical_field(self):
         # Case 1
         # All users can edit non-critical fields of datasets
         desc = (
@@ -1373,6 +1373,7 @@ class TestOpenMLDataset(TestBase):
         edited_dataset = openml.datasets.get_dataset(did)
         self.assertEqual(edited_dataset.description, desc)
 
+    def test_data_edit_critical_field(self):
         # Case 2
         # only owners (or admin) can edit all critical fields of datasets
         # for this, we need to first clone a dataset to do changes

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -860,7 +860,7 @@ class TestOpenMLDataset(TestBase):
         decoder = arff.ArffDecoder()
         # check if the arff from the dataset is
         # the same as the arff from _get_arff function
-        d_format = (dataset.data_format).lower()
+        d_format = (dataset.format).lower()
 
         self.assertEqual(
             dataset._get_arff(d_format),
@@ -879,7 +879,7 @@ class TestOpenMLDataset(TestBase):
         dataset = openml.datasets.get_dataset(dataset_id, download_data=False)
 
         self.assertEqual(
-            (dataset.data_format).lower(),
+            (dataset.format).lower(),
             _get_online_dataset_format(dataset_id),
             "The format of the ARFF files is different",
         )

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -518,14 +518,12 @@ class TestRun(TestBase):
             sentinel=sentinel,
         )
 
-    @unittest.mock.patch("warnings.warn")
-    def test_run_and_upload_logistic_regression(self, warn_mock):
-        lr = LogisticRegression(solver="lbfgs")
+    def test_run_and_upload_logistic_regression(self):
+        lr = LogisticRegression(solver="lbfgs", max_iter=1000)
         task_id = self.TEST_SERVER_TASK_SIMPLE[0]
         n_missing_vals = self.TEST_SERVER_TASK_SIMPLE[1]
         n_test_obs = self.TEST_SERVER_TASK_SIMPLE[2]
         self._run_and_upload_classification(lr, task_id, n_missing_vals, n_test_obs, "62501")
-        self.assertLessEqual(warn_mock.call_count, 3)
 
     def test_run_and_upload_linear_regression(self):
         lr = LinearRegression()
@@ -638,6 +636,11 @@ class TestRun(TestBase):
         n_missing_vals = self.TEST_SERVER_TASK_MISSING_VALS[1]
         n_test_obs = self.TEST_SERVER_TASK_MISSING_VALS[2]
         self._run_and_upload_classification(pipeline2, task_id, n_missing_vals, n_test_obs, "62501")
+        # The warning raised is:
+        # The total space of parameters 8 is smaller than n_iter=10.
+        # Running 8 iterations. For exhaustive searches, use GridSearchCV.'
+        # It is raised three times because we once run the model to upload something and then run
+        # it again twice to compare that the predictions are reproducible.
         self.assertEqual(warnings_mock.call_count, 3)
 
     def test_run_and_upload_gridsearch(self):

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -518,14 +518,14 @@ class TestRun(TestBase):
             sentinel=sentinel,
         )
 
-    def test_run_and_upload_logistic_regression(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            lr = LogisticRegression(solver="lbfgs")
-            task_id = self.TEST_SERVER_TASK_SIMPLE[0]
-            n_missing_vals = self.TEST_SERVER_TASK_SIMPLE[1]
-            n_test_obs = self.TEST_SERVER_TASK_SIMPLE[2]
-            self._run_and_upload_classification(lr, task_id, n_missing_vals, n_test_obs, "62501")
+    @unittest.mock.patch("warnings.warn")
+    def test_run_and_upload_logistic_regression(self, warn_mock):
+        lr = LogisticRegression(solver="lbfgs")
+        task_id = self.TEST_SERVER_TASK_SIMPLE[0]
+        n_missing_vals = self.TEST_SERVER_TASK_SIMPLE[1]
+        n_test_obs = self.TEST_SERVER_TASK_SIMPLE[2]
+        self._run_and_upload_classification(lr, task_id, n_missing_vals, n_test_obs, "62501")
+        self.assertEqual(warn_mock.call_count, 3)
 
     def test_run_and_upload_linear_regression(self):
         lr = LinearRegression()

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -525,7 +525,7 @@ class TestRun(TestBase):
         n_missing_vals = self.TEST_SERVER_TASK_SIMPLE[1]
         n_test_obs = self.TEST_SERVER_TASK_SIMPLE[2]
         self._run_and_upload_classification(lr, task_id, n_missing_vals, n_test_obs, "62501")
-        self.assertEqual(warn_mock.call_count, 3)
+        self.assertLessEqual(warn_mock.call_count, 3)
 
     def test_run_and_upload_linear_regression(self):
         lr = LinearRegression()

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -519,11 +519,13 @@ class TestRun(TestBase):
         )
 
     def test_run_and_upload_logistic_regression(self):
-        lr = LogisticRegression(solver="lbfgs")
-        task_id = self.TEST_SERVER_TASK_SIMPLE[0]
-        n_missing_vals = self.TEST_SERVER_TASK_SIMPLE[1]
-        n_test_obs = self.TEST_SERVER_TASK_SIMPLE[2]
-        self._run_and_upload_classification(lr, task_id, n_missing_vals, n_test_obs, "62501")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            lr = LogisticRegression(solver="lbfgs")
+            task_id = self.TEST_SERVER_TASK_SIMPLE[0]
+            n_missing_vals = self.TEST_SERVER_TASK_SIMPLE[1]
+            n_test_obs = self.TEST_SERVER_TASK_SIMPLE[2]
+            self._run_and_upload_classification(lr, task_id, n_missing_vals, n_test_obs, "62501")
 
     def test_run_and_upload_linear_regression(self):
         lr = LinearRegression()
@@ -605,7 +607,8 @@ class TestRun(TestBase):
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",
     )
-    def test_run_and_upload_knn_pipeline(self):
+    @unittest.mock.patch("warnings.warn")
+    def test_run_and_upload_knn_pipeline(self, warnings_mock):
 
         cat_imp = make_pipeline(
             SimpleImputer(strategy="most_frequent"), OneHotEncoder(handle_unknown="ignore")
@@ -635,11 +638,13 @@ class TestRun(TestBase):
         n_missing_vals = self.TEST_SERVER_TASK_MISSING_VALS[1]
         n_test_obs = self.TEST_SERVER_TASK_MISSING_VALS[2]
         self._run_and_upload_classification(pipeline2, task_id, n_missing_vals, n_test_obs, "62501")
+        self.assertEqual(warnings_mock.call_count, 3)
 
     def test_run_and_upload_gridsearch(self):
         gridsearch = GridSearchCV(
             BaggingClassifier(base_estimator=SVC()),
             {"base_estimator__C": [0.01, 0.1, 10], "base_estimator__gamma": [0.01, 0.1, 10]},
+            cv=3,
         )
         task_id = self.TEST_SERVER_TASK_SIMPLE[0]
         n_missing_vals = self.TEST_SERVER_TASK_SIMPLE[1]

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -442,7 +442,7 @@ class TestRun(TestBase):
             # suboptimal (slow), and not guaranteed to work if evaluation
             # engine is behind.
             # TODO: mock this? We have the arff already on the server
-            self._wait_for_processed_run(run.run_id, 400)
+            self._wait_for_processed_run(run.run_id, 600)
             try:
                 model_prime = openml.runs.initialize_model_from_trace(
                     run_id=run.run_id, repeat=0, fold=0,

--- a/tests/test_tasks/test_task_methods.py
+++ b/tests/test_tasks/test_task_methods.py
@@ -40,9 +40,9 @@ class OpenMLTaskMethodsTest(TestBase):
         self.assertEqual(681, train_indices[-1])
         self.assertEqual(583, test_indices[0])
         self.assertEqual(24, test_indices[-1])
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, "Fold 10 not known", task.get_train_test_split_indices, 10, 0
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, "Repeat 10 not known", task.get_train_test_split_indices, 0, 10
         )


### PR DESCRIPTION
* increase wait time when uploading a run to 600s. It's better to wait a very long time instead of failing that test (on CI)
* reduce the warnings a bit to have less output online
* remove deprecated `format` argument to `OpenMLDataset`
* add load balancing for parallel unit tests