### PR TITLE
Configuration ci

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,7 @@ select = C,E,F,W,B,T
 ignore = E203, E402, W503
 per-file-ignores =
     *__init__.py:F401
+    *cli.py:T001
 exclude =
     venv
     examples

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -10,6 +10,7 @@ Changelog
 ~~~~~~
 
 * FIX #1035: Render class attributes and methods again.
+* ADD #1049: Add a command line tool for configuration openml-python.
 
 0.12.0
 ~~~~~~

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -59,6 +59,10 @@ which are separated by newlines. The following keys are defined:
     * 1: info output
     * 2: debug output
 
+This file is easily configurable by the ``openml`` command line interface.
+To see where the file is stored, and what its values are, use `openml configure none`.
+Set any field with ``openml configure FIELD`` or even all fields with just ``openml configure``.
+
 ~~~~~~~~~~~~
 Key concepts
 ~~~~~~~~~~~~

--- a/examples/20_basic/introduction_tutorial.py
+++ b/examples/20_basic/introduction_tutorial.py
@@ -42,13 +42,17 @@ An example how to set up OpenML-Python followed up by a simple example.
 # * After logging in, open your account page (avatar on the top right)
 # * Open 'Account Settings', then 'API authentication' to find your API key.
 #
-# There are two ways to authenticate:
+# There are two ways to permanently authenticate:
 #
+# * Use the ``openml`` CLI tool with ``openml configure apikey MYKEY``,
+#   replacing **MYKEY** with your API key.
 # * Create a plain text file **~/.openml/config** with the line
 #   **'apikey=MYKEY'**, replacing **MYKEY** with your API key. The config
 #   file must be in the directory ~/.openml/config and exist prior to
 #   importing the openml module.
-# * Run the code below, replacing 'YOURKEY' with your API key.
+#
+# Alternatively, by running the code below and replacing 'YOURKEY' with your API key,
+# you authenticate for the duration of the python process.
 #
 # .. warning:: This example uploads data. For that reason, this example
 #   connects to the test server instead. This prevents the live server from

--- a/openml/cli.py
+++ b/openml/cli.py
@@ -1,15 +1,95 @@
 """" Command Line Interface for `openml` to configure its settings. """
 
 import argparse
+import string
+from typing import Union, Callable
 
-# from openml import config
+
+from openml import config
+
+
+def is_hex(string_: str) -> bool:
+    return all(c in string.hexdigits for c in string_)
+
+
+def looks_like_api_key(apikey: str) -> bool:
+    return len(apikey) == 32 and is_hex(apikey)
+
+
+def wait_until_valid_input(
+    prompt: str,
+    check: Callable[[str], bool],
+    error_message: Union[str, Callable[[str], str]] = "That is not a valid response.",
+) -> str:
+    """  Asks `prompt` until an input is received which returns True for `check`.
+
+    Parameters
+    ----------
+    prompt: str
+        message to display
+    check: Callable[[str], bool]
+        function to call with the given input, should return true only if the input is valid.
+    error_message: Union[str, Callable[[str], str]
+        a message to display on invalid input, or a `str`->`str` function that can give feedback
+        specific to the error.
+
+    Returns
+    -------
+
+    """
+
+    response = input(prompt)
+    while not check(response):
+        if isinstance(error_message, str):
+            print(error_message)
+        else:
+            print(error_message(response), end="\n\n")
+        response = input(prompt)
+
+    return response
+
+
+def print_configuration():
+    file = config.determine_config_file_path()
+    header = f"File '{file}' contains (or defaults to):"
+    print(header)
+
+    max_key_length = max(map(len, config.get_config_as_dict()))
+    for field, value in config.get_config_as_dict().items():
+        print(f"{field.ljust(max_key_length)}: {value}")
+
+
+def configure_apikey() -> None:
+    print(f"\nYour current API key is set to: '{config.apikey}'")
+    print("You can get an API key at https://new.openml.org")
+    print("You must create an account if you don't have one yet.")
+    print("  1. Log in with the account.")
+    print("  2. Navigate to the profile page (top right circle > Your Profile). ")
+    print("  3. Click the API Key button to reach the page with your API key.")
+    print("If you have any difficulty following these instructions, please let us know on Github.")
+
+    def apikey_error(apikey: str) -> str:
+        if len(apikey) != 32:
+            return f"The key should contain 32 characters but contains {len(apikey)}."
+        if not is_hex(apikey):
+            return "Some characters are not hexadecimal."
+        return "This does not look like an API key."
+
+    response = wait_until_valid_input(
+        prompt="Please enter your API key:", check=looks_like_api_key, error_message=apikey_error,
+    )
+
+    config.set_field_in_config_file("apikey", response)
+    print("Key set.")
 
 
 def configure(args: argparse.Namespace):
     """ Configures the openml configuration file. """
