### PR TITLE
Add: dependabot checks for workflow versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  # This will check for updates to github actions every day
+  # https://docs.github.com/en/enterprise-server@3.4/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds dependabot to check for updates to workflow versions, creating PR's to the repo if an update exists. This is checked daily and the documentation for such is included in the file.

We did so in [autosklearn](https://github.com/automl/auto-sklearn/blob/development/.github/dependabot.yml) and [here you can see sample PRs from dependabot](https://github.com/automl/auto-sklearn/pulls?q=is%3Apr+dependabot)

CC @mfeurer  