### PR TITLE
Predictions

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -10,7 +10,7 @@ Changelog
 ~~~~~~
  * FIX#1110: Make arguments to ``create_study`` and ``create_suite`` that are defined as optional by the OpenML XSD actually optional.
  * MAIN#1088: Do CI for Windows on Github Actions instead of Appveyor.
-
+ * ADD#1103: Add a ``predictions`` property to OpenMLRun for easy accessibility of prediction data.
 
 0.12.2
 ~~~~~~

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -175,6 +175,7 @@ class TestRun(TestBase):
         predictions_prime = run_prime._generate_arff_dict()
 
         self._compare_predictions(predictions, predictions_prime)
+        pd.testing.assert_frame_equal(run.predictions, run_prime.predictions)
 
     def _perform_run(
         self,


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->
Closes #1103 


#### What does this PR implement/fix? Explain your changes.
Adds a `predictions` property to the OpenMLRun object which will download and format the predictions on-demand.
Only output for a pandas dataframe is supported, since we will slowly move to that standard anyway.
Local run results can also be formatted in this way.
Data is only accessed and transformed when the property is called and does not impact performance otherwise.

#### How should this PR be tested?
I added a line to test where we test other run consistency (download vs local run).

#### Any other comments?
Test server is currently not live so I couldn't test on the whole suite, but since it's an added feature it shouldn't interfere with old tests. I did a test on the live server which worked, but it may not be as comprehensive.
