### PR TITLE
Add AttributeError as suspect for dependency issue

### DIFF
--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -552,7 +552,15 @@ class OpenMLDataset(OpenMLBase):
                 readable_error = "Detected a corrupt cache file"
             elif isinstance(e, (ModuleNotFoundError, AttributeError)):
                 readable_error = "Detected likely dependency issues"
-                hint = "This is most likely due to https://github.com/openml/openml-python/issues/918. "  # noqa: 501
+                hint = (
+                    "This can happen if the cache was constructed with a different pandas version "
+                    "than the one that is used to load the data. See also "
+                )
+                if isinstance(e, ModuleNotFoundError):
+                    hint += "https://github.com/openml/openml-python/issues/918. "
+                elif isinstance(e, AttributeError):
+                    hint = "https://github.com/openml/openml-python/pull/1121. "
+
             elif isinstance(e, ValueError) and "unsupported pickle protocol" in e.args[0]:
                 readable_error = "Encountered unsupported pickle protocol"
             else:

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -544,13 +544,13 @@ class OpenMLDataset(OpenMLBase):
                     data, categorical, attribute_names = pickle.load(fh)
         except FileNotFoundError:
             raise ValueError(f"Cannot find file for dataset {self.name} at location '{fpath}'.")
-        except (EOFError, ModuleNotFoundError, ValueError) as e:
+        except (EOFError, ModuleNotFoundError, ValueError, AttributeError) as e:
             error_message = e.message if hasattr(e, "message") else e.args[0]
             hint = ""
 
             if isinstance(e, EOFError):
                 readable_error = "Detected a corrupt cache file"
-            elif isinstance(e, ModuleNotFoundError):
+            elif isinstance(e, (ModuleNotFoundError, AttributeError)):
                 readable_error = "Detected likely dependency issues"
                 hint = "This is most likely due to https://github.com/openml/openml-python/issues/918. "  # noqa: 501
             elif isinstance(e, ValueError) and "unsupported pickle protocol" in e.args[0]:

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -559,7 +559,7 @@ class OpenMLDataset(OpenMLBase):
                 if isinstance(e, ModuleNotFoundError):
                     hint += "https://github.com/openml/openml-python/issues/918. "
                 elif isinstance(e, AttributeError):
-                    hint = "https://github.com/openml/openml-python/pull/1121. "
+                    hint += "https://github.com/openml/openml-python/pull/1121. "
 
             elif isinstance(e, ValueError) and "unsupported pickle protocol" in e.args[0]:
                 readable_error = "Encountered unsupported pickle protocol"


### PR DESCRIPTION
Having an `AttributeError` while loading a pickled file may also be an indication of mismatched dependency versions.
I encountered the following when trying to load a `1.3.x` dataframe with pandas `1.0.x`  installed:

```
Traceback (most recent call last):
  File "...../AppData/Roaming/JetBrains/PyCharm2020.1/scratches/scratch_3.py", line 8, in <module>
    X, y, _, _ = data.get_data(dataset_format='dataframe',
  File ".....\venv2100\lib\site-packages\openml\datasets\dataset.py", line 698, in get_data
    data, categorical, attribute_names = self._load_data()
  File ".....\venv2100\lib\site-packages\openml\datasets\dataset.py", line 544, in _load_data
    data, categorical, attribute_names = pickle.load(fh)
AttributeError: Can't get attribute 'new_block' on <module 'pandas.core.internals.blocks' from '.....\\venv2100\\lib\\site-packages\\pandas\\core\\internals\\blocks.py'>
```

Upgrading back to pandas `1.3.x` solved the issue (confirming it was exclusively a version issue). 
Clearing the cache also made it work (confirming the advice given by the error is sound for this issue).
Did not add a unit test since it's not done for the similar situation (`ModuleNotFoundError`) either and it would be somewhat complex/annoying (have to add "old" data to the repository and execute the unit test only for specific pandas versions and/or have multiple "old" data so there is always a predictable incompatible mismatch).