### PR TITLE
Provide clearer error when server provides bad data description XML

### DIFF
--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -23,6 +23,14 @@ from .exceptions import (
 )
 
 
+def _create_url_from_endpoint(endpoint: str) -> str:
+    url = config.server
+    if not url.endswith("/"):
+        url += "/"
+    url += endpoint
+    return url.replace("=", "%3d")
+
+
 def _perform_api_call(call, request_method, data=None, file_elements=None):
     """
     Perform an API call at the OpenML server.
@@ -50,12 +58,7 @@ def _perform_api_call(call, request_method, data=None, file_elements=None):
     return_value : str
         Return value of the OpenML server
     """
-    url = config.server
-    if not url.endswith("/"):
-        url += "/"
-    url += call
-
-    url = url.replace("=", "%3d")
+    url = _create_url_from_endpoint(call)
     logging.info("Starting [%s] request for the URL %s", request_method, url)
     start = time.time()
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1240,7 +1240,7 @@ class TestOpenMLDataset(TestBase):
             try:
                 downloaded_dataset = openml.datasets.get_dataset(dataset_id)
                 break
-            except Exception as e:
+            except OpenMLServerException as e:
                 # returned code 273: Dataset not processed yet
                 # returned code 362: No qualities found
                 TestBase.logger.error(


### PR DESCRIPTION
Debugging the errors of some dataset unit tests were particularly difficult, because the _real_ reason for their errors (malformed XML) got swallowed as if the dataset is still in preprocessing (hence the change in `test_dataset_functions`). By our own definition, we should only catch `OpenMLServerException` there ("exception for when the result of the server was not 200").

The malformed XML error was still hard to debug, since only the xml parse `ExpartError` was provided, which does not provide information on the XML file. Restructuring the `_get_dataset_description` function has two purposes:
 - now a new XML file will be downloaded, even if a local cached description xml got malformed somehow, and
 - check that an XML file from the server is properly formed before storing it, and reporting a clearer error otherwise (provide the exact endpoint that serves the malformed URL).
 
I ran`pytest pytest tests/test_datasets/test_dataset_functions.py::TestOpenMLDataset` locally, and all tests still pass (except those with known server or parquet issues).