### PR TITLE
check number of datasets for run (#1102)

### DIFF
--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -819,7 +819,7 @@ def _create_run_from_xml(xml, from_server=True):
     # whenever that's resolved, we can enforce it being present (OpenML#1087)
     run_details = obtain_field(run, "oml:run_details", from_server=False)
 
-    if "oml:input_data" in run:
+    if "oml:input_data" in run and len(run["oml:input_data"].get("oml:dataset")) == 1:
         dataset_id = int(run["oml:input_data"]["oml:dataset"]["oml:did"])
     elif not from_server:
         dataset_id = None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes openml/OpenML#1182 


#### What does this PR implement/fix? Explain your changes.
Fixes issue with `get_run` and `get_runs` where run 1 would throw an error due to multiple datasets being present for the run. The issue is fixed by checking the number of datasets before attempting to access the supposed dictionary (in this case actually a list of dictionaries) containing the run. In the case of multiple datasets, dataset discovery falls back to the `else` clause and retrieves dataset info from the attached task.

#### How should this PR be tested?
Run any current tests for `get_run` and `get_runs` to ensure proper functionality.