### PR TITLE
Replace removed file with new target for download test

### DIFF
--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -462,9 +462,9 @@ class TestOpenMLDataset(TestBase):
         )
 
     def test__download_minio_file_works_with_bucket_subdirectory(self):
-        file_destination = pathlib.Path(self.workdir, "custom.csv")
+        file_destination = pathlib.Path(self.workdir, "custom.pq")
         _download_minio_file(
-            source="http://openml1.win.tue.nl/test/subdirectory/test.csv",
+            source="http://openml1.win.tue.nl/dataset61/dataset_61.pq",
             destination=file_destination,
             exists_ok=True,
         )


### PR DESCRIPTION
The `test__download_minio_file_works_with_bucket_subdirectory` unit test failed because it was attempting to download a file which no longer exists. I updated it to refer to a live dataset file which should not be at risk of being (re)moved. The filetype is irrelevant.
