### PR TITLE
Remove E500 from list of exception to raise

### DIFF
--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -247,9 +247,8 @@ def _send_request(request_method, url, data, files=None, md5_checksum=None):
                 OpenMLHashException,
             ) as e:
                 if isinstance(e, OpenMLServerException):
-                    if e.code not in [107, 500]:
+                    if e.code not in [107]:
                         # 107: database connection error
-                        # 500: internal server error
                         raise
                 elif isinstance(e, xml.parsers.expat.ExpatError):
                     if request_method != "get" or retry_counter >= n_retries:


### PR DESCRIPTION
OpenML code 500 indicates no results for a flow query, and was likely
confused with the HTTP code 500 for internal server error.

Note that when parsing the error, this is actually annotated correctly [here](https://github.com/openml/openml-python/blob/6e8a9db03fd1af9d3eb0623970101413b531cc69/openml/_api_calls.py#L302-L310).