-    print("Configuring", args.file)
-
-    # check if API key exists, if so ask to overwrite.
+    print_configuration()
+    set_functions = {
+        "apikey": configure_apikey,
+    }
+    set_functions.get(args.field, quit)()
 
 
 def main() -> None:
@@ -21,8 +101,26 @@ def main() -> None:
     parser_configure = subparsers.add_parser(
         "configure", description="Set or read variables in your configuration file.",
     )
+
     parser_configure.add_argument(
-        "file", default="~/.openml/config", help="The configuration file to edit or read."
+        "field",
+        type=str,
+        choices=[
+            "apikey",
+            "server",
+            "cachedir",
+            "avoid_duplicate_runs",
+            "connection_n_retries",
+            "verbosity",
+            "all",
+            "none",
+        ],
+        default="all",
+        nargs="?",
+        help="The field you wish to edit, auto-completes the field name, "
+        "e.g. `openml configure cache` is equivalent to `openml configure cachedir`."
+        "Choosing 'all' lets you configure all fields one by one."
+        "Choosing 'none' will print out the current configuration.",
     )
 
     args = parser.parse_args()

--- a/openml/cli.py
+++ b/openml/cli.py
@@ -105,20 +105,10 @@ def main() -> None:
     parser_configure.add_argument(
         "field",
         type=str,
-        choices=[
-            "apikey",
-            "server",
-            "cachedir",
-            "avoid_duplicate_runs",
-            "connection_n_retries",
-            "verbosity",
-            "all",
-            "none",
-        ],
+        choices=[*config._defaults.keys(), "all", "none"],
         default="all",
         nargs="?",
-        help="The field you wish to edit, auto-completes the field name, "
-        "e.g. `openml configure cache` is equivalent to `openml configure cachedir`."
+        help="The field you wish to edit."
         "Choosing 'all' lets you configure all fields one by one."
         "Choosing 'none' will print out the current configuration.",
     )

