### PR TITLE
Fix #1106

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -414,17 +414,7 @@ class OpenMLDataset(OpenMLBase):
             if isinstance(type_, list):
                 categorical.append(True)
                 categories_names[name] = type_
-                if len(type_) == 2:
-                    type_norm = [cat.lower().capitalize() for cat in type_]
-                    if set(["True", "False"]) == set(type_norm):
-                        categories_names[name] = [
-                            True if cat == "True" else False for cat in type_norm
-                        ]
-                        attribute_dtype[name] = "boolean"
-                    else:
-                        attribute_dtype[name] = "categorical"
-                else:
-                    attribute_dtype[name] = "categorical"
+                attribute_dtype[name] = "categorical"
             else:
                 categorical.append(False)
                 attribute_dtype[name] = ARFF_DTYPES_TO_PD_DTYPE[type_]

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -147,12 +147,12 @@ class OpenMLDatasetTest(TestBase):
         # test to check that we are converting properly True and False even
         # with some inconsistency when dumping the data on openml
         data, _, _, _ = self.jm1.get_data()
-        self.assertTrue(data["defects"].dtype.name == "category")
-        self.assertTrue(set(data["defects"].cat.categories) == {True, False})
+        self.assertEquals(data["defects"].dtype.name, "category")
+        self.assertEquals(data["defects"].cat.categories.to_list(), ["false", "true"])
 
         data, _, _, _ = self.pc4.get_data()
-        self.assertTrue(data["c"].dtype.name == "category")
-        self.assertTrue(set(data["c"].cat.categories) == {True, False})
+        self.assertEquals(data["c"].dtype.name, "category")
+        self.assertEquals(data["c"].cat.categories.to_list(), ["FALSE", "TRUE"])
 
     def test_get_data_no_str_data_for_nparrays(self):
         # check that an error is raised when the dataset contains string


### PR DESCRIPTION
Fixes #1106

For pandas Dataframe do not encode categories with values "True" and "False" as type boolean but keep them as type category.