### PR TITLE
Bump version for new release

### DIFF
--- a/openml/__version__.py
+++ b/openml/__version__.py
@@ -3,4 +3,4 @@
 # License: BSD 3-Clause
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.11.1dev"
+__version__ = "0.12.0"


### PR DESCRIPTION
This PR just bumps the version number to 0.12 for a new release.