### PR TITLE
Use GET instead of POST for flow exist

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -10,6 +10,7 @@ Changelog
 ~~~~~~
  * FIX#1030: ``pre-commit`` hooks now no longer should issue a warning.
  * FIX#1110: Make arguments to ``create_study`` and ``create_suite`` that are defined as optional by the OpenML XSD actually optional.
+ * FIX#1147: ``openml.flow.flow_exists`` no longer requires an API key.
  * MAIN#1088: Do CI for Windows on Github Actions instead of Appveyor.
  * ADD#1103: Add a ``predictions`` property to OpenMLRun for easy accessibility of prediction data.
 

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -253,7 +253,7 @@ def flow_exists(name: str, external_version: str) -> Union[int, bool]:
         raise ValueError("Argument 'version' should be a non-empty string")
 
     xml_response = openml._api_calls._perform_api_call(
-        "flow/exists", "post", data={"name": name, "external_version": external_version},
+        "flow/exists", "get", data={"name": name, "external_version": external_version},
     )
 
     result_dict = xmltodict.parse(xml_response)


### PR DESCRIPTION
The `flow/exist` endpoint can be accessed with a `GET` request, which avoids requiring an API key. Particularly important for https://github.com/openml/openml-python/issues/1143