### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,7 @@ preferred-citation:
     given-names: "Sahithya"
   - family-names: "Müller"
     given-names: "Andreas"
+    orcid: "https://orcid.org/0000-0002-2349-9428"
   - family-names: "Vanschoren"
     given-names: "Joaquin"
     orcid: "https://orcid.org/0000-0001-7044-9805"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use this software in a publication, please cite the metadata from preferred-citation."
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Feurer"
+    given-names: "Matthias"
+    alias: "mfeurer"
+  - family-names: "van Rijn"
+    given-names: "Jan N."
+    orcid: "https://orcid.org/0000-0003-2898-2168"
+  - family-names: "Kadra"
+    given-names: "Arlind"
+  - family-names: "Gijsbers"
+    given-names: "Pieter"
+    orcid: "https://orcid.org/0000-0001-7346-8075"
+  - family-names: "Mallik"
+    given-names: "Neeratyoy"
+    orcid: "https://orcid.org/0000-0002-0598-1608"
+  - family-names: "Ravi"
+    given-names: "Sahithya"
+  - family-names: "Müller"
+    given-names: "Andreas"
+  - family-names: "Vanschoren"
+    given-names: "Joaquin"
+    orcid: "https://orcid.org/0000-0001-7044-9805"
+  - family-names: "Hutter"
+    given-names: "Frank"
+  journal: "Journal of Machine Learning Research"
+  title: "OpenML-Python: an extensible Python API for OpenML"
+  abstract: "OpenML is an online platform for open science collaboration in machine learning, used to share datasets and results of machine learning experiments. In this paper, we introduce OpenML-Python, a client API for Python, which opens up the OpenML platform for a wide range of Python-based machine learning tools. It provides easy access to all datasets, tasks and experiments on OpenML from within Python. It also provides functionality to conduct machine learning experiments, upload the results to OpenML, and reproduce results which are stored on OpenML. Furthermore, it comes with a scikit-learn extension and an extension mechanism to easily integrate other machine learning libraries written in Python into the OpenML ecosystem. Source code and documentation are available at https://github.com/openml/openml-python/."
+  volume: 22
+  year: 2021
+  url: https://jmlr.org/papers/v22/19-920.html

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,7 @@ preferred-citation:
     orcid: "https://orcid.org/0000-0001-7044-9805"
   - family-names: "Hutter"
     given-names: "Frank"
+    orcid: "https://orcid.org/0000-0002-2037-3694"
   journal: "Journal of Machine Learning Research"
   title: "OpenML-Python: an extensible Python API for OpenML"
   abstract: "OpenML is an online platform for open science collaboration in machine learning, used to share datasets and results of machine learning experiments. In this paper, we introduce OpenML-Python, a client API for Python, which opens up the OpenML platform for a wide range of Python-based machine learning tools. It provides easy access to all datasets, tasks and experiments on OpenML from within Python. It also provides functionality to conduct machine learning experiments, upload the results to OpenML, and reproduce results which are stored on OpenML. Furthermore, it comes with a scikit-learn extension and an extension mechanism to easily integrate other machine learning libraries written in Python into the OpenML ecosystem. Source code and documentation are available at https://github.com/openml/openml-python/."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ preferred-citation:
   authors:
   - family-names: "Feurer"
     given-names: "Matthias"
-    alias: "mfeurer"
+    orcid: "https://orcid.org/0000-0001-9611-8588"
   - family-names: "van Rijn"
     given-names: "Jan N."
     orcid: "https://orcid.org/0000-0003-2898-2168"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,4 +31,8 @@ preferred-citation:
   abstract: "OpenML is an online platform for open science collaboration in machine learning, used to share datasets and results of machine learning experiments. In this paper, we introduce OpenML-Python, a client API for Python, which opens up the OpenML platform for a wide range of Python-based machine learning tools. It provides easy access to all datasets, tasks and experiments on OpenML from within Python. It also provides functionality to conduct machine learning experiments, upload the results to OpenML, and reproduce results which are stored on OpenML. Furthermore, it comes with a scikit-learn extension and an extension mechanism to easily integrate other machine learning libraries written in Python into the OpenML ecosystem. Source code and documentation are available at https://github.com/openml/openml-python/."
   volume: 22
   year: 2021
+  start: 1
+  end: 5
+  pages: 5
+  number: 100
   url: https://jmlr.org/papers/v22/19-920.html


### PR DESCRIPTION
Adds a `CITATION.cff` file to the repository which creates a Github integrated way of requesting a specific citation (visible if you browse the [`citation`](https://github.com/openml/openml-python/tree/citation) branch):
![image](https://user-images.githubusercontent.com/15890747/138748996-62735ab2-89c4-44d8-b585-881353f5f07b.png)

the bibtex produced is:

```tex
@article{Feurer_OpenMLPython_an_extensible_2021,
author = {Feurer, Matthias and van Rijn, Jan N. and Kadra, Arlind and Gijsbers, Pieter and Mallik, Neeratyoy and Ravi, Sahithya and Müller, Andreas and Vanschoren, Joaquin and Hutter, Frank},
journal = {Journal of Machine Learning Research},
pages = {1--5},
title = {{OpenML-Python: an extensible Python API for OpenML}},
url = {https://jmlr.org/papers/v22/19-920.html},
volume = {22},
year = {2021}
}
```

compared to directly getting it from JMLR:

```tex
@article{JMLR:v22:19-920,
  author  = {Matthias Feurer and Jan N. van Rijn and Arlind Kadra and Pieter Gijsbers and Neeratyoy Mallik and Sahithya Ravi and Andreas Müller and Joaquin Vanschoren and Frank Hutter},
  title   = {OpenML-Python: an extensible Python API for OpenML},
  journal = {Journal of Machine Learning Research},
  year    = {2021},
  volume  = {22},
  number  = {100},
  pages   = {1-5},
  url     = {http://jmlr.org/papers/v22/19-920.html}
}
```

While it's pretty close, `number` seems to be ignored which is kind of vital for JMLR (then again, you can always search by title).

Some ORCIDs are missing because I could not with certainty determine the ORCID of some co-authors.
I'll sent out an e-mail to all co-authors to verify or add their ORCID (as comment/per e-mail) and suggest to merge by the end of the week regardless (it can be updated later anyway).
