### PR TITLE
Always ignore MaxRetryError but log with warning

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -428,10 +428,7 @@ def get_dataset(
 
         arff_file = _get_dataset_arff(description) if download_data else None
         if "oml:minio_url" in description and download_data:
-            try:
-                parquet_file = _get_dataset_parquet(description)
-            except urllib3.exceptions.MaxRetryError:
-                parquet_file = None
+            parquet_file = _get_dataset_parquet(description)
         else:
             parquet_file = None
         remove_dataset_cache = False
@@ -1003,7 +1000,8 @@ def _get_dataset_parquet(
             openml._api_calls._download_minio_file(
                 source=cast(str, url), destination=output_file_path
             )
-        except FileNotFoundError:
+        except (FileNotFoundError, urllib3.exceptions.MaxRetryError) as e:
+            logger.warning("Could not download file from %s: %s" % (cast(str, url), e))
             return None
     return output_file_path
 


### PR DESCRIPTION
Currently parquet files are completely optional, so under no circumstance should the inability to download it raise an error to the user. Instead we log a warning and proceed without the parquet file.

Note that while in the code diff the change might seem ineffectual, the function was also called unprotected [from dataset.py#306](https://github.com/openml/openml-python/blob/6717e66a1e967a131a6ca7feb96f6d166017bed7/openml/datasets/dataset.py#L306), which is what caused the issue in #1116.

Fixes #1116
