### PR TITLE
Mark sklearn tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, ${{ format("sk-only:{0}", ${{ matrix.sklearn-only }} ) }} )
+    name: (matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, sk-only:${{ matrix.sklearn-only }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         scikit-learn: [0.21.2, 0.22.2, 0.23.1, 0.24]
         os: [ubuntu-latest]
-        sklearn-only: [true]
+        sklearn-only: ['true']
         exclude:  # no scikit-learn 0.21.2 release for Python 3.8
           - python-version: 3.8
             scikit-learn: 0.21.2
@@ -29,10 +29,10 @@ jobs:
           - python-version: 3.8
             scikit-learn: 0.23.1
             code-cov: true
-            sklearn-only: false
+            sklearn-only: 'false'
             os: ubuntu-latest
           - os: windows-latest
-            sklearn-only: false
+            sklearn-only: 'false'
             scikit-learn: 0.24.*
       fail-fast:  false
       max-parallel: 4
@@ -66,7 +66,7 @@ jobs:
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
         # Most of the time, running only the scikit-learn tests is sufficient
-        if [ ${{ matrix.sklearn-only }} ]; then sklearn='-m sklearn'; fi
+        if [ ${{ matrix.sklearn-only }} = 'true' ]; then sklearn='-m sklearn'; fi
         echo pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
         pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
     - name: Run tests on Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, sk-only:${{ matrix.sklearn-only }})
+    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, format('sk-only: {0}', ${{ matrix.sklearn-only }} ))
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         scikit-learn: [0.21.2, 0.22.2, 0.23.1, 0.24]
         os: [ubuntu-latest]
+        sklearn-only: [true]
         exclude:  # no scikit-learn 0.21.2 release for Python 3.8
           - python-version: 3.8
             scikit-learn: 0.21.2
@@ -28,9 +29,10 @@ jobs:
           - python-version: 3.8
             scikit-learn: 0.23.1
             code-cov: true
+            sklearn-only: false
             os: ubuntu-latest
-            all-tests: true
           - os: windows-latest
+            sklearn-only: false
             scikit-learn: 0.24.*
       fail-fast:  false
       max-parallel: 4
@@ -64,7 +66,8 @@ jobs:
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
         # Most of the time, running only the scikit-learn tests is sufficient
-        if [ ! ${{ matrix.all-tests }} ]; then sklearn='-m sklearn'; fi
+        if [ ${{ matrix.sklearn-only }} ]; then sklearn='-m sklearn'; fi
+        echo pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
         pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
     - name: Run tests on Windows
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, format("sk-only:{0}", ${{ matrix.sklearn-only }} ))
+    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, ${{ format("sk-only:{0}", ${{ matrix.sklearn-only }} ) }} )
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
             scikit-learn: 0.23.1
             code-cov: true
             os: ubuntu-latest
+            all-tests: true
           - os: windows-latest
             scikit-learn: 0.24.*
       fail-fast:  false
@@ -62,7 +63,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
-        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov --reruns 5 --reruns-delay 1
+        # Most of the time, running only the scikit-learn tests is sufficient
+        if [ ! ${{ matrix.all-tests }} ]; then sklearn='-m "sklearn"'; fi
+        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn_select --reruns 5 --reruns-delay 1
     - name: Run tests on Windows
       if: matrix.os == 'windows-latest'
       run: |  # we need a separate step because of the bash-specific if-statement in the previous one.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }})
