### PR TITLE
Fix temp directory creation on container

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -204,7 +204,7 @@ def _setup(config=None):
     # read config file, create directory for config file
     if not os.path.exists(config_dir):
         try:
-            os.mkdir(config_dir)
+            os.makedirs(config_dir, exist_ok=True)
             cache_exists = True
         except PermissionError:
             cache_exists = False
@@ -235,7 +235,7 @@ def _setup(config=None):
     # create the cache subdirectory
     if not os.path.exists(cache_directory):
         try:
-            os.mkdir(cache_directory)
+            os.makedirs(cache_directory, exist_ok=True)
         except PermissionError:
             openml_logger.warning(
                 "No permission to create openml cache directory at %s! This can result in "

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -26,6 +26,16 @@ class TestConfig(openml.testing.TestBase):
         self.assertEqual(log_handler_mock.call_count, 1)
         self.assertFalse(log_handler_mock.call_args_list[0][1]["create_file_handler"])
 
+    @unittest.mock.patch("os.path.expanduser")
+    def test_XDG_directories_do_not_exist(self, expanduser_mock):
+        with tempfile.TemporaryDirectory(dir=self.workdir) as td:
+
+            def side_effect(path_):
+                return os.path.join(td, str(path_).replace("~/", ""))
+
+            expanduser_mock.side_effect = side_effect
+            openml.config._setup()
+
     def test_get_config_as_dict(self):
         """ Checks if the current configuration is returned accurately as a dict. """
         config = openml.config.get_config_as_dict()


### PR DESCRIPTION
#### Reference Issue

Fixes a bug which could occur when using OpenML-Python in a docker container. Initially reported as https://github.com/conda-forge/openml-feedstock/pull/1#issuecomment-817332813 by @bastianzim

When OpenML-Python was trying to create a cache directory as `/home/${USER}/.config/openml` it would only try to create the `openml` directory. If the `.config` directory was also missing, it would fail.

#### What does this PR implement/fix? Explain your changes.

This PR creates both directories.

#### How should this PR be tested?

New unit test, or in a docker container built with:
```
apt update
apt upgrade
apt install python3-dev ipython3 python3-pip git
pip3 install openml
```
#### Any other comments?

