### PR TITLE
Change sphinx autodoc syntax

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,7 +49,7 @@ extensions = [
 autosummary_generate = True
 numpydoc_show_class_members = False
 
-autodoc_default_flags = ["members", "inherited-members"]
+autodoc_default_options = {"members": True, "inherited-members": True}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -6,7 +6,12 @@
 Changelog
 =========
 
-0.11.1
+0.12.1
+~~~~~~
+
+* FIX #1035: Render class attributes and methods again.
+
+0.12.0
 ~~~~~~
 * ADD #964: Validate ``ignore_attribute``, ``default_target_attribute``, ``row_id_attribute`` are set to attributes that exist on the dataset when calling ``create_dataset``.
 * ADD #979: Dataset features and qualities are now also cached in pickle format.

--- a/openml/__version__.py
+++ b/openml/__version__.py
@@ -3,4 +3,4 @@
 # License: BSD 3-Clause
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.12.0"
+__version__ = "0.12.1dev"

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
             "seaborn",
         ],
         "examples_unix": ["fanova"],
-        "docs": ["sphinx", "sphinx-gallery", "sphinx_bootstrap_theme", "numpydoc"],
+        "docs": ["sphinx>=3", "sphinx-gallery", "sphinx_bootstrap_theme", "numpydoc",],
     },
     test_suite="pytest",
     classifiers=[


### PR DESCRIPTION
#### Reference Issue
#1035

#### What does this PR implement/fix? Explain your changes.
Change sphinx autodoc configuration to use a dictionary instead of a list. I don't know when this was changed in sphinx, but I was able to pin down when this was changed in scikit-learn: https://github.com/scikit-learn/scikit-learn/pull/13982

#### How should this PR be tested?
Build the docs locally with and without this PR using sphinx >= 3.X (the change isn't necessary for sphinx 2.X)