+    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, sk-only:${{ matrix.sklearn-only }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: (matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, sk-only:${{ matrix.sklearn-only }})
+    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, sk-only:${{ matrix.sklearn-only }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
         # Most of the time, running only the scikit-learn tests is sufficient
-        if [ ! ${{ matrix.all-tests }} ]; then sklearn='-m "sklearn"'; fi
+        if [ ! ${{ matrix.all-tests }} ]; then sklearn='-m sklearn'; fi
         pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
     - name: Run tests on Windows
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
         # Most of the time, running only the scikit-learn tests is sufficient
         if [ ! ${{ matrix.all-tests }} ]; then sklearn='-m "sklearn"'; fi
-        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn_select --reruns 5 --reruns-delay 1
+        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
     - name: Run tests on Windows
       if: matrix.os == 'windows-latest'
       run: |  # we need a separate step because of the bash-specific if-statement in the previous one.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, format('sk-only: {0}', ${{ matrix.sklearn-only }} ))
+    name: (${{ matrix.os }}, Py${{ matrix.python-version }}, sk${{ matrix.scikit-learn }}, format("sk-only:{0}", ${{ matrix.sklearn-only }} ))
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,15 @@ jobs:
             scikit-learn: 0.18.2
             scipy: 1.2.0
             os: ubuntu-latest
+            sklearn-only: 'true'
           - python-version: 3.6
             scikit-learn: 0.19.2
             os: ubuntu-latest
+            sklearn-only: 'true'
           - python-version: 3.6
             scikit-learn: 0.20.2
             os: ubuntu-latest
+            sklearn-only: 'true'
           - python-version: 3.8
             scikit-learn: 0.23.1
             code-cov: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,8 @@ following rules before you submit a pull request:
    
 - Add [unit tests](https://github.com/openml/openml-python/tree/develop/tests) and [examples](https://github.com/openml/openml-python/tree/develop/examples) for any new functionality being introduced. 
     - If an unit test contains an upload to the test server, please ensure that it is followed by a file collection for deletion, to prevent the test server from bulking up. For example, `TestBase._mark_entity_for_removal('data', dataset.dataset_id)`, `TestBase._mark_entity_for_removal('flow', (flow.flow_id, flow.name))`.
-    - Please ensure that the example is run on the test server by beginning with the call to `openml.config.start_using_configuration_for_example()`.      
+    - Please ensure that the example is run on the test server by beginning with the call to `openml.config.start_using_configuration_for_example()`.
+    - Add the `@pytest.mark.sklearn` marker to your unit tests if they have a dependency on scikit-learn.
 
 -  All tests pass when running `pytest`. On
    Unix-like systems, check with (from the toplevel source folder):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,10 @@ def pytest_sessionfinish() -> None:
     logger.info("{} is killed".format(worker))
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "sklearn: marks tests that use scikit-learn")
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--long",

--- a/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
+++ b/tests/test_extensions/test_sklearn_extension/test_sklearn_extension.py
@@ -15,6 +15,7 @@ from packaging import version
 
 import numpy as np
 import pandas as pd
+import pytest
 import scipy.optimize
 import scipy.stats
 import sklearn.base
@@ -176,6 +177,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
             return serialization, new_model
 
+    @pytest.mark.sklearn
     def test_serialize_model(self):
         model = sklearn.tree.DecisionTreeClassifier(
             criterion="entropy", max_features="auto", max_leaf_nodes=2000
@@ -265,6 +267,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertEqual(serialization.dependencies, version_fixture)
         self.assertDictEqual(structure, structure_fixture)
 
+    @pytest.mark.sklearn
     def test_can_handle_flow(self):
         openml.config.server = self.production_server
 
@@ -275,6 +278,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         openml.config.server = self.test_server
 
+    @pytest.mark.sklearn
     def test_serialize_model_clustering(self):
         model = sklearn.cluster.KMeans()
 
@@ -367,6 +371,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         assert serialization.dependencies == version_fixture
         assert structure == fixture_structure
 
+    @pytest.mark.sklearn
     def test_serialize_model_with_subcomponent(self):
         model = sklearn.ensemble.AdaBoostClassifier(
             n_estimators=100, base_estimator=sklearn.tree.DecisionTreeClassifier()
@@ -427,6 +432,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         )
         self.assertDictEqual(structure, fixture_structure)
 
+    @pytest.mark.sklearn
     def test_serialize_pipeline(self):
         scaler = sklearn.preprocessing.StandardScaler(with_mean=False)
         dummy = sklearn.dummy.DummyClassifier(strategy="prior")
@@ -496,6 +502,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertIsNot(new_model.steps[0][1], model.steps[0][1])
         self.assertIsNot(new_model.steps[1][1], model.steps[1][1])
 
+    @pytest.mark.sklearn
     def test_serialize_pipeline_clustering(self):
         scaler = sklearn.preprocessing.StandardScaler(with_mean=False)
         km = sklearn.cluster.KMeans()
@@ -564,6 +571,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertIsNot(new_model.steps[0][1], model.steps[0][1])
         self.assertIsNot(new_model.steps[1][1], model.steps[1][1])
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",
@@ -622,6 +630,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertEqual(serialization.description, fixture_description)
         self.assertDictEqual(structure, fixture_structure)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",
@@ -688,6 +697,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
 
         self.assertDictEqual(structure, fixture_structure)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20", reason="Pipeline processing behaviour updated"
     )
@@ -756,6 +766,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         )
         self.assertIs(new_model.transformer_list[1][1], "drop")
 
+    @pytest.mark.sklearn
     def test_serialize_feature_union_switched_names(self):
         ohe_params = {"categories": "auto"} if LooseVersion(sklearn.__version__) >= "0.20" else {}
         ohe = sklearn.preprocessing.OneHotEncoder(**ohe_params)
@@ -796,6 +807,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             "ohe=sklearn.preprocessing.{}.StandardScaler)".format(module_name_encoder, scaler_name),
         )
 
+    @pytest.mark.sklearn
     def test_serialize_complex_flow(self):
         ohe = sklearn.preprocessing.OneHotEncoder(handle_unknown="ignore")
         scaler = sklearn.preprocessing.StandardScaler(with_mean=False)
@@ -856,6 +868,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertEqual(serialized.name, fixture_name)
         self.assertEqual(structure, fixture_structure)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.21",
         reason="Pipeline till 0.20 doesn't support 'passthrough'",
@@ -951,6 +964,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertIsInstance(extracted_info[2]["drop"], OpenMLFlow)
         self.assertEqual(extracted_info[2]["drop"].name, "drop")
 
