### PR TITLE
Rework local openml directory

### DIFF
--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -155,7 +155,7 @@ def _read_url_files(url, data=None, file_elements=None):
 
 def __read_url(url, request_method, data=None, md5_checksum=None):
     data = {} if data is None else data
-    if config.apikey is not None:
+    if config.apikey:
         data["api_key"] = config.apikey
     return _send_request(
         request_method=request_method, url=url, data=data, md5_checksum=md5_checksum

--- a/openml/config.py
+++ b/openml/config.py
@@ -122,8 +122,8 @@ cache_directory = str(_defaults["cachedir"])  # so mypy knows it is a string
 avoid_duplicate_runs = True if _defaults["avoid_duplicate_runs"] == "True" else False
 
 # Number of retries if the connection breaks
-connection_n_retries = _defaults["connection_n_retries"]
-max_retries = _defaults["max_retries"]
+connection_n_retries = int(_defaults["connection_n_retries"])
+max_retries = int(_defaults["max_retries"])
 
 
 class ConfigurationForExamples:

--- a/openml/testing.py
+++ b/openml/testing.py
@@ -8,14 +8,7 @@ import sys
 import time
 from typing import Dict, Union, cast
 import unittest
-import warnings
 import pandas as pd
-
-# Currently, importing oslo raises a lot of warning that it will stop working
-# under python3.8; remove this once they disappear
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from oslo_concurrency import lockutils
 
 import openml
 from openml.tasks import TaskType
@@ -99,13 +92,6 @@ class TestBase(unittest.TestCase):
         openml.config.server = TestBase.test_server
         openml.config.avoid_duplicate_runs = False
         openml.config.cache_directory = self.workdir
-
-        # If we're on travis, we save the api key in the config file to allow
-        # the notebook tests to read them.
-        if os.environ.get("TRAVIS") or os.environ.get("APPVEYOR"):
-            with lockutils.external_lock("config", lock_path=self.workdir):
-                with open(openml.config.config_file, "w") as fh:
-                    fh.write("apikey = %s" % openml.config.apikey)
 
         # Increase the number of retries to avoid spurious server failures
         self.connection_n_retries = openml.config.connection_n_retries

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -244,7 +244,7 @@ def _list_all(listing_call, output_format="dict", *args, **filters):
                 limit=batch_size,
                 offset=current_offset,
                 output_format=output_format,
-                **active_filters
+                **active_filters,
             )
         except openml.exceptions.OpenMLServerNoResult:
             # we want to return an empty dict in this case
@@ -277,9 +277,11 @@ def _create_cache_directory(key):
     cache = config.get_cache_directory()
     cache_dir = os.path.join(cache, key)
     try:
-        os.makedirs(cache_dir)
-    except OSError:
-        pass
+        os.makedirs(cache_dir, exist_ok=True)
+    except Exception as e:
+        raise openml.exceptions.OpenMLCacheException(
+            f"Cannot create cache directory {cache_dir} due to exception {e}"
+        ) from e
     return cache_dir
 
 

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -280,7 +280,7 @@ def _create_cache_directory(key):
         os.makedirs(cache_dir, exist_ok=True)
     except Exception as e:
         raise openml.exceptions.OpenMLCacheException(
-            f"Cannot create cache directory {cache_dir} due to exception {e}"
+            f"Cannot create cache directory {cache_dir}."
         ) from e
     return cache_dir
 

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -10,8 +10,9 @@ import openml.testing
 
 class TestConfig(openml.testing.TestBase):
     @unittest.mock.patch("os.path.expanduser")
-    @unittest.mock.patch("warnings.warn")
-    def test_non_writable_home(self, warnings_mock, expanduser_mock):
+    @unittest.mock.patch("openml.config.openml_logger.warning")
+    @unittest.mock.patch("openml.config._create_log_handlers")
+    def test_non_writable_home(self, log_handler_mock, warnings_mock, expanduser_mock):
         with tempfile.TemporaryDirectory(dir=self.workdir) as td:
             expanduser_mock.side_effect = (
                 os.path.join(td, "openmldir"),
@@ -21,6 +22,8 @@ class TestConfig(openml.testing.TestBase):
             openml.config._setup()
 
         self.assertEqual(warnings_mock.call_count, 2)
+        self.assertEqual(log_handler_mock.call_count, 1)
+        self.assertFalse(log_handler_mock.call_args_list[0][1]["create_file_handler"])
 
 
 class TestConfigurationForExamples(openml.testing.TestBase):

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -97,7 +97,6 @@ class OpenMLTaskTest(TestBase):
             os.chmod(subdir, 0o444)
             config_mock.return_value = subdir
             with self.assertRaisesRegex(
-                openml.exceptions.OpenMLCacheException,
-                r"due to exception \[Errno 13\] Permission denied",
+                openml.exceptions.OpenMLCacheException, r"Cannot create cache directory",
             ):
                 openml.utils._create_cache_directory("ghi")

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -1,12 +1,11 @@
-from openml.testing import TestBase
-import numpy as np
-import openml
-import sys
+import os
+import tempfile
+import unittest.mock
 
-if sys.version_info[0] >= 3:
-    from unittest import mock
-else:
-    import mock
+import numpy as np
+
+import openml
+from openml.testing import TestBase
 
 
 class OpenMLTaskTest(TestBase):
@@ -20,7 +19,7 @@ class OpenMLTaskTest(TestBase):
     def test_list_all(self):
         openml.utils._list_all(listing_call=openml.tasks.functions._list_tasks)
 
-    @mock.patch("openml._api_calls._perform_api_call", side_effect=mocked_perform_api_call)
+    @unittest.mock.patch("openml._api_calls._perform_api_call", side_effect=mocked_perform_api_call)
     def test_list_all_few_results_available(self, _perform_api_call):
         # we want to make sure that the number of api calls is only 1.
         # Although we have multiple versions of the iris dataset, there is only
@@ -86,3 +85,19 @@ class OpenMLTaskTest(TestBase):
 
         # might not be on test server after reset, please rerun test at least once if fails
         self.assertEqual(len(evaluations), required_size)
+
+    @unittest.mock.patch("openml.config.get_cache_directory")
+    def test__create_cache_directory(self, config_mock):
+        with tempfile.TemporaryDirectory(dir=self.workdir) as td:
+            config_mock.return_value = td
+            openml.utils._create_cache_directory("abc")
+            self.assertTrue(os.path.exists(os.path.join(td, "abc")))
+            subdir = os.path.join(td, "def")
+            os.mkdir(subdir)
+            os.chmod(subdir, 0o444)
+            config_mock.return_value = subdir
+            with self.assertRaisesRegex(
+                openml.exceptions.OpenMLCacheException,
+                r"due to exception \[Errno 13\] Permission denied",
+            ):
+                openml.utils._create_cache_directory("ghi")


### PR DESCRIPTION
Closes #883 #884 #906 #972

#### What does this PR implement/fix? Explain your changes.

* Fixes #883: package can be imported if the home directory is not writable.
* Fixes #884: use standard linux locations for config and cache
* Fixes #906: package can be imported if there is no permission to create a cache directory.
* Fixes #972: give a more useful error message if a cache directory cannot be created

#### How should this PR be tested?

Unit tests.

#### Any other comments?

@mitar does this resolve the issues you had with the package?

@phmueller does this help you using OpenML inside HPOlib?