--- a/openml/cli.py
+++ b/openml/cli.py
@@ -1,0 +1,33 @@
+"""" Command Line Interface for `openml` to configure its settings. """
+
+import argparse
+
+# from openml import config
+
+
+def configure(args: argparse.Namespace):
+    """ Configures the openml configuration file. """
+    print("Configuring", args.file)
+
+    # check if API key exists, if so ask to overwrite.
+
+
+def main() -> None:
+    subroutines = {"configure": configure}
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subroutine")
+
+    parser_configure = subparsers.add_parser(
+        "configure", description="Set or read variables in your configuration file.",
+    )
+    parser_configure.add_argument(
+        "file", default="~/.openml/config", help="The configuration file to edit or read."
+    )
+
+    args = parser.parse_args()
+    subroutines.get(args.subroutine, lambda _: parser.print_help())(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/openml/cli.py
+++ b/openml/cli.py
@@ -68,15 +68,12 @@ def print_configuration():
         print(f"{field.ljust(max_key_length)}: {value}")
 
 
-def configure_apikey() -> None:
-    print(f"\nYour current API key is set to: '{config.apikey}'")
-    print("You can get an API key at https://new.openml.org")
-    print("You must create an account if you don't have one yet.")
-    print("  1. Log in with the account.")
-    print("  2. Navigate to the profile page (top right circle > Your Profile). ")
-    print("  3. Click the API Key button to reach the page with your API key.")
-    print("If you have any difficulty following these instructions, please let us know on Github.")
+def verbose_set(field, value):
+    config.set_field_in_config_file(field, value)
+    print(f"{field} set to '{value}'.")
 
+
+def configure_apikey(value: str) -> None:
     def apikey_error(apikey: str) -> str:
         if len(apikey) != 32:
             return f"The key should contain 32 characters but contains {len(apikey)}."
@@ -84,51 +81,75 @@ def configure_apikey() -> None:
             return "Some characters are not hexadecimal."
         return "This does not look like an API key."
 
-    response = wait_until_valid_input(
-        prompt="Please enter your API key:", check=looks_like_api_key, error_message=apikey_error,
-    )
+    if value is not None:
+        if not looks_like_api_key(value):
+            print(apikey_error(value))
+            quit(-1)
+    else:
+        print(f"\nYour current API key is set to: '{config.apikey}'")
+        print("You can get an API key at https://new.openml.org")
+        print("You must create an account if you don't have one yet.")
+        print("  1. Log in with the account.")
+        print("  2. Navigate to the profile page (top right circle > Your Profile). ")
+        print("  3. Click the API Key button to reach the page with your API key.")
+        print("If you have any difficulty following these instructions, let us know on Github.")
 
-    config.set_field_in_config_file("apikey", response)
-    print("Key set.")
+        value = wait_until_valid_input(
+            prompt="Please enter your API key:",
+            check=looks_like_api_key,
+            error_message=apikey_error,
+        )
+    verbose_set("apikey", value)
 
 
-def configure_server():
-    print("\nSpecify which server you wish to connect to.")
-
+def configure_server(value: str):
     def is_valid_server(server: str) -> bool:
         is_shorthand = server in ["test", "production"]
         return is_shorthand or looks_like_url(server)
 
-    response = wait_until_valid_input(
-        prompt="Specify a url or use 'test' or 'production' as a shorthand:",
-        check=is_valid_server,
-        error_message="Must be 'test', 'production' or a url.",
-    )
+    error_message = "Must be 'test', 'production' or a url."
 
-    if response == "test":
-        response = "https://test.openml.org/api/v1/xml"
-    elif response == "production":
-        response = "https://www.openml.org/api/v1/xml"
+    if value is not None:
+        if not is_valid_server(value):
+            print(error_message)
+            quit(-1)
+    else:
+        print("\nSpecify which server you wish to connect to.")
+        value = wait_until_valid_input(
+            prompt="Specify a url or use 'test' or 'production' as a shorthand:",
+            check=is_valid_server,
+            error_message=error_message,
+        )
 
-    config.set_field_in_config_file("server", response)
+    if value == "test":
+        value = "https://test.openml.org/api/v1/xml"
+    elif value == "production":
+        value = "https://www.openml.org/api/v1/xml"
+
+    verbose_set("server", value)
 
 
 def configure(args: argparse.Namespace):
     """ Calls the right submenu(s) to edit `args.field` in the configuration file. """
-    print_configuration()
     set_functions = {
         "apikey": configure_apikey,
         "server": configure_server,
     }
 
-    def not_supported_yet():
+    def not_supported_yet(_):
         print(f"Setting '{args.field}' is not supported yet.")
 
     if args.field not in ["all", "none"]:
-        set_functions.get(args.field, not_supported_yet)()
-    elif args.field == "all":
+        set_functions.get(args.field, not_supported_yet)(args.value)
+    else:
+        if args.value is not None:
+            print(f"Can not set value ('{args.value}') when field is specified as '{args.field}'.")
+            quit()
+        print_configuration()
+
+    if args.field == "all":
         for set_field_function in set_functions.values():
-            set_field_function()
+            set_field_function(args.value)
 
 
 def main() -> None:
@@ -152,6 +173,10 @@ def main() -> None:
         help="The field you wish to edit."
         "Choosing 'all' lets you configure all fields one by one."
         "Choosing 'none' will print out the current configuration.",
+    )
+
+    parser_configure.add_argument(
+        "value", type=str, default=None, nargs="?", help="The value to set the FIELD to.",
     )
 
     args = parser.parse_args()