+    @pytest.mark.sklearn
     def test_serialize_type(self):
         supported_types = [float, np.float32, np.float64, int, np.int32, np.int64]
         if LooseVersion(np.__version__) < "1.24":
@@ -962,6 +976,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             deserialized = self.extension.flow_to_model(serialized)
             self.assertEqual(deserialized, supported_type)
 
+    @pytest.mark.sklearn
     def test_serialize_rvs(self):
         supported_rvs = [
             scipy.stats.norm(loc=1, scale=5),
@@ -977,11 +992,13 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             del supported_rv.dist
             self.assertEqual(deserialized.__dict__, supported_rv.__dict__)
 
+    @pytest.mark.sklearn
     def test_serialize_function(self):
         serialized = self.extension.model_to_flow(sklearn.feature_selection.chi2)
         deserialized = self.extension.flow_to_model(serialized)
         self.assertEqual(deserialized, sklearn.feature_selection.chi2)
 
+    @pytest.mark.sklearn
     def test_serialize_cvobject(self):
         methods = [sklearn.model_selection.KFold(3), sklearn.model_selection.LeaveOneOut()]
         fixtures = [
@@ -1031,6 +1048,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             self.assertIsNot(m_new, m)
             self.assertIsInstance(m_new, type(method))
 
+    @pytest.mark.sklearn
     def test_serialize_simple_parameter_grid(self):
 
         # We cannot easily test for scipy random variables in here, but they
@@ -1078,6 +1096,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             del deserialized_params["estimator"]
             self.assertEqual(hpo_params, deserialized_params)
 
+    @pytest.mark.sklearn
     @unittest.skip(
         "This feature needs further reworking. If we allow several "
         "components, we need to register them all in the downstream "
@@ -1132,6 +1151,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertEqual(grid[1]["reduce_dim__k"], deserialized[1]["reduce_dim__k"])
         self.assertEqual(grid[1]["classify__C"], deserialized[1]["classify__C"])
 
+    @pytest.mark.sklearn
     def test_serialize_advanced_grid_fails(self):
         # This unit test is checking that the test we skip above would actually fail
 
@@ -1151,6 +1171,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         ):
             self.extension.model_to_flow(clf)
 
+    @pytest.mark.sklearn
     def test_serialize_resampling(self):
         kfold = sklearn.model_selection.StratifiedKFold(n_splits=4, shuffle=True)
         serialized = self.extension.model_to_flow(kfold)
@@ -1159,6 +1180,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertEqual(str(deserialized), str(kfold))
         self.assertIsNot(deserialized, kfold)
 
+    @pytest.mark.sklearn
     def test_hypothetical_parameter_values(self):
         # The hypothetical parameter values of true, 1, 0.1 formatted as a
         # string (and their correct serialization and deserialization) an only
@@ -1172,6 +1194,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         self.assertEqual(deserialized.get_params(), model.get_params())
         self.assertIsNot(deserialized, model)
 
+    @pytest.mark.sklearn
     def test_gaussian_process(self):
         opt = scipy.optimize.fmin_l_bfgs_b
         kernel = sklearn.gaussian_process.kernels.Matern()
@@ -1182,6 +1205,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         ):
             self.extension.model_to_flow(gp)
 
+    @pytest.mark.sklearn
     def test_error_on_adding_component_multiple_times_to_flow(self):
         # this function implicitly checks
         # - openml.flows._check_multiple_occurence_of_component_in_flow()
@@ -1206,6 +1230,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         with self.assertRaisesRegex(ValueError, fixture):
             self.extension.model_to_flow(pipeline2)
 
+    @pytest.mark.sklearn
     def test_subflow_version_propagated(self):
         this_directory = os.path.dirname(os.path.abspath(__file__))
         tests_directory = os.path.abspath(os.path.join(this_directory, "..", ".."))
@@ -1230,12 +1255,14 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             ),
         )
 
+    @pytest.mark.sklearn
     @mock.patch("warnings.warn")
     def test_check_dependencies(self, warnings_mock):
         dependencies = ["sklearn==0.1", "sklearn>=99.99.99", "sklearn>99.99.99"]
         for dependency in dependencies:
             self.assertRaises(ValueError, self.extension._check_dependencies, dependency)
 
+    @pytest.mark.sklearn
     def test_illegal_parameter_names(self):
         # illegal name: estimators
         clf1 = sklearn.ensemble.VotingClassifier(
@@ -1255,6 +1282,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         for case in cases:
             self.assertRaises(PyOpenMLError, self.extension.model_to_flow, case)
 
+    @pytest.mark.sklearn
     def test_paralizable_check(self):
         # using this model should pass the test (if param distribution is
         # legal)
@@ -1304,6 +1332,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             with self.assertRaises(PyOpenMLError):
                 self.extension._prevent_optimize_n_jobs(model)
 
+    @pytest.mark.sklearn
     def test__get_fn_arguments_with_defaults(self):
         sklearn_version = LooseVersion(sklearn.__version__)
         if sklearn_version < "0.19":
@@ -1361,6 +1390,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             self.assertSetEqual(set(defaults.keys()), set(defaults.keys()) - defaultless)
             self.assertSetEqual(defaultless, defaultless - set(defaults.keys()))
 
+    @pytest.mark.sklearn
     def test_deserialize_with_defaults(self):
         # used the 'initialize_with_defaults' flag of the deserialization
         # method to return a flow that contains default hyperparameter
@@ -1396,6 +1426,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             self.extension.model_to_flow(pipe_deserialized),
         )
 
