### PR TITLE
Set default value of avoid_duplicate_runs to false for run_model_on_task

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.13.0
 ~~~~~~
+ * MAINT#1143: Change default argument for ``avoid_duplicate_runs`` of ``run_model_on_task`` to false to avoid requiring an API key by default.
  * FIX#1030: ``pre-commit`` hooks now no longer should issue a warning.
  * FIX#1110: Make arguments to ``create_study`` and ``create_suite`` that are defined as optional by the OpenML XSD actually optional.
  * MAIN#1088: Do CI for Windows on Github Actions instead of Appveyor.

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -48,7 +48,7 @@ RUNS_CACHE_DIR_NAME = "runs"
 def run_model_on_task(
     model: Any,
     task: Union[int, str, OpenMLTask],
-    avoid_duplicate_runs: bool = True,
+    avoid_duplicate_runs: bool = False,
     flow_tags: List[str] = None,
     seed: int = None,
     add_local_measures: bool = True,
@@ -68,7 +68,7 @@ def run_model_on_task(
     task : OpenMLTask or int or str
         Task to perform or Task id.
         This may be a model instead if the first argument is an OpenMLTask.
-    avoid_duplicate_runs : bool, optional (default=True)
+    avoid_duplicate_runs : bool, optional (default=False)
         If True, the run will throw an error if the setup/task combination is already present on
         the server. This feature requires an internet connection.
     flow_tags : List[str], optional (default=None)


### PR DESCRIPTION
#### Reference Issue

Closes #1143


#### What does this PR implement/fix? Explain your changes.

Sets the default value of `avoid_duplicate_runs` in the `run_model_on_task` function to False. When true, this option avoids running an experiment that already exists on OpenML, but this requires an API key. This change means that an API key is not required unless explicitly setting `avoid_duplicate_runs` to true.

#### How should this PR be tested?

Tested that without an API key, the following code block does not return a 401 error any more after this change has been made.

```python
from sklearn import ensemble
from openml import tasks, runs

clf = ensemble.RandomForestClassifier()
task = tasks.get_task(3954)
run = runs.run_model_on_task(clf, task)
```

I don't believe that an automated test should be required as we are just changing a default value and not changing any implementation, but please let me know if otherwise and I will add a test.

