### PR TITLE
Create a non-linear retry policy.

### DIFF
--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -3,7 +3,9 @@
 import time
 import hashlib
 import logging
+import math
 import pathlib
+import random
 import requests
 import urllib.parse
 import xml
@@ -262,7 +264,10 @@ def _send_request(request_method, url, data, files=None, md5_checksum=None):
                 if retry_counter >= n_retries:
                     raise
                 else:
-                    time.sleep(retry_counter)
+                    wait = retry_counter + (1 / (1 + math.exp(-(retry_counter - 6)))) * 20
+                    variation = random.gauss(0, wait / 10)
+                    wait_time = max(1.0, wait + variation)
+                    time.sleep(wait_time)
     if response is None:
         raise ValueError("This should never happen!")
     return response


### PR DESCRIPTION
This PR implements a non-linear retry policy that is used when downloading from the server fails.

Users of the AutoML benchmark find the OpenML server failing regularly when using parallel instances of the benchmark.
Each parallel instance downloads a task and dataset (and its meta-data), which leads to many server requests.
These requests typically come in roughly at the same time because the job deployment is fully automated.
While these issues can be tackled at in the benchmark code, I think they should be addressed by OpenML.
After all, we want to support a large amount of concurrent users (automated or otherwise).

The previous policy was linear, which meant that even if the first few connections failed, the retry time was still relatively low.
This leads to a low total time which might be insufficient for the server to have handled its previous requests (e.g. large data downloads).
The previous policy was also deterministic, which means the load of requests are not distributed well.

In this PR I propose to use a retry policy based on the sigmoid function, this allows quick retries at first (to keep the experience of interactive users good) but slows down quickly.
It also introduces random fluctuations to avoid creating more artificial peaks.

While I try to provide a good experience for both interactive users and automated workloads, perhaps we should consider a `retry policy` setting in our configuration file.
We could make a distinction for `interactive` users (for which we prioritize a quick response and randomization is not necessary), and a policy for `robot`s which is more liberal with waiting times and can have more extreme randomization.

Wait times for 20 retries (minus the noise):
```
0 1.0  # minimum wait time
1 1.133857018485697
2 2.359724199241831
3 3.948517463551336
4 6.384058440442351
5 10.378828427399903
6 16.0
7 21.621171572600097
8 25.615941559557648
9 28.051482536448667
10 29.640275800758168
11 30.866142981514304
12 31.950547536867308
13 32.98177897611199
14 33.99329299739067
15 34.99753210848027
16 35.99909204262595
17 36.99966597156304
18 37.99987711650796
19 38.99995479351404
```