+    @pytest.mark.sklearn
     def test_deserialize_adaboost_with_defaults(self):
         # used the 'initialize_with_defaults' flag of the deserialization
         # method to return a flow that contains default hyperparameter
@@ -1434,6 +1465,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             self.extension.model_to_flow(pipe_deserialized),
         )
 
+    @pytest.mark.sklearn
     def test_deserialize_complex_with_defaults(self):
         # used the 'initialize_with_defaults' flag of the deserialization
         # method to return a flow that contains default hyperparameter
@@ -1477,6 +1509,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             self.extension.model_to_flow(pipe_deserialized),
         )
 
+    @pytest.mark.sklearn
     def test_openml_param_name_to_sklearn(self):
         scaler = sklearn.preprocessing.StandardScaler(with_mean=False)
         boosting = sklearn.ensemble.AdaBoostClassifier(
@@ -1511,6 +1544,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
             openml_name = "%s(%s)_%s" % (subflow.name, subflow.version, splitted[-1])
             self.assertEqual(parameter.full_name, openml_name)
 
+    @pytest.mark.sklearn
     def test_obtain_parameter_values_flow_not_from_server(self):
         model = sklearn.linear_model.LogisticRegression(solver="lbfgs")
         flow = self.extension.model_to_flow(model)
@@ -1532,6 +1566,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         with self.assertRaisesRegex(ValueError, msg):
             self.extension.obtain_parameter_values(flow)
 
+    @pytest.mark.sklearn
     def test_obtain_parameter_values(self):
 
         model = sklearn.model_selection.RandomizedSearchCV(
@@ -1557,6 +1592,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
                 self.assertEqual(parameter["oml:value"], "5")
                 self.assertEqual(parameter["oml:component"], 2)
 
+    @pytest.mark.sklearn
     def test_numpy_type_allowed_in_flow(self):
         """Simple numpy types should be serializable."""
         dt = sklearn.tree.DecisionTreeClassifier(
@@ -1564,6 +1600,7 @@ class TestSklearnExtensionFlowFunctions(TestBase):
         )
         self.extension.model_to_flow(dt)
 
+    @pytest.mark.sklearn
     def test_numpy_array_not_allowed_in_flow(self):
         """Simple numpy arrays should not be serializable."""
         bin = sklearn.preprocessing.MultiLabelBinarizer(classes=np.asarray([1, 2, 3]))
@@ -1581,6 +1618,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
     ################################################################################################
     # Test methods for performing runs with this extension module
 
+    @pytest.mark.sklearn
     def test_run_model_on_task(self):
         task = openml.tasks.get_task(1)  # anneal; crossvalidation
         # using most_frequent imputer since dataset has mixed types and to keep things simple
@@ -1592,6 +1630,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
         )
         openml.runs.run_model_on_task(pipe, task, dataset_format="array")
 
+    @pytest.mark.sklearn
     def test_seed_model(self):
         # randomized models that are initialized without seeds, can be seeded
         randomized_clfs = [
@@ -1634,6 +1673,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             if idx == 1:
                 self.assertEqual(clf.cv.random_state, 56422)
 
+    @pytest.mark.sklearn
     def test_seed_model_raises(self):
         # the _set_model_seed_where_none should raise exception if random_state is
         # anything else than an int
@@ -1646,6 +1686,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             with self.assertRaises(ValueError):
                 self.extension.seed_model(model=clf, seed=42)
 
+    @pytest.mark.sklearn
     def test_run_model_on_fold_classification_1_array(self):
         task = openml.tasks.get_task(1)  # anneal; crossvalidation
 
@@ -1702,6 +1743,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             check_scores=False,
         )
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.21",
         reason="SimpleImputer, ColumnTransformer available only after 0.19 and "
@@ -1773,6 +1815,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             check_scores=False,
         )
 
+    @pytest.mark.sklearn
     def test_run_model_on_fold_classification_2(self):
         task = openml.tasks.get_task(7)  # kr-vs-kp; crossvalidation
 
@@ -1826,6 +1869,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             check_scores=False,
         )
 
+    @pytest.mark.sklearn
     def test_run_model_on_fold_classification_3(self):
         class HardNaiveBayes(sklearn.naive_bayes.GaussianNB):
             # class for testing a naive bayes classifier that does not allow soft
@@ -1896,6 +1940,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
                 X_test.shape[0] * len(task.class_labels),
             )
 
+    @pytest.mark.sklearn
     def test_run_model_on_fold_regression(self):
         # There aren't any regression tasks on the test server
         openml.config.server = self.production_server
@@ -1945,6 +1990,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             check_scores=False,
         )
 
