### PR TITLE
fix nonetype error during print for tasks without class labels

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.13.0
 ~~~~~~
+ * FIX#1100/#1058: Avoid ``NoneType`` error when printing task without ``class_labels`` attribute.
  * FIX#1030: ``pre-commit`` hooks now no longer should issue a warning.
  * FIX#1110: Make arguments to ``create_study`` and ``create_suite`` that are defined as optional by the OpenML XSD actually optional.
  * MAIN#1088: Do CI for Windows on Github Actions instead of Appveyor.

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -97,7 +97,7 @@ class OpenMLTask(OpenMLBase):
             fields["Estimation Procedure"] = self.estimation_procedure["type"]
         if getattr(self, "target_name", None) is not None:
             fields["Target Feature"] = getattr(self, "target_name")
-            if hasattr(self, "class_labels"):
+            if hasattr(self, "class_labels") and getattr(self, "class_labels") is not None:
                 fields["# of Classes"] = len(getattr(self, "class_labels"))
             if hasattr(self, "cost_matrix"):
                 fields["Cost Matrix"] = "Available"


### PR DESCRIPTION
#### Reference Issue
Fixes #1100 and #1058

#### What does this PR implement/fix? Explain your changes.
Previously, if `class_labels` attribute of task is `None` when `__repr__` was called, a `NoneType` error was thrown. Now "# of Classes" is not printed if there are no `class_labels`.

#### How should this PR be tested?


#### Any other comments?
I followed the implementation suggestion from #1100 where "# of Classes" is ignored. Let me know if this is no longer the best solution to this issue.
