### PR TITLE
Add `ChunkEncodingError` to list of errors on which to retry requests

### DIFF
--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -242,6 +242,7 @@ def _send_request(request_method, url, data, files=None, md5_checksum=None):
                     )
                 break
             except (
+                requests.exceptions.ChunkedEncodingError,
                 requests.exceptions.ConnectionError,
                 requests.exceptions.SSLError,
                 OpenMLServerException,


### PR DESCRIPTION
Encountered a `ChunkEncodingError` the other day which was reraised without retrying first. The error stems from a connectivity issue (as far as I can tell) and either way seemed to have disappeared when I tried again - so I think it's reasonable to include this in the set of errors which lead to retries.

```
  File "/repo/venv/lib/python3.7/site-packages/openml/tasks/functions.py", line 361, in get_task
    dataset = get_dataset(task.dataset_id, download_data, download_qualities=download_qualities)
  File "/repo/venv/lib/python3.7/site-packages/openml/datasets/functions.py", line 429, in get_dataset
    arff_file = _get_dataset_arff(description) if download_data else None
  File "/repo/venv/lib/python3.7/site-packages/openml/datasets/functions.py", line 1051, in _get_dataset_arff
    source=url, output_path=output_file_path, md5_checksum=md5_checksum_fixture
  File "/repo/venv/lib/python3.7/site-packages/openml/_api_calls.py", line 154, in _download_text_file
    response = __read_url(source, request_method="get", md5_checksum=md5_checksum)
  File "/repo/venv/lib/python3.7/site-packages/openml/_api_calls.py", line 206, in __read_url
    request_method=request_method, url=url, data=data, md5_checksum=md5_checksum
  File "/repo/venv/lib/python3.7/site-packages/openml/_api_calls.py", line 230, in _send_request
    response = session.get(url, params=data)
  File "/repo/venv/lib/python3.7/site-packages/requests/sessions.py", line 555, in get
    return self.request('GET', url, **kwargs)
  File "/repo/venv/lib/python3.7/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/repo/venv/lib/python3.7/site-packages/requests/sessions.py", line 697, in send
    r.content
  File "/repo/venv/lib/python3.7/site-packages/requests/models.py", line 831, in content
    self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
  File "/repo/venv/lib/python3.7/site-packages/requests/models.py", line 756, in generate
    raise ChunkedEncodingError(e)
requests.exceptions.ChunkedEncodingError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", Invalid
ChunkLength(got length b'', 0 bytes read))
```