+    @pytest.mark.sklearn
     def test_run_model_on_fold_clustering(self):
         # There aren't any regression tasks on the test server
         openml.config.server = self.production_server
@@ -1987,6 +2033,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             check_scores=False,
         )
 
+    @pytest.mark.sklearn
     def test__extract_trace_data(self):
 
         param_grid = {
@@ -2038,6 +2085,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
                 param_value = json.loads(trace_iteration.parameters[param_in_trace])
                 self.assertTrue(param_value in param_grid[param])
 
+    @pytest.mark.sklearn
     def test_trim_flow_name(self):
         import re
 
@@ -2100,6 +2148,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             "weka.IsolationForest", SklearnExtension.trim_flow_name("weka.IsolationForest")
         )
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.21",
         reason="SimpleImputer, ColumnTransformer available only after 0.19 and "
@@ -2189,6 +2238,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
         self.assertEqual(len(new_model.named_steps), 3)
         self.assertEqual(new_model.named_steps["dummystep"], "passthrough")
 
+    @pytest.mark.sklearn
     def test_sklearn_serialization_with_none_step(self):
         msg = (
             "Cannot serialize objects of None type. Please use a valid "
@@ -2201,6 +2251,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
         with self.assertRaisesRegex(ValueError, msg):
             self.extension.model_to_flow(clf)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",
@@ -2236,6 +2287,7 @@ class TestSklearnExtensionRunFunctions(TestBase):
             else:
                 raise Exception(e)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",

--- a/tests/test_flows/test_flow.py
+++ b/tests/test_flows/test_flow.py
@@ -7,6 +7,7 @@ import hashlib
 import re
 import time
 from unittest import mock
+import pytest
 
 import scipy.stats
 import sklearn
@@ -148,6 +149,7 @@ class TestFlow(TestBase):
 
             self.assertEqual(new_xml, flow_xml)
 
+    @pytest.mark.sklearn
     def test_to_xml_from_xml(self):
         scaler = sklearn.preprocessing.StandardScaler(with_mean=False)
         boosting = sklearn.ensemble.AdaBoostClassifier(
@@ -166,6 +168,7 @@ class TestFlow(TestBase):
         openml.flows.functions.assert_flows_equal(new_flow, flow)
         self.assertIsNot(new_flow, flow)
 
+    @pytest.mark.sklearn
     def test_publish_flow(self):
         flow = openml.OpenMLFlow(
             name="sklearn.dummy.DummyClassifier",
@@ -191,6 +194,7 @@ class TestFlow(TestBase):
         TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], flow.flow_id))
         self.assertIsInstance(flow.flow_id, int)
 
+    @pytest.mark.sklearn
     @mock.patch("openml.flows.functions.flow_exists")
     def test_publish_existing_flow(self, flow_exists_mock):
         clf = sklearn.tree.DecisionTreeClassifier(max_depth=2)
@@ -206,6 +210,7 @@ class TestFlow(TestBase):
 
         self.assertTrue("OpenMLFlow already exists" in context_manager.exception.message)
 
+    @pytest.mark.sklearn
     def test_publish_flow_with_similar_components(self):
         clf = sklearn.ensemble.VotingClassifier(
             [("lr", sklearn.linear_model.LogisticRegression(solver="lbfgs"))]
@@ -259,6 +264,7 @@ class TestFlow(TestBase):
         TestBase._mark_entity_for_removal("flow", (flow3.flow_id, flow3.name))
         TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], flow3.flow_id))
 
+    @pytest.mark.sklearn
     def test_semi_legal_flow(self):
         # TODO: Test if parameters are set correctly!
         # should not throw error as it contains two differentiable forms of
@@ -275,6 +281,7 @@ class TestFlow(TestBase):
         TestBase._mark_entity_for_removal("flow", (flow.flow_id, flow.name))
         TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], flow.flow_id))
 
+    @pytest.mark.sklearn
     @mock.patch("openml.flows.functions.get_flow")
     @mock.patch("openml.flows.functions.flow_exists")
     @mock.patch("openml._api_calls._perform_api_call")
@@ -331,6 +338,7 @@ class TestFlow(TestBase):
         self.assertEqual(context_manager.exception.args[0], fixture)
         self.assertEqual(get_flow_mock.call_count, 2)
 
+    @pytest.mark.sklearn
     def test_illegal_flow(self):
         # should throw error as it contains two imputers
         illegal = sklearn.pipeline.Pipeline(
@@ -359,6 +367,7 @@ class TestFlow(TestBase):
         flow_id = openml.flows.flow_exists(name, version)
         self.assertFalse(flow_id)
 
+    @pytest.mark.sklearn
     def test_existing_flow_exists(self):
         # create a flow
         nb = sklearn.naive_bayes.GaussianNB()
@@ -397,6 +406,7 @@ class TestFlow(TestBase):
             )
             self.assertEqual(downloaded_flow_id, flow.flow_id)
 
+    @pytest.mark.sklearn
     def test_sklearn_to_upload_to_flow(self):
         iris = sklearn.datasets.load_iris()
         X = iris.data

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -271,6 +271,7 @@ class TestFlowFunctions(TestBase):
         )
         assert_flows_equal(flow, flow, ignore_parameter_values_on_older_children=None)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="OrdinalEncoder introduced in 0.20. "
@@ -302,6 +303,7 @@ class TestFlowFunctions(TestBase):
         flow = openml.flows.get_flow(1)
         self.assertIsNone(flow.external_version)
 
+    @pytest.mark.sklearn
     def test_get_flow_reinstantiate_model(self):
         model = ensemble.RandomForestClassifier(n_estimators=33)
         extension = openml.extensions.get_extension_by_model(model)
@@ -323,6 +325,7 @@ class TestFlowFunctions(TestBase):
             reinstantiate=True,
         )
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) == "0.19.1",
         reason="Requires scikit-learn!=0.19.1, because target flow is from that version.",
@@ -340,6 +343,7 @@ class TestFlowFunctions(TestBase):
             strict_version=True,
         )
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "1" and LooseVersion(sklearn.__version__) != "1.0.0",
         reason="Requires scikit-learn < 1.0.1."
@@ -352,6 +356,7 @@ class TestFlowFunctions(TestBase):
         assert flow.flow_id is None
         assert "sklearn==1.0.0" not in flow.dependencies
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         (LooseVersion(sklearn.__version__) < "0.23.2")
         or ("1.0" < LooseVersion(sklearn.__version__)),
@@ -364,6 +369,7 @@ class TestFlowFunctions(TestBase):
         assert flow.flow_id is None
         assert "sklearn==0.23.1" not in flow.dependencies
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         "0.23" < LooseVersion(sklearn.__version__),
         reason="Requires scikit-learn<=0.23, because the scikit-learn module structure changed.",
@@ -374,6 +380,7 @@ class TestFlowFunctions(TestBase):
         assert flow.flow_id is None
         assert "sklearn==0.19.1" not in flow.dependencies
 
+    @pytest.mark.sklearn
     def test_get_flow_id(self):
         if self.long_version:
             list_all = openml.utils._list_all

--- a/tests/test_runs/test_run.py
+++ b/tests/test_runs/test_run.py
@@ -102,6 +102,7 @@ class TestRun(TestBase):
         else:
             self.assertIsNone(run_prime_trace_content)
 
+    @pytest.mark.sklearn
     def test_to_from_filesystem_vanilla(self):
 
         model = Pipeline(
@@ -137,6 +138,7 @@ class TestRun(TestBase):
             "collected from {}: {}".format(__file__.split("/")[-1], run_prime.run_id)
         )
 
+    @pytest.mark.sklearn
     @pytest.mark.flaky()
     def test_to_from_filesystem_search(self):
 
@@ -189,6 +191,7 @@ class TestRun(TestBase):
         with self.assertRaises(ValueError, msg="Could not find model.pkl"):
             openml.runs.OpenMLRun.from_filesystem(cache_path)
 
