### PR TITLE
Refactor data loading/storing

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.11.1
 ~~~~~~
+* MAINT #1018 : Refactor data loading and storage. Data is now compressed on the first call to `get_data`.
 * MAINT #891: Changed the way that numerical features are stored. Numerical features that range from 0 to 255 are now stored as uint8, which reduces the storage space required as well as storing and loading times.
 * MAINT #671: Improved the performance of ``check_datasets_active`` by only querying the given list of datasets in contrast to querying all datasets. Modified the corresponding unit test.
 * FIX #964 : AValidate `ignore_attribute`, `default_target_attribute`, `row_id_attribute` are set to attributes that exist on the dataset when calling ``create_dataset``.

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -276,7 +276,7 @@ class OpenMLDataset(OpenMLBase):
             "upload_date",
             "url",
             "dataset",
-            "arff_file",
+            "data_file",
         }
 
         # check that the keys are identical
@@ -289,7 +289,7 @@ class OpenMLDataset(OpenMLBase):
         return all(self.__dict__[key] == other.__dict__[key] for key in self_keys)
 
     def _download_data(self) -> None:
-        """ Download ARFF data file to standard cache directory. Set `self.arff_file`. """
+        """ Download ARFF data file to standard cache directory. Set `self.data_file`. """
         # import required here to avoid circular import.
         from .functions import _get_dataset_arff
 
@@ -298,7 +298,7 @@ class OpenMLDataset(OpenMLBase):
     def _get_arff(self, format: str) -> Dict:
         """Read ARFF file and return decoded arff.
 
-        Reads the file referenced in self.arff_file.
+        Reads the file referenced in self.data_file.
 
         Parameters
         ----------

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -218,16 +218,13 @@ class OpenMLDataset(OpenMLBase):
 
         if data_file is not None:
             rval = self._compressed_cache_file_paths(data_file)
-            self.data_pickle_file = rval[0]  # type: Optional[str]
-            self.data_feather_file = rval[1]  # type: Optional[str]
-            self.feather_attribute_file = rval[2]  # type: Optional[str]
-            self._cache_compressed_file_from_arff(self.data_file)
+            self.data_pickle_file = rval[0] if os.path.exists(rval[0]) else None
+            self.data_feather_file = rval[1] if os.path.exists(rval[1]) else None
+            self.feather_attribute_file = rval[2] if os.path.exists(rval[2]) else None
         else:
-            self.data_pickle_file, self.data_feather_file, self.feather_attribute_file = (
-                None,
-                None,
-                None,
-            )
+            self.data_pickle_file = None
+            self.data_feather_file = None
+            self.feather_attribute_file = None
 
     @property
     def id(self) -> Optional[int]:

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -305,9 +305,9 @@ def _create_cache_directory_for_id(key, id_):
         Path of the created dataset cache directory.
     """
     cache_dir = os.path.join(_create_cache_directory(key), str(id_))
-    if os.path.exists(cache_dir) and os.path.isdir(cache_dir):
+    if os.path.isdir(cache_dir):
         pass
-    elif os.path.exists(cache_dir) and not os.path.isdir(cache_dir):
+    elif os.path.exists(cache_dir):
         raise ValueError("%s cache dir exists but is not a directory!" % key)
     else:
         os.makedirs(cache_dir)

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1258,6 +1258,8 @@ class TestOpenMLDataset(TestBase):
 
     def test_get_dataset_cache_format_pickle(self):
         dataset = openml.datasets.get_dataset(1)
+        dataset.get_data()
+
         self.assertEqual(type(dataset), OpenMLDataset)
         self.assertEqual(dataset.name, "anneal")
         self.assertGreater(len(dataset.features), 1)

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1272,6 +1272,7 @@ class TestOpenMLDataset(TestBase):
     def test_get_dataset_cache_format_feather(self):
 
         dataset = openml.datasets.get_dataset(128, cache_format="feather")
+        dataset.get_data()
 
         # Check if dataset is written to cache directory using feather
         cache_dir = openml.config.get_cache_directory()


### PR DESCRIPTION
I stumbled on the dataset loading/caching code and found the flow very difficult to parse. Additionally there was a lot of duplicate code around. The main goal of this PR is to make the flow of loading and storing compressed data easier to read, and reduce the amount of duplicate code. In the process I streamlined the flow a little, which should lead to some performance gains (less excessive data loading).

Differences in behavior:
  - When the OpenMLDataset is constructed, outdated pickle data is no longer pro-actively updated. Instead the numpy pickle files are updated in `_load_data`.
  - When `_load_data` is called on a dataset which is not yet compressed (or needs to be updated), it is loaded only once instead of twice.
  - When the OpenMLDataset is constructed, the arff file is not immediately converted to a compressed format. Instead this happens the first time the data is required in `_load_data`.
  - OpenMLDataset's `data_pickle_file`, `data_feather_file` and `feather_attribute_file` members more accurately reflect the presence of the file. Previously the cache format files for the format that was not used would also be set, while they are never generated.


All unit tests passed without modification, except for the `test_get_dataset_cache_format_feather` which relied on the assumption that the data was compressed and stored on disk before the first load. However I also updated the pickle test which "tests" if the file can be loaded from the compressed format, otherwise it would now test if they are loaded from arff (the first load is from arff but stores to pickle, subsequent loads are from pickle).
