### PR TITLE
Fix outdated docstring for list_tasks function

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -8,6 +8,7 @@ Changelog
 
 0.13.0
 ~~~~~~
+ * MAINT#1104: Fix outdated docstring for ``list_task``.
  * FIX#1030: ``pre-commit`` hooks now no longer should issue a warning.
  * FIX#1110: Make arguments to ``create_study`` and ``create_suite`` that are defined as optional by the OpenML XSD actually optional.
  * MAIN#1088: Do CI for Windows on Github Actions instead of Appveyor.

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -135,15 +135,7 @@ def list_tasks(
     it is used as task_type in the task description, but it is named
     type when used as a filter in list tasks call.
     task_type : TaskType, optional
-        ID of the task type as detailed `here <https://www.openml.org/search?type=task_type>`_.
-        - Supervised classification: 1
-        - Supervised regression: 2
-        - Learning curve: 3
-        - Supervised data stream classification: 4
-        - Clustering: 5
-        - Machine Learning Challenge: 6
-        - Survival Analysis: 7
-        - Subgroup Discovery: 8
+        Refers to the type of task.
     offset : int, optional
         the number of tasks to skip, starting from the first
     size : int, optional
@@ -196,16 +188,7 @@ def _list_tasks(task_type=None, output_format="dict", **kwargs):
     it is used as task_type in the task description, but it is named
     type when used as a filter in list tasks call.
     task_type : TaskType, optional
-        ID of the task type as detailed
-        `here <https://www.openml.org/search?type=task_type>`_.
-        - Supervised classification: 1
-        - Supervised regression: 2
-        - Learning curve: 3
-        - Supervised data stream classification: 4
-        - Clustering: 5
-        - Machine Learning Challenge: 6
-        - Survival Analysis: 7
-        - Subgroup Discovery: 8
+        Refers to the type of task.
     output_format: str, optional (default='dict')
         The parameter decides the format of the output.
         - If 'dict' the output is a dict of dict


### PR DESCRIPTION
#### Reference Issue

Closes #1104

#### What does this PR implement/fix? Explain your changes.

Fixes the docstring for the `list_tasks` function, as well as the private `_list_tasks` function. It used to refer to TaskType as an ID, but as it is now an enum, the reference to the ID has been removed. The documentation for the `TaskType` enum can be reference for clarity.

#### How should this PR be tested?

Not applicable as only documentation has been changed.


