### PR TITLE
Don't fail when Parquet server can't be reached

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Union, Optional, cast
 import numpy as np
 import arff
 import pandas as pd
+import urllib3
 
 import xmltodict
 from scipy.sparse import coo_matrix
@@ -425,7 +426,10 @@ def get_dataset(
 
         arff_file = _get_dataset_arff(description) if download_data else None
         if "oml:minio_url" in description and download_data:
-            parquet_file = _get_dataset_parquet(description)
+            try:
+                parquet_file = _get_dataset_parquet(description)
+            except urllib3.exceptions.MaxRetryError:
+                parquet_file = None
         else:
             parquet_file = None
         remove_dataset_cache = False


### PR DESCRIPTION
Fixes #1084.
The Parquet file is optional, and failing to reach it (and download it)
should not prevent the usage of the other cached/downloaded files.

To test run:
```python
import openml

d = openml.datasets.get_dataset(4135)
print(d)
```
once with an internet connection, and once without. Both should work.
