### PR TITLE
Updating examples to use names instead of integer ids whenever possible

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,7 +8,7 @@ Changelog
 
 0.12.2
 ~~~~~~
-
+* MAINT/DOC: #1066/#1063 Use names instead of integer ids in the examples whenever possible. Update documentation for ``get_dataset``.
 * DOC: Fixes a few broken links in the documentation.
 * MAINT/DOC: Automatically check for broken external links when building the documentation.
 * MAINT/DOC: Fail documentation building on warnings. This will make the documentation building

--- a/examples/20_basic/simple_datasets_tutorial.py
+++ b/examples/20_basic/simple_datasets_tutorial.py
@@ -26,8 +26,7 @@ print(datasets_df.head(n=10))
 # Download a dataset
 # ==================
 
-# Iris dataset https://www.openml.org/d/61
-dataset = openml.datasets.get_dataset(61)
+dataset = openml.datasets.get_dataset(dataset_id="iris", version=1)
 
 # Print a summary
 print(

--- a/examples/20_basic/simple_flows_and_runs_tutorial.py
+++ b/examples/20_basic/simple_flows_and_runs_tutorial.py
@@ -21,7 +21,7 @@ openml.config.start_using_configuration_for_example()
 # ==============================
 
 # NOTE: We are using dataset 20 from the test server: https://test.openml.org/d/20
-dataset = openml.datasets.get_dataset(20)
+dataset = openml.datasets.get_dataset(dataset_id="diabetes", version=1)
 X, y, categorical_indicator, attribute_names = dataset.get_data(
     dataset_format="array", target=dataset.default_target_attribute
 )

--- a/examples/20_basic/simple_suites_tutorial.py
+++ b/examples/20_basic/simple_suites_tutorial.py
@@ -38,8 +38,9 @@ import openml
 ####################################################################################################
 # Downloading benchmark suites
 # ============================
-
-suite = openml.study.get_suite(99)
+# OpenML Benchmarking Suites and the OpenML-CC18
+# https://www.openml.org/s/99
+suite = openml.study.get_suite("OpenML-CC18")
 print(suite)
 
 ####################################################################################################

--- a/examples/30_extended/configure_logging.py
+++ b/examples/30_extended/configure_logging.py
@@ -24,7 +24,7 @@ Explains openml-python logging, and shows how to configure it.
 
 import openml
 
-openml.datasets.get_dataset("iris")
+openml.datasets.get_dataset("iris", version=1)
 
 # With default configuration, the above example will show no output to console.
 # However, in your cache directory you should find a file named 'openml_python.log',
@@ -39,7 +39,7 @@ import logging
 
 openml.config.console_log.setLevel(logging.DEBUG)
 openml.config.file_log.setLevel(logging.WARNING)
-openml.datasets.get_dataset("iris")
+openml.datasets.get_dataset("iris", version=1)
 
 # Now the log level that was previously written to file should also be shown in the console.
 # The message is now no longer written to file as the `file_log` was set to level `WARNING`.

--- a/examples/30_extended/datasets_tutorial.py
+++ b/examples/30_extended/datasets_tutorial.py
@@ -52,7 +52,7 @@ datalist.query("NumberOfClasses > 50")
 # =================
 
 # This is done based on the dataset ID.
-dataset = openml.datasets.get_dataset(1471)
+dataset = openml.datasets.get_dataset(dataset_id="eeg-eye-state", version=1)
 
 # Print a summary
 print(
@@ -92,7 +92,7 @@ print(X.info())
 # data file. The dataset object can be used as normal.
 # Whenever you use any functionality that requires the data,
 # such as `get_data`, the data will be downloaded.
-dataset = openml.datasets.get_dataset(1471, download_data=False)
+dataset = openml.datasets.get_dataset(dataset_id="eeg-eye-state", version=1, download_data=False)
 
 ############################################################################
 # Exercise 2

--- a/examples/30_extended/flows_and_runs_tutorial.py
+++ b/examples/30_extended/flows_and_runs_tutorial.py
@@ -25,7 +25,7 @@ openml.config.start_using_configuration_for_example()
 # Train a scikit-learn model on the data manually.
 
 # NOTE: We are using dataset 68 from the test server: https://test.openml.org/d/68
-dataset = openml.datasets.get_dataset(68)
+dataset = openml.datasets.get_dataset(dataset_id="eeg-eye-state", version=1)
 X, y, categorical_indicator, attribute_names = dataset.get_data(
     dataset_format="array", target=dataset.default_target_attribute
 )
@@ -36,7 +36,7 @@ clf.fit(X, y)
 # You can also ask for meta-data to automatically preprocess the data.
 #
 # * e.g. categorical features -> do feature encoding
-dataset = openml.datasets.get_dataset(17)
+dataset = openml.datasets.get_dataset(dataset_id="credit-g", version=1)
 X, y, categorical_indicator, attribute_names = dataset.get_data(
     dataset_format="array", target=dataset.default_target_attribute
 )

--- a/examples/30_extended/study_tutorial.py
+++ b/examples/30_extended/study_tutorial.py
@@ -36,7 +36,8 @@ print(studies.head(n=10))
 
 ############################################################################
 # This is done based on the study ID.
-study = openml.study.get_study(123)
+# https://www.openml.org/api/v1/study/123
+study = openml.study.get_study("Linear vs. Non Linear")
 print(study)
 
 ############################################################################
@@ -77,7 +78,8 @@ clf = RandomForestClassifier()
 tasks = [115, 259, 307]
 
 # To verify
-suite = openml.study.get_suite(1)
+# https://test.openml.org/api/v1/study/1
+suite = openml.study.get_suite("OpenML100")
 print(all([t_id in suite.tasks for t_id in tasks]))
 
 run_ids = []

--- a/examples/30_extended/study_tutorial.py
+++ b/examples/30_extended/study_tutorial.py
@@ -36,8 +36,7 @@ print(studies.head(n=10))
 
 ############################################################################
 # This is done based on the study ID.
-# https://www.openml.org/api/v1/study/123
-study = openml.study.get_study("Linear vs. Non Linear")
+study = openml.study.get_study(123)
 print(study)
 
 ############################################################################

--- a/examples/30_extended/suites_tutorial.py
+++ b/examples/30_extended/suites_tutorial.py
@@ -37,7 +37,8 @@ print(suites.head(n=10))
 
 ############################################################################
 # This is done based on the dataset ID.
-suite = openml.study.get_suite(99)
+# https://www.openml.org/api/v1/study/99
+suite = openml.study.get_suite("OpenML-CC18")
 print(suite)
 
 ############################################################################

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -368,7 +368,8 @@ def get_dataset(
     Parameters
     ----------
     dataset_id : int or str
-        Dataset ID of the dataset to download
+        Dataset ID of the dataset to download. It can be an integer or it can be a string
+        of the dataset name.
     download_data : bool, optional (default=True)
         If True, also download the data file. Beware that some datasets are large and it might
         make the operation noticeably slower. Metadata is also still retrieved.


### PR DESCRIPTION
#### Reference Issue

#1066, #1063

#### What does this PR implement/fix? Explain your changes.

- [x] Uses names instead of integer ids in the examples whenever possible. 
- [x] Update documentation for `get_dataset`
- [ ] Check implementation of examples for datasets and splits, update them if necessary in case they do not show that they can be accessed with names too.

#### How should this PR be tested?

Existing unit tests.