--- a/openml/cli.py
+++ b/openml/cli.py
@@ -43,18 +43,16 @@ def wait_until_valid_input(
     valid input
 
     """
-    response = input(prompt)
-    if sanitize:
-        response = sanitize(response)
-    error_message = check(response)
-    while error_message:
-        print(error_message, end="\n\n")
+
+    while True:
         response = input(prompt)
         if sanitize:
             response = sanitize(response)
         error_message = check(response)
-
-    return response
+        if error_message:
+            print(error_message, end="\n\n")
+        else:
+            return response
 
 
 def print_configuration():

--- a/openml/config.py
+++ b/openml/config.py
@@ -273,8 +273,11 @@ def set_field_in_config_file(field: str, value: Any):
     config = _parse_config(str(config_file))
     with open(config_file, "w") as fh:
         for f in _defaults.keys():
-            # We can't blindly set all values based on globals() because the user when the user
+            # We can't blindly set all values based on globals() because when the user
             # sets it through config.FIELD it should not be stored to file.
+            # There doesn't seem to be a way to avoid writing defaults to file with configparser,
+            # because it is impossible to distinguish from an explicitly set value that matches
+            # the default value, to one that was set to its default because it was omitted.
             value = config.get("FAKE_SECTION", f)
             if f == field:
                 value = globals()[f]

--- a/openml/config.py
+++ b/openml/config.py
@@ -265,22 +265,14 @@ def _setup(config=None):
 
 def set_field_in_config_file(field: str, value: Any):
     """ Overwrites the `field` in the configuration file with the new `value`. """
-    fields = [
-        "apikey",
-        "server",
-        "cache_directory",
-        "avoid_duplicate_runs",
-        "connection_n_retries",
-        "max_retries",
-    ]
-    if field not in fields:
-        return ValueError(f"Field '{field}' is not valid and must be one of '{fields}'.")
+    if field not in _defaults:
+        return ValueError(f"Field '{field}' is not valid and must be one of '{_defaults.keys()}'.")
 
     globals()[field] = value
     config_file = determine_config_file_path()
     config = _parse_config(str(config_file))
     with open(config_file, "w") as fh:
-        for f in fields:
+        for f in _defaults.keys():
             # We can't blindly set all values based on globals() because the user when the user
             # sets it through config.FIELD it should not be stored to file.
             value = config.get("FAKE_SECTION", f)

--- a/setup.py
+++ b/setup.py
@@ -102,4 +102,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
+    entry_points={"console_scripts": ["openml=openml.cli:main"]},
 )


### PR DESCRIPTION
Closes #1045 

Adding a CLI which can be used to configure the fields in the configuration file.
This is a draft PR because it's feature incomplete (some fields are missing), but I wanted some input to see if this is an acceptable way to do it.

Installing openml with `pip install openml` will also add a cli script `openml`. It'll expect something like `openml ROUTINE ROUTINE_ARGS`, the current routine is only `configure`, but I figured some day we might use it for e.g. dataset download.
The signature of `openml configure` looks like this:

```
usage: openml configure [-h] [{apikey,server,cachedir,avoid_duplicate_runs,connection_n_retries,max_retries,all,none}]

Set or read variables in your configuration file. For more help also see 'https://openml.github.io/openml-
python/master/usage.html#configuration'.

positional arguments:
  {apikey,server,cachedir,avoid_duplicate_runs,connection_n_retries,max_retries,all,none}
                        The field you wish to edit.Choosing 'all' lets you configure all fields one by one.Choosing
                        'none' will print out the current configuration.

optional arguments:
  -h, --help            show this help message and exit
```

[Video](https://www.loom.com/share/8e106734f0fc4947b59d74619782b460) of current functionality.
~I'm also planning for a direct option that avoids the explanation/interactive routine (e.g. `openml config apikey 1234567890abcdef1234567890abcdef`).~
Update: It's also possible to use a non-interactive direct command, e.g.: `openml configure apikey 1234567890abcdef1234567890abcdef`.