### PR TITLE
Make OpenMLTraceIteration a dataclass

### DIFF
--- a/tests/test_runs/test_trace.py
+++ b/tests/test_runs/test_trace.py
@@ -63,7 +63,7 @@ class TestTrace(TestBase):
         ]
         trace_content = [[0, 0, 0, 0.5, "true", 1], [0, 0, 0, 0.9, "false", 2]]
         with self.assertRaisesRegex(
-            ValueError, "Either setup_string or parameters needs to be passed as argument."
+            ValueError, "Either `setup_string` or `parameters` needs to be passed as argument."
         ):
             OpenMLRunTrace.generate(trace_attributes, trace_content)
 


### PR DESCRIPTION
This PR changes OpenMLTraceIteration into a dataclass, which makes the code neater and comes with a nice default repr.

---

Someone recently remarked that the OpenMLTrace iteration representation was cryptic and hard to miss.
One example (produced by MWE below, shortened for convenience):
```
OrderedDict([((0, 0, 0), [(0,0,0): 0.615341 (False)]),
             ...
             ((0, 9, 4), [(0,9,4): 0.798329 (True)])])
>>> 
```
In a large dump, it's easy to miss at first take that the "[(0,9,4): 0.798329 (True)]" parts represent custom OpenML objects.
Even when you spot that, it's not immediately obvious what the provided information is and it misses some of the information for the trace (e.g., parameter values).
This PR will change the corresponding output to:
```
new:
```
OrderedDict([((0, 0, 0),
              OpenMLTraceIteration(repeat=0,
                                   fold=0,
                                   iteration=0,
                                   evaluation=0.6153406132170588,
                                   selected=False,
                                   setup_string=None,
                                   parameters=OrderedDict([('parameter_max_depth',
                                                            '1')]))),
	     ...,	
             ((0, 9, 4),
              OpenMLTraceIteration(repeat=0,
                                   fold=9,
                                   iteration=4,
                                   evaluation=0.7978332002449244,
                                   selected=True,
                                   setup_string=None,
                                   parameters=OrderedDict([('parameter_max_depth',
                                                            'null')])))])
```

Both outputs were generated by following script:
```python
import openml
import pprint

task = openml.tasks.get_task(167119)

from sklearn.model_selection import GridSearchCV
from sklearn.tree import DecisionTreeClassifier

pipe = GridSearchCV(
    estimator=DecisionTreeClassifier(),
    param_grid={
        'max_depth': [1,2,3,4,None],
    },
)

r = openml.runs.run_model_on_task(
    pipe, task, upload_flow=False, avoid_duplicate_runs=False
)

pprint.pprint(r.trace.trace_iterations)
```

