### PR TITLE
Feature/give possibility to not download the dataset qualities

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -12,6 +12,7 @@ Changelog
 * MAINT #671: Improved the performance of ``check_datasets_active`` by only querying the given list of datasets in contrast to querying all datasets. Modified the corresponding unit test.
 * FIX #964 : AValidate `ignore_attribute`, `default_target_attribute`, `row_id_attribute` are set to attributes that exist on the dataset when calling ``create_dataset``.
 * DOC #973 : Change the task used in the welcome page example so it no longer fails using numerical dataset.
+* ADD #1009 : Give possibility to not download the dataset qualities. The cached version is used even so download attribute is false.
 0.11.0
 ~~~~~~
 * ADD #753: Allows uploading custom flows to OpenML via OpenML-Python.

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -338,7 +338,9 @@ def get_datasets(
     """
     datasets = []
     for dataset_id in dataset_ids:
-        datasets.append(get_dataset(dataset_id, download_data, download_qualities))
+        datasets.append(
+            get_dataset(dataset_id, download_data, download_qualities=download_qualities)
+        )
     return datasets
 
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -290,6 +290,8 @@ def _name_to_id(
     error_if_multiple : bool (default=False)
         If `False`, if multiple datasets match, return the least recent active dataset.
         If `True`, if multiple datasets match, raise an error.
+    download_qualities : bool, optional
+        If `True`, also download qualities.xml file. If false use the file if it was cached.
 
     Returns
     -------
@@ -326,6 +328,8 @@ def get_datasets(
         make the operation noticeably slower. Metadata is also still retrieved.
         If False, create the OpenMLDataset and only populate it with the metadata.
         The data may later be retrieved through the `OpenMLDataset.get_data` method.
+    download_qualities : bool, optional
+        If True, also download qualities.xml file. If false use the file if it was cached.
 
     Returns
     -------

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -310,8 +310,7 @@ def _name_to_id(
 
 
 def get_datasets(
-    dataset_ids: List[Union[str, int]], download_data: bool = True,
-    download_qualities: bool = True
+    dataset_ids: List[Union[str, int]], download_data: bool = True, download_qualities: bool = True
 ) -> List[OpenMLDataset]:
     """Download datasets.
 
@@ -346,7 +345,8 @@ def get_dataset(
     version: int = None,
     error_if_multiple: bool = False,
     cache_format: str = "pickle",
-    download_qualities: bool = True) -> OpenMLDataset:
+    download_qualities: bool = True,
+) -> OpenMLDataset:
     """ Download the OpenML dataset representation, optionally also download actual data file.
 
     This function is thread/multiprocessing safe.
@@ -406,7 +406,9 @@ def get_dataset(
         features_file = _get_dataset_features_file(did_cache_dir, dataset_id)
 
         try:
-            qualities_file = _get_dataset_qualities_file(did_cache_dir, dataset_id,download_qualities)
+            qualities_file = _get_dataset_qualities_file(
+                did_cache_dir, dataset_id, download_qualities
+            )
         except OpenMLServerException as e:
             if e.code == 362 and str(e) == "No qualities found - None":
                 logger.warning("No qualities found for dataset {}".format(dataset_id))
@@ -982,7 +984,7 @@ def _get_dataset_features_file(did_cache_dir: str, dataset_id: int) -> str:
     return features_file
 
 
-def _get_dataset_qualities_file(did_cache_dir, dataset_id,download_qualities):
+def _get_dataset_qualities_file(did_cache_dir, dataset_id, download_qualities=True):
     """API call to load dataset qualities. Loads from cache or downloads them.
 
     Features are metafeatures (number of features, number of classes, ...)
