### PR TITLE
Test `get_parquet` on production server

### DIFF
--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1541,7 +1541,10 @@ class TestOpenMLDataset(TestBase):
         )
 
     def test_get_dataset_parquet(self):
-        dataset = openml.datasets.get_dataset(20)
+        # Parquet functionality is disabled on the test server
+        # There is no parquet-copy of the test server yet.
+        openml.config.server = self.production_server
+        dataset = openml.datasets.get_dataset(61)
         self.assertIsNotNone(dataset._minio_url)
         self.assertIsNotNone(dataset.parquet_file)
         self.assertTrue(os.path.isfile(dataset.parquet_file))


### PR DESCRIPTION
The test server has minio urls disabled. This is because we currently do not have a setup that represents the live server in a test environment yet. So, we download from the production server instead.

This is to be reverted in the future when the test environment more closely mimics the production environment. I assume that will be months away.