### PR TITLE
Remove extra period

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"OpenML"
-copyright = u"2014-{}, the OpenML-Python team.".format(
+copyright = u"2014-{}, the OpenML-Python team".format(
     time.strftime("%Y,%m,%d,%H,%M,%S").split(",")[0]
 )
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,7 +64,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"OpenML"
+project = "OpenML"
 copyright = f"2014-{time.localtime().tm_year}, the OpenML-Python team"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -261,7 +261,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ("index", "OpenML.tex", u"OpenML Documentation", u"Matthias Feurer", "manual"),
+    ("index", "OpenML.tex", "OpenML Documentation", "Matthias Feurer", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -289,7 +289,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "openml", u"OpenML Documentation", [u"Matthias Feurer"], 1)]
+man_pages = [("index", "openml", "OpenML Documentation", ["Matthias Feurer"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -304,8 +304,8 @@ texinfo_documents = [
     (
         "index",
         "OpenML",
-        u"OpenML Documentation",
-        u"Matthias Feurer",
+        "OpenML Documentation",
+        "Matthias Feurer",
         "OpenML",
         "One line description of project.",
         "Miscellaneous",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,9 +65,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"OpenML"
-copyright = u"2014-{}, the OpenML-Python team".format(
-    time.strftime("%Y,%m,%d,%H,%M,%S").split(",")[0]
-)
+copyright = f"2014-{time.localtime().tm_year}, the OpenML-Python team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
It is added by the Copyright template already (as observed from built docs).
Saw the old code for getting the year from the copyright message, and decided I might as well touch that up for readable python3.