### PR TITLE
Allow tasks to be downloaded without dataqualities

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -11,6 +11,7 @@ Changelog
 
 * ADD #1065: Add a ``retry_policy`` configuration option that determines the frequency and number of times to attempt to retry server requests.
 * ADD #1075: A docker image is now automatically built on a push to develop. It can be used to build docs or run tests in an isolated environment.
+* ADD: You can now avoid downloading 'qualities' meta-data when downloading a task with the ``download_qualities`` parameter of ``openml.tasks.get_task[s]`` functions.
 * DOC: Fixes a few broken links in the documentation.
 * MAINT: Rename `master` brach to ` main` branch.
 * MAINT/DOC: Automatically check for broken external links when building the documentation.

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -369,7 +369,7 @@ def get_dataset(
     ----------
     dataset_id : int or str
         Dataset ID of the dataset to download
-    download_data : bool, optional (default=True)
+    download_data : bool (default=True)
         If True, also download the data file. Beware that some datasets are large and it might
         make the operation noticeably slower. Metadata is also still retrieved.
         If False, create the OpenMLDataset and only populate it with the metadata.
@@ -377,12 +377,14 @@ def get_dataset(
     version : int, optional (default=None)
         Specifies the version if `dataset_id` is specified by name.
         If no version is specified, retrieve the least recent still active version.
-    error_if_multiple : bool, optional (default=False)
+    error_if_multiple : bool (default=False)
         If ``True`` raise an error if multiple datasets are found with matching criteria.
-    cache_format : str, optional (default='pickle')
+    cache_format : str (default='pickle')
         Format for caching the dataset - may be feather or pickle
         Note that the default 'pickle' option may load slower than feather when
         no.of.rows is very high.
+    download_qualities : bool (default=True)
+        Option to download 'qualities' meta-data in addition to the minimal dataset description.
     Returns
     -------
     dataset : :class:`openml.OpenMLDataset`

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import io
 import re
 import os
-from typing import Union, Dict, Optional
+from typing import Union, Dict, Optional, List
 
 import pandas as pd
 import xmltodict
@@ -297,7 +297,9 @@ def __list_tasks(api_call, output_format="dict"):
     return tasks
 
 
-def get_tasks(task_ids, download_data=True):
+def get_tasks(
+    task_ids: List[Union[str, int]], download_data: bool = True, download_qualities: bool = True
+) -> List[OpenMLTask]:
     """Download tasks.
 
     This function iterates :meth:`openml.tasks.get_task`.
@@ -306,8 +308,10 @@ def get_tasks(task_ids, download_data=True):
     ----------
     task_ids : iterable
         Integers/Strings representing task ids.
-    download_data : bool
+    download_data : bool (default = True)
         Option to trigger download of data along with the meta data.
+    download_qualities : bool (default=True)
+        Option to download 'qualities' meta-data in addition to the minimal dataset description.
 
     Returns
     -------
@@ -315,12 +319,14 @@ def get_tasks(task_ids, download_data=True):
     """
     tasks = []
     for task_id in task_ids:
-        tasks.append(get_task(task_id, download_data))
+        tasks.append(get_task(task_id, download_data, download_qualities))
     return tasks
 
 
 @openml.utils.thread_safe_if_oslo_installed
-def get_task(task_id: int, download_data: bool = True) -> OpenMLTask:
+def get_task(
+    task_id: int, download_data: bool = True, download_qualities: bool = True
+) -> OpenMLTask:
     """Download OpenML task for a given task ID.
 
     Downloads the task representation, while the data splits can be
@@ -331,8 +337,10 @@ def get_task(task_id: int, download_data: bool = True) -> OpenMLTask:
     ----------
     task_id : int or str
         The OpenML task id.
-    download_data : bool
+    download_data : bool (default=True)
         Option to trigger download of data along with the meta data.
+    download_qualities : bool (default=True)
+        Option to download 'qualities' meta-data in addition to the minimal dataset description.
 
     Returns
     -------
@@ -347,7 +355,7 @@ def get_task(task_id: int, download_data: bool = True) -> OpenMLTask:
 
     try:
         task = _get_task_description(task_id)
-        dataset = get_dataset(task.dataset_id, download_data)
+        dataset = get_dataset(task.dataset_id, download_data, download_qualities=download_qualities)
         # List of class labels availaible in dataset description
         # Including class labels as part of task meta data handles
         #   the case where data download was initially disabled

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -1,5 +1,5 @@
 # License: BSD 3-Clause
-
+import warnings
 from collections import OrderedDict
 import io
 import re
@@ -298,7 +298,7 @@ def __list_tasks(api_call, output_format="dict"):
 
 
 def get_tasks(
-    task_ids: List[Union[str, int]], download_data: bool = True, download_qualities: bool = True
+    task_ids: List[int], download_data: bool = True, download_qualities: bool = True
 ) -> List[OpenMLTask]:
     """Download tasks.
 
@@ -306,8 +306,8 @@ def get_tasks(
 
     Parameters
     ----------
-    task_ids : iterable
-        Integers/Strings representing task ids.
+    task_ids : List[int]
+        A list of task ids to download.
     download_data : bool (default = True)
         Option to trigger download of data along with the meta data.
     download_qualities : bool (default=True)
@@ -335,8 +335,8 @@ def get_task(
 
     Parameters
     ----------
-    task_id : int or str
-        The OpenML task id.
+    task_id : int
+        The OpenML task id of the task to download.
     download_data : bool (default=True)
         Option to trigger download of data along with the meta data.
     download_qualities : bool (default=True)
@@ -346,10 +346,13 @@ def get_task(
     -------
     task
     """
+    if not isinstance(task_id, int):
+        warnings.warn("Task id must be specified as `int` from 0.14.0 onwards.", DeprecationWarning)
+
     try:
         task_id = int(task_id)
     except (ValueError, TypeError):
-        raise ValueError("Dataset ID is neither an Integer nor can be " "cast to an Integer.")
+        raise ValueError("Dataset ID is neither an Integer nor can be cast to an Integer.")
 
     tid_cache_dir = openml.utils._create_cache_directory_for_id(TASKS_CACHE_DIR_NAME, task_id,)
 


### PR DESCRIPTION
Previously ``download_qualities`` would be left at the default of `True` with no way to overwrite it, this PR adds the parameter to `get_task` which would allow you to download a task with its dataset without ever downloading qualities.