@@ -1002,7 +1004,7 @@ def _get_dataset_qualities_file(did_cache_dir, dataset_id,download_qualities):
     str
         Path of the cached qualities file
     """
-    if download_qualities == True:
+    if download_qualities:
         # Dataset qualities are subject to change and must be fetched every time
         qualities_file = os.path.join(did_cache_dir, "qualities.xml")
         try:
@@ -1017,7 +1019,6 @@ def _get_dataset_qualities_file(did_cache_dir, dataset_id,download_qualities):
         return qualities_file
     else:
         pass
-    
 
 
 def _create_dataset_from_description(

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -291,7 +291,7 @@ def _name_to_id(
         If `False`, if multiple datasets match, return the least recent active dataset.
         If `True`, if multiple datasets match, raise an error.
     download_qualities : bool, optional (default=True)
-        If `True`, also download qualities.xml file. If false use the file if it was cached.
+        If `True`, also download qualities.xml file. If False it skip the qualities.xml.
 
     Returns
     -------
@@ -329,7 +329,7 @@ def get_datasets(
         If False, create the OpenMLDataset and only populate it with the metadata.
         The data may later be retrieved through the `OpenMLDataset.get_data` method.
     download_qualities : bool, optional (default=True)
-        If True, also download qualities.xml file. If false use the file if it was cached.
+        If True, also download qualities.xml file. If False it skip the qualities.xml.
 
     Returns
     -------
@@ -412,9 +412,10 @@ def get_dataset(
         features_file = _get_dataset_features_file(did_cache_dir, dataset_id)
 
         try:
-            qualities_file = _get_dataset_qualities_file(
-                did_cache_dir, dataset_id, download_qualities
-            )
+            if download_qualities:
+                qualities_file = _get_dataset_qualities_file(did_cache_dir, dataset_id)
+            else:
+                qualities_file = ""
         except OpenMLServerException as e:
             if e.code == 362 and str(e) == "No qualities found - None":
                 logger.warning("No qualities found for dataset {}".format(dataset_id))
@@ -990,7 +991,7 @@ def _get_dataset_features_file(did_cache_dir: str, dataset_id: int) -> str:
     return features_file
 
 
-def _get_dataset_qualities_file(did_cache_dir, dataset_id, download_qualities=True):
+def _get_dataset_qualities_file(did_cache_dir, dataset_id):
     """API call to load dataset qualities. Loads from cache or downloads them.
 
     Features are metafeatures (number of features, number of classes, ...)
@@ -1012,10 +1013,6 @@ def _get_dataset_qualities_file(did_cache_dir, dataset_id, download_qualities=Tr
     str
         Path of the cached qualities file
     """
-    # return empty path to avoied used cahched version, this will make the output consistent
-    # regardless the cache state.
-    if not download_qualities:
-        return ""
     # Dataset qualities are subject to change and must be fetched every time
     qualities_file = os.path.join(did_cache_dir, "qualities.xml")
     try:

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -1004,21 +1004,18 @@ def _get_dataset_qualities_file(did_cache_dir, dataset_id, download_qualities=Tr
     str
         Path of the cached qualities file
     """
-    if download_qualities:
-        # Dataset qualities are subject to change and must be fetched every time
-        qualities_file = os.path.join(did_cache_dir, "qualities.xml")
-        try:
-            with io.open(qualities_file, encoding="utf8") as fh:
-                qualities_xml = fh.read()
-        except (OSError, IOError):
+    # Dataset qualities are subject to change and must be fetched every time
+    qualities_file = os.path.join(did_cache_dir, "qualities.xml")
+    try:
+        with io.open(qualities_file, encoding="utf8") as fh:
+            qualities_xml = fh.read()
+    except (OSError, IOError):
+        if download_qualities:
             url_extension = "data/qualities/{}".format(dataset_id)
             qualities_xml = openml._api_calls._perform_api_call(url_extension, "get")
-
             with io.open(qualities_file, "w", encoding="utf8") as fh:
                 fh.write(qualities_xml)
-        return qualities_file
-    else:
-        pass
+    return qualities_file
 
 
 def _create_dataset_from_description(

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -433,10 +433,9 @@ class TestOpenMLDataset(TestBase):
         qualities_xml_path = os.path.join(self.workdir, "qualities.xml")
         self.assertTrue(os.path.exists(qualities_xml_path))
 
-    def test__get_dataset_qualities_skip_download(self):
-        qualities = _get_dataset_qualities_file(self.workdir, 2, False)
-        self.assertIsInstance(qualities, str)
-        self.assertEqual(qualities, "")
+    def test__get_dataset_skip_download(self):
+        qualities = openml.datasets.get_dataset(2, download_qualities=False).qualities
+        self.assertIsNone(qualities)
 
     def test_deletion_of_cache_dir(self):
         # Simple removal


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this PR implement/fix? Explain your changes.
We can Ignore downloading the dataset qualities if its not exist while getting datasets.

#### How should this PR be tested?
Clear the cache , and calling get_dataset with download_qualities set to false : this result in qulaities.xml to not be downloaded.
Clear the cache , and calling get_dataset with download_qualities set to default : this result in qulaities.xml to be downloaded.

#### Any other comments?