+    @pytest.mark.sklearn
     def test_publish_with_local_loaded_flow(self):
         """
         Publish a run tied to a local flow after it has first been saved to

--- a/tests/test_runs/test_run.py
+++ b/tests/test_runs/test_run.py
@@ -175,6 +175,7 @@ class TestRun(TestBase):
             "collected from {}: {}".format(__file__.split("/")[-1], run_prime.run_id)
         )
 
+    @pytest.mark.sklearn
     def test_to_from_filesystem_no_model(self):
 
         model = Pipeline(

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -20,6 +20,7 @@ import sklearn
 import unittest
 import warnings
 import pandas as pd
+import pytest
 
 import openml.extensions.sklearn
 from openml.testing import TestBase, SimpleImputer, CustomImputer
@@ -387,6 +388,7 @@ class TestRun(TestBase):
                                 self.assertGreater(evaluation, 0)
                             self.assertLess(evaluation, max_time_allowed)
 
+    @pytest.mark.sklearn
     def test_run_regression_on_classif_task(self):
         task_id = 115  # diabetes; crossvalidation
 
@@ -404,6 +406,7 @@ class TestRun(TestBase):
                 dataset_format="array",
             )
 
+    @pytest.mark.sklearn
     def test_check_erronous_sklearn_flow_fails(self):
         task_id = 115  # diabetes; crossvalidation
         task = openml.tasks.get_task(task_id)
@@ -578,6 +581,7 @@ class TestRun(TestBase):
             sentinel=sentinel,
         )
 
+    @pytest.mark.sklearn
     def test_run_and_upload_logistic_regression(self):
         lr = LogisticRegression(solver="lbfgs", max_iter=1000)
         task_id = self.TEST_SERVER_TASK_SIMPLE["task_id"]
@@ -585,6 +589,7 @@ class TestRun(TestBase):
         n_test_obs = self.TEST_SERVER_TASK_SIMPLE["n_test_obs"]
         self._run_and_upload_classification(lr, task_id, n_missing_vals, n_test_obs, "62501")
 
+    @pytest.mark.sklearn
     def test_run_and_upload_linear_regression(self):
         lr = LinearRegression()
         task_id = self.TEST_SERVER_TASK_REGRESSION["task_id"]
@@ -614,6 +619,7 @@ class TestRun(TestBase):
         n_test_obs = self.TEST_SERVER_TASK_REGRESSION["n_test_obs"]
         self._run_and_upload_regression(lr, task_id, n_missing_vals, n_test_obs, "62501")
 
+    @pytest.mark.sklearn
     def test_run_and_upload_pipeline_dummy_pipeline(self):
 
         pipeline1 = Pipeline(
@@ -627,6 +633,7 @@ class TestRun(TestBase):
         n_test_obs = self.TEST_SERVER_TASK_SIMPLE["n_test_obs"]
         self._run_and_upload_classification(pipeline1, task_id, n_missing_vals, n_test_obs, "62501")
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",
@@ -689,6 +696,7 @@ class TestRun(TestBase):
             sentinel=sentinel,
         )
 
+    @pytest.mark.sklearn
     @unittest.skip("https://github.com/openml/OpenML/issues/1180")
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
@@ -740,6 +748,7 @@ class TestRun(TestBase):
                 call_count += 1
         self.assertEqual(call_count, 3)
 
+    @pytest.mark.sklearn
     def test_run_and_upload_gridsearch(self):
         gridsearch = GridSearchCV(
             BaggingClassifier(base_estimator=SVC()),
@@ -758,6 +767,7 @@ class TestRun(TestBase):
         )
         self.assertEqual(len(run.trace.trace_iterations), 9)
 
+    @pytest.mark.sklearn
     def test_run_and_upload_randomsearch(self):
         randomsearch = RandomizedSearchCV(
             RandomForestClassifier(n_estimators=5),
@@ -789,6 +799,7 @@ class TestRun(TestBase):
         trace = openml.runs.get_run_trace(run.run_id)
         self.assertEqual(len(trace.trace_iterations), 5)
 
+    @pytest.mark.sklearn
     def test_run_and_upload_maskedarrays(self):
         # This testcase is important for 2 reasons:
         # 1) it verifies the correct handling of masked arrays (not all
@@ -811,6 +822,7 @@ class TestRun(TestBase):
 
     ##########################################################################
 
+    @pytest.mark.sklearn
     def test_learning_curve_task_1(self):
         task_id = 801  # diabates dataset
         num_test_instances = 6144  # for learning curve
@@ -830,6 +842,7 @@ class TestRun(TestBase):
         )
         self._check_sample_evaluations(run.sample_evaluations, num_repeats, num_folds, num_samples)
 
+    @pytest.mark.sklearn
     def test_learning_curve_task_2(self):
         task_id = 801  # diabates dataset
         num_test_instances = 6144  # for learning curve
@@ -861,6 +874,7 @@ class TestRun(TestBase):
         )
         self._check_sample_evaluations(run.sample_evaluations, num_repeats, num_folds, num_samples)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.21",
         reason="Pipelines don't support indexing (used for the assert check)",
@@ -940,6 +954,7 @@ class TestRun(TestBase):
                 self.assertGreaterEqual(alt_scores[idx], 0)
                 self.assertLessEqual(alt_scores[idx], 1)
 
+    @pytest.mark.sklearn
     def test_local_run_swapped_parameter_order_model(self):
         clf = DecisionTreeClassifier()
         australian_task = 595  # Australian; crossvalidation
@@ -955,6 +970,7 @@ class TestRun(TestBase):
 
         self._test_local_evaluations(run)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="SimpleImputer doesn't handle mixed type DataFrame as input",
@@ -984,6 +1000,7 @@ class TestRun(TestBase):
 
         self._test_local_evaluations(run)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="SimpleImputer doesn't handle mixed type DataFrame as input",
@@ -1021,6 +1038,7 @@ class TestRun(TestBase):
 
         self._test_local_evaluations(run)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="SimpleImputer doesn't handle mixed type DataFrame as input",
@@ -1082,6 +1100,7 @@ class TestRun(TestBase):
         self.assertEqual(flowS.components["Imputer"].parameters["strategy"], '"most_frequent"')
         self.assertEqual(flowS.components["VarianceThreshold"].parameters["threshold"], "0.05")
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="SimpleImputer doesn't handle mixed type DataFrame as input",
@@ -1136,6 +1155,7 @@ class TestRun(TestBase):
             run_ids = run_exists(task.task_id, setup_exists)
             self.assertTrue(run_ids, msg=(run_ids, clf))
 
+    @pytest.mark.sklearn
     def test_run_with_illegal_flow_id(self):
         # check the case where the user adds an illegal flow id to a
         # non-existing flo
@@ -1154,6 +1174,7 @@ class TestRun(TestBase):
                 avoid_duplicate_runs=True,
             )
 
+    @pytest.mark.sklearn
     def test_run_with_illegal_flow_id_after_load(self):
         # Same as `test_run_with_illegal_flow_id`, but test this error is also
         # caught if the run is stored to and loaded from disk first.
@@ -1182,6 +1203,7 @@ class TestRun(TestBase):
             TestBase._mark_entity_for_removal("run", loaded_run.run_id)
             TestBase.logger.info("collected from test_run_functions: {}".format(loaded_run.run_id))
 
+    @pytest.mark.sklearn
     def test_run_with_illegal_flow_id_1(self):
         # Check the case where the user adds an illegal flow id to an existing
         # flow. Comes to a different value error than the previous test
@@ -1206,6 +1228,7 @@ class TestRun(TestBase):
                 avoid_duplicate_runs=True,
             )
 
+    @pytest.mark.sklearn
     def test_run_with_illegal_flow_id_1_after_load(self):
         # Same as `test_run_with_illegal_flow_id_1`, but test this error is
         # also caught if the run is stored to and loaded from disk first.
@@ -1239,6 +1262,7 @@ class TestRun(TestBase):
             openml.exceptions.PyOpenMLError, expected_message_regex, loaded_run.publish
         )
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="OneHotEncoder cannot handle mixed type DataFrame as input",
@@ -1455,6 +1479,7 @@ class TestRun(TestBase):
         runs = openml.runs.list_runs(tag="curves")
         self.assertGreaterEqual(len(runs), 1)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",
@@ -1490,6 +1515,7 @@ class TestRun(TestBase):
             # repeat, fold, row_id, 6 confidences, prediction and correct label
             self.assertEqual(len(row), 12)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.20",
         reason="columntransformer introduction in 0.20.0",
@@ -1541,6 +1567,7 @@ class TestRun(TestBase):
         with self.assertRaises(openml.exceptions.OpenMLCacheException):
             openml.runs.functions._get_cached_run(10)
 
+    @pytest.mark.sklearn
     def test_run_flow_on_task_downloaded_flow(self):
         model = sklearn.ensemble.RandomForestClassifier(n_estimators=33)
         flow = self.extension.model_to_flow(model)
@@ -1633,6 +1660,7 @@ class TestRun(TestBase):
         res = format_prediction(regression, *ignored_input)
         self.assertListEqual(res, [0] * 5)
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.21",
         reason="couldn't perform local tests successfully w/o bloating RAM",
@@ -1686,6 +1714,7 @@ class TestRun(TestBase):
             scores, expected_scores, decimal=2 if os.name == "nt" else 7
         )
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.21",
         reason="couldn't perform local tests successfully w/o bloating RAM",

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -10,6 +10,7 @@ import openml.extensions.sklearn
 from openml.testing import TestBase
 from typing import Dict
 import pandas as pd
+import pytest
 
 import sklearn.tree
 import sklearn.naive_bayes
@@ -34,6 +35,7 @@ class TestSetupFunctions(TestBase):
         self.extension = openml.extensions.sklearn.SklearnExtension()
         super().setUp()
 
+    @pytest.mark.sklearn
     def test_nonexisting_setup_exists(self):
         # first publish a non-existing flow
         sentinel = get_sentinel()
@@ -81,6 +83,7 @@ class TestSetupFunctions(TestBase):
         setup_id = openml.setups.setup_exists(flow)
         self.assertEqual(setup_id, run.setup_id)
 
+    @pytest.mark.sklearn
     def test_existing_setup_exists_1(self):
         def side_effect(self):
             self.var_smoothing = 1e-9
@@ -95,10 +98,12 @@ class TestSetupFunctions(TestBase):
             nb = sklearn.naive_bayes.GaussianNB()
             self._existing_setup_exists(nb)
 
+    @pytest.mark.sklearn
     def test_exisiting_setup_exists_2(self):
         # Check a flow with one hyperparameter
         self._existing_setup_exists(sklearn.naive_bayes.GaussianNB())
 
+    @pytest.mark.sklearn
     def test_existing_setup_exists_3(self):
         # Check a flow with many hyperparameters
         self._existing_setup_exists(

--- a/tests/test_study/test_study_examples.py
+++ b/tests/test_study/test_study_examples.py
@@ -3,6 +3,7 @@
 from openml.testing import TestBase
 from openml.extensions.sklearn import cat, cont
 
+import pytest
 import sklearn
 import unittest
 from distutils.version import LooseVersion
@@ -12,6 +13,7 @@ class TestStudyFunctions(TestBase):
     _multiprocess_can_split_ = True
     """Test the example code of Bischl et al. (2018)"""
 
+    @pytest.mark.sklearn
     @unittest.skipIf(
         LooseVersion(sklearn.__version__) < "0.24",
         reason="columntransformer introduction in 0.24.0",


### PR DESCRIPTION
Closes #1186 

Marks 103 tests that use scikit-learn. I hope it is exhaustive, though it is possible I missed a few.
Updated the Github Workflow to _only_ run scikit-learn dependent tests by default, as most matrix jobs are specifically to test different scikit-learn versions (and non sklearn tests should not be affected by scikit-learn version). The code coverage and windows job still run the full suite.

Built on top of #1199, #1200 (hence the draft state).