### PR TITLE
Fetch before checkout

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -44,6 +44,7 @@ if [ -n "$2" ]; then
     git fetch "$fork_url" "$fork_branch":branch_from_fork
     branch=branch_from_fork
   else
+    git fetch origin "$2"
     branch=$2
   fi
   if ! git checkout "$branch" ; then


### PR DESCRIPTION
Fixes a bug where the `BRANCH` syntax did not work for branches on the main repository if they were created after the docker image (the `openml#BRANCH` would allow for a workaround however).

