### PR TITLE
Add summary of locally computed metrics to representation of run  

### DIFF
--- a/.github/workflows/release_docker.yaml
+++ b/.github/workflows/release_docker.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         scikit-learn: [0.21.2, 0.22.2, 0.23.1, 0.24]
         os: [ubuntu-latest]
         sklearn-only: ['true']
@@ -19,15 +19,31 @@ jobs:
           - python-version: 3.6
             scikit-learn: 0.18.2
             scipy: 1.2.0
-            os: ubuntu-latest
+            os: ubuntu-20.04 
             sklearn-only: 'true'
           - python-version: 3.6
             scikit-learn: 0.19.2
-            os: ubuntu-latest
+            os: ubuntu-20.04 
             sklearn-only: 'true'
           - python-version: 3.6
             scikit-learn: 0.20.2
-            os: ubuntu-latest
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.21.2
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.22.2
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.23.1
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.24
+            os: ubuntu-20.04 
             sklearn-only: 'true'
           - python-version: 3.8
             scikit-learn: 0.23.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,11 @@ jobs:
     - name: Install scikit-learn ${{ matrix.scikit-learn }}
       run: |
         pip install scikit-learn==${{ matrix.scikit-learn }}
+    - name: Install numpy for Python 3.8
+      # Python 3.8 & scikit-learn<0.24 requires numpy<=1.23.5
+      if: ${{ matrix.python-version == '3.8' && contains(fromJSON('["0.23.1", "0.22.2", "0.21.2"]'), matrix.scikit-learn) }}
+      run: |
+        pip install numpy==1.23.5
     - name: Install scipy ${{ matrix.scipy }}
       if: ${{ matrix.scipy }}
       run: |
@@ -105,7 +110,7 @@ jobs:
         fi
     - name: Upload coverage
       if: matrix.code-cov && always()
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
         fail_ci_if_error: true

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -13,7 +13,7 @@ Changelog
  * ADD#1144: Add locally computed results to the ``OpenMLRun`` object's representation.
  * FIX #1197 #559 #1131: Fix the order of ground truth and predictions in the ``OpenMLRun`` object and in ``format_prediction``.
  * FIX #1198: Support numpy 1.24 and higher.
- * ADD#1144: Add locally computed results to the ``OpenMLRun`` object's representation.
+ * ADD#1144: Add locally computed results to the ``OpenMLRun`` object's representation if the run was created locally and not downloaded from the server.
 
 0.13.0
 ~~~~~~

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -11,6 +11,7 @@ Changelog
 
  * FIX #1197 #559 #1131: Fix the order of ground truth and predictions in the ``OpenMLRun`` object and in ``format_prediction``.
  * FIX #1198: Support numpy 1.24 and higher.
+ * ADD#1144: Add locally computed results to the ``OpenMLRun`` object's representation.
 
 0.13.0
 ~~~~~~

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -9,6 +9,8 @@ Changelog
 0.13.1
 ~~~~~~
 
+ * Add new contributions here.
+ * ADD#1144: Add locally computed results to the ``OpenMLRun`` object's representation.
  * FIX #1197 #559 #1131: Fix the order of ground truth and predictions in the ``OpenMLRun`` object and in ``format_prediction``.
  * FIX #1198: Support numpy 1.24 and higher.
  * ADD#1144: Add locally computed results to the ``OpenMLRun`` object's representation.

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -303,9 +303,7 @@ def __is_checksum_equal(downloaded_file, md5_checksum=None):
     md5 = hashlib.md5()
     md5.update(downloaded_file.encode("utf-8"))
     md5_checksum_download = md5.hexdigest()
-    if md5_checksum == md5_checksum_download:
-        return True
-    return False
+    return md5_checksum == md5_checksum_download
 
 
 def _send_request(request_method, url, data, files=None, md5_checksum=None):

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -275,7 +275,7 @@ class OpenMLDataset(OpenMLBase):
 
     def __eq__(self, other):
 
-        if type(other) != OpenMLDataset:
+        if not isinstance(other, OpenMLDataset):
             return False
 
         server_fields = {
@@ -287,14 +287,12 @@ class OpenMLDataset(OpenMLBase):
             "data_file",
         }
 
-        # check that the keys are identical
+        # check that common keys and values are identical
         self_keys = set(self.__dict__.keys()) - server_fields
         other_keys = set(other.__dict__.keys()) - server_fields
-        if self_keys != other_keys:
-            return False
-
-        # check that values of the common keys are identical
-        return all(self.__dict__[key] == other.__dict__[key] for key in self_keys)
+        return self_keys == other_keys and all(
+            self.__dict__[key] == other.__dict__[key] for key in self_keys
+        )
 
     def _download_data(self) -> None:
         """Download ARFF data file to standard cache directory. Set `self.data_file`."""

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -275,6 +275,39 @@ def list_evaluation_measures() -> List[str]:
     return qualities
 
 
+def list_estimation_procedures():
+    """Return list of evaluation procedures available.
+
+    The function performs an API call to retrieve the entire list of
+    evaluation procedures' names that are available.
+
+    Returns
+    -------
+    list
+    """
+
+    api_call = "estimationprocedure/list"
+    xml_string = openml._api_calls._perform_api_call(api_call, "get")
+    api_results = xmltodict.parse(xml_string)
+
+    # Minimalistic check if the XML is useful
+    if "oml:estimationprocedures" not in api_results:
+        raise ValueError("Error in return XML, does not contain " '"oml:estimationprocedures"')
+    if "oml:estimationprocedure" not in api_results["oml:estimationprocedures"]:
+        raise ValueError("Error in return XML, does not contain " '"oml:estimationprocedure"')
+
+    if not isinstance(api_results["oml:estimationprocedures"]["oml:estimationprocedure"], list):
+        raise TypeError(
+            "Error in return XML, does not contain " '"oml:estimationprocedure" as a list'
+        )
+
+    prods = [
+        prod["oml:name"]
+        for prod in api_results["oml:estimationprocedures"]["oml:estimationprocedure"]
+    ]
+    return prods
+
+
 def list_evaluations_setups(
     function: str,
     offset: Optional[int] = None,

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -275,7 +275,7 @@ def list_evaluation_measures() -> List[str]:
     return qualities
 
 
-def list_estimation_procedures():
+def list_estimation_procedures() -> List[str]:
     """Return list of evaluation procedures available.
 
     The function performs an API call to retrieve the entire list of

--- a/openml/flows/functions.py
+++ b/openml/flows/functions.py
@@ -261,10 +261,7 @@ def flow_exists(name: str, external_version: str) -> Union[int, bool]:
 
     result_dict = xmltodict.parse(xml_response)
     flow_id = int(result_dict["oml:flow_exists"]["oml:id"])
-    if flow_id > 0:
-        return flow_id
-    else:
-        return False
+    return flow_id if flow_id > 0 else False
 
 
 def get_flow_id(

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -31,36 +31,55 @@ class OpenMLRun(OpenMLBase):
     Parameters
     ----------
     task_id: int
+        The ID of the OpenML task associated with the run.
     flow_id: int
+        The ID of the OpenML flow associated with the run.
     dataset_id: int
+        The ID of the OpenML dataset used for the run.
     setup_string: str
+        The setup string of the run.
     output_files: Dict[str, str]
-        A dictionary that specifies where each related file can be found.
+        Specifies where each related file can be found. 
     setup_id: int
+        An integer representing the ID of the setup used for the run.
     tags: List[str]
+        Representing the tags associated with the run.
     uploader: int
-        User ID of the uploader.
+        User ID of the uploader. 
     uploader_name: str
+        The name of the person who uploaded the run.
     evaluations: Dict
+        Representing the evaluations of the run.
     fold_evaluations: Dict
+        The evaluations of the run for each fold.
     sample_evaluations: Dict
+        The evaluations of the run for each sample.
     data_content: List[List]
         The predictions generated from executing this run.
     trace: OpenMLRunTrace
+        The trace containing information on internal model evaluations of this run.
     model: object
+        The untrained model that was evaluated in the run.
     task_type: str
+        The type of the OpenML task associated with the run.
     task_evaluation_measure: str
+        The evaluation measure used for the task.
     flow_name: str
+        The name of the OpenML flow associated with the run.
     parameter_settings: List[OrderedDict]
+        Representing the parameter settings used for the run.
     predictions_url: str
+        The URL of the predictions file.
     task: OpenMLTask
+        An instance of the OpenMLTask class, representing the OpenML task associated with the run.
     flow: OpenMLFlow
+        An instance of the OpenMLFlow class, representing the OpenML flow associated with the run.
     run_id: int
+        The ID of the run.
     description_text: str, optional
-        Description text to add to the predictions file.
-        If left None, is set to the time the arff file is generated.
+        Description text to add to the predictions file. If left None, is set to the time the arff file is generated.
     run_details: str, optional (default=None)
-        Description of the run stored in the run meta-data.
+        Description of the run stored in the run meta-data. 
     """
 
     def __init__(

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -26,7 +26,7 @@ from ..tasks import (
 
 
 class OpenMLRun(OpenMLBase):
-    """OpenML Run: result of running a model on an openml dataset.
+    """OpenML Run: result of running a model on an OpenML dataset.
 
     Parameters
     ----------
@@ -71,13 +71,16 @@ class OpenMLRun(OpenMLBase):
     predictions_url: str
         The URL of the predictions file.
     task: OpenMLTask
-        An instance of the OpenMLTask class, representing the OpenML task associated with the run.
+        An instance of the OpenMLTask class, representing the OpenML task associated
+        with the run.
     flow: OpenMLFlow
-        An instance of the OpenMLFlow class, representing the OpenML flow associated with the run.
+        An instance of the OpenMLFlow class, representing the OpenML flow associated
+        with the run.
     run_id: int
         The ID of the run.
     description_text: str, optional
-        Description text to add to the predictions file. If left None, is set to the time the arff file is generated.
+        Description text to add to the predictions file. If left None, is set to the
+        time the arff file is generated.
     run_details: str, optional (default=None)
         Description of the run stored in the run meta-data.
     """

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -158,7 +158,7 @@ class OpenMLRun(OpenMLBase):
     def id(self) -> Optional[int]:
         return self.run_id
 
-    def evaluation_summary(self, metric: str) -> str:
+    def _evaluation_summary(self, metric: str) -> str:
         """Summarizes the evaluation of a metric over all folds.
 
         The fold scores for the metric must exist already. During run creation,
@@ -222,21 +222,20 @@ class OpenMLRun(OpenMLBase):
                 # OpenMLClassificationTask; OpenMLLearningCurveTask
                 # default: predictive_accuracy
                 result_field = "Local Result - Accuracy (+- STD)"
-                fields[result_field] = self.evaluation_summary("predictive_accuracy")
+                fields[result_field] = self._evaluation_summary("predictive_accuracy")
                 order.append(result_field)
             elif "mean_absolute_error" in self.fold_evaluations:
                 # OpenMLRegressionTask
                 # default: mean_absolute_error
                 result_field = "Local Result - MAE (+- STD)"
-                fields[result_field] = self.evaluation_summary("mean_absolute_error")
+                fields[result_field] = self._evaluation_summary("mean_absolute_error")
                 order.append(result_field)
 
-            # Runtime should be available for any task type
-            rt_field = "Local Runtime - ms (+- STD)"
-            fields[rt_field] = self.evaluation_summary("usercpu_time_millis")
-
-            # Add to order to be below / same as results
-            order.append(rt_field)
+            if "usercpu_time_millis" in self.fold_evaluations:
+                # Runtime should be available for most tasks types
+                rt_field = "Local Runtime - ms (+- STD)"
+                fields[rt_field] = self._evaluation_summary("usercpu_time_millis")
+                order.append(rt_field)
 
         # determines the remaining order
         order += [

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -39,13 +39,13 @@ class OpenMLRun(OpenMLBase):
     setup_string: str
         The setup string of the run.
     output_files: Dict[str, str]
-        Specifies where each related file can be found. 
+        Specifies where each related file can be found.
     setup_id: int
         An integer representing the ID of the setup used for the run.
     tags: List[str]
         Representing the tags associated with the run.
     uploader: int
-        User ID of the uploader. 
+        User ID of the uploader.
     uploader_name: str
         The name of the person who uploaded the run.
     evaluations: Dict
@@ -79,7 +79,7 @@ class OpenMLRun(OpenMLBase):
     description_text: str, optional
         Description text to add to the predictions file. If left None, is set to the time the arff file is generated.
     run_details: str, optional (default=None)
-        Description of the run stored in the run meta-data. 
+        Description of the run stored in the run meta-data.
     """
 
     def __init__(

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -217,7 +217,7 @@ class OpenMLRun(OpenMLBase):
         if self.evaluations is not None and self.task_evaluation_measure in self.evaluations:
             fields["Result"] = self.evaluations[self.task_evaluation_measure]
         elif self.fold_evaluations is not None:
-            # -- Add Locally computed summary values to if possible
+            # -- Add locally computed summary values if possible
             if "predictive_accuracy" in self.fold_evaluations:
                 # OpenMLClassificationTask; OpenMLLearningCurveTask
                 # default: predictive_accuracy
@@ -231,6 +231,7 @@ class OpenMLRun(OpenMLBase):
                 fields[result_field] = self.evaluation_summary("mean_absolute_error")
                 order.append(result_field)
 
+            # Runtime should be available for any task type
             rt_field = "Local Runtime - ms (+- STD)"
             fields[rt_field] = self.evaluation_summary("usercpu_time_millis")
 

--- a/openml/runs/run.py
+++ b/openml/runs/run.py
@@ -158,7 +158,7 @@ class OpenMLRun(OpenMLBase):
     def id(self) -> Optional[int]:
         return self.run_id
 
-    def evaluation_summary(self, metric: str):
+    def evaluation_summary(self, metric: str) -> str:
         """Summarizes the evaluation of a metric over all folds.
 
         The fold scores for the metric must exist already. During run creation,

--- a/openml/setups/functions.py
+++ b/openml/setups/functions.py
@@ -55,10 +55,7 @@ def setup_exists(flow) -> int:
     )
     result_dict = xmltodict.parse(result)
     setup_id = int(result_dict["oml:setup_exists"]["oml:id"])
-    if setup_id > 0:
-        return setup_id
-    else:
-        return False
+    return setup_id if setup_id > 0 else False
 
 
 def _get_cached_setup(setup_id):

--- a/openml/tasks/split.py
+++ b/openml/tasks/split.py
@@ -47,12 +47,10 @@ class OpenMLSplit(object):
             or self.name != other.name
             or self.description != other.description
             or self.split.keys() != other.split.keys()
-        ):
-            return False
-
-        if any(
-            self.split[repetition].keys() != other.split[repetition].keys()
-            for repetition in self.split
+            or any(
+                self.split[repetition].keys() != other.split[repetition].keys()
+                for repetition in self.split
+            )
         ):
             return False
 

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -174,10 +174,7 @@ def _delete_entity(entity_type, entity_id):
     url_suffix = "%s/%d" % (entity_type, entity_id)
     result_xml = openml._api_calls._perform_api_call(url_suffix, "delete")
     result = xmltodict.parse(result_xml)
-    if "oml:%s_delete" % entity_type in result:
-        return True
-    else:
-        return False
+    return "oml:%s_delete" % entity_type in result
 
 
 def _list_all(listing_call, output_format="dict", *args, **filters):

--- a/tests/test_extensions/test_functions.py
+++ b/tests/test_extensions/test_functions.py
@@ -9,6 +9,7 @@ from openml.extensions import get_extension_by_model, get_extension_by_flow, reg
 
 class DummyFlow:
     external_version = "DummyFlow==0.1"
+    dependencies = None
 
 
 class DummyModel:
@@ -18,15 +19,11 @@ class DummyModel:
 class DummyExtension1:
     @staticmethod
     def can_handle_flow(flow):
-        if not inspect.stack()[2].filename.endswith("test_functions.py"):
-            return False
-        return True
+        return inspect.stack()[2].filename.endswith("test_functions.py")
 
     @staticmethod
     def can_handle_model(model):
-        if not inspect.stack()[2].filename.endswith("test_functions.py"):
-            return False
-        return True
+        return inspect.stack()[2].filename.endswith("test_functions.py")
 
 
 class DummyExtension2:

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -127,7 +127,7 @@ class TestRun(TestBase):
             "evaluated correctly on the server".format(run_id)
         )
 
-    def _compare_predictions(self, predictions, predictions_prime):
+    def _assert_predictions_equal(self, predictions, predictions_prime):
         self.assertEqual(
             np.array(predictions_prime["data"]).shape, np.array(predictions["data"]).shape
         )
@@ -150,8 +150,6 @@ class TestRun(TestBase):
                     )
                 else:
                     self.assertEqual(val_1, val_2)
-
-        return True
 
     def _rerun_model_and_compare_predictions(self, run_id, model_prime, seed, create_task_obj):
         run = openml.runs.get_run(run_id)
@@ -183,7 +181,7 @@ class TestRun(TestBase):
 
         predictions_prime = run_prime._generate_arff_dict()
 
-        self._compare_predictions(predictions, predictions_prime)
+        self._assert_predictions_equal(predictions, predictions_prime)
         pd.testing.assert_frame_equal(
             run.predictions,
             run_prime.predictions,

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -531,6 +531,14 @@ class TestRun(TestBase):
 
         # todo: check if runtime is present
         self._check_fold_timing_evaluations(run.fold_evaluations, 1, num_folds, task_type=task_type)
+
+        # Check if run string and print representation do not run into an error
+        #   The above check already verifies that all columns needed for supported
+        #   representations are present.
+        #   Supported: SUPERVISED_CLASSIFICATION, LEARNING_CURVE, SUPERVISED_REGRESSION
+        str(run)
+        self.logger.info(run)
+
         return run
 
     def _run_and_upload_classification(


### PR DESCRIPTION
This addresses #1144 and might be a solution for the issue. 

It is important to note that the representation already included a "Result" field and thus could have reported results in the printout. However, this only happens if the `evaluation` of the run is filled. 

This implementation now also covers locally computed results. The locally computed results are only shown if no task/run-specific results already exist. 

### Example 
```python
from sklearn import ensemble
from openml import tasks, runs

clf = ensemble.RandomForestClassifier()
task = tasks.get_task(3954)
run = runs.run_model_on_task(clf, task, avoid_duplicate_runs=False)
print(run)
```

Old Output:

```
OpenML Run
==========
Uploader Name: None
Metric.......: None
Run ID.......: None
Task ID......: 3954
Task Type....: None
Task URL.....: https://www.openml.org/t/3954
Flow ID......: None
Flow Name....: sklearn.ensemble._forest.RandomForestClassifier
Flow URL.....: https://www.openml.org/f/None
Setup ID.....: None
Setup String.: Python_3.7.13. Sklearn_1.0.2. NumPy_1.21.6. SciPy_1.4.1.
Dataset ID...: 1120
Dataset URL..: https://www.openml.org/d/1120
```

New Output (ignore the difference in `Setup String`):
```
OpenML Run
==========
Uploader Name...................: None
Metric..........................: None
Local Result - Accuracy (+- STD): 0.8790 +- 0.0054
Local Runtime - ms (+- STD).....: 9662.5000 +- 2621.0648
Run ID..........................: None
Task ID.........................: 3954
Task Type.......................: None
Task URL........................: https://www.openml.org/t/3954
Flow ID.........................: None
Flow Name.......................: sklearn.ensemble._forest.RandomForestClassifier
Flow URL........................: https://www.openml.org/f/None
Setup ID........................: None
Setup String....................: Python_3.9.10. Sklearn_1.2.1. NumPy_1.23.5. SciPy_1.10.0.
Dataset ID......................: 1120
Dataset URL.....................: https://www.openml.org/d/1120
```

### Test
I am not sure if we need to write a test for this. I did not find any tests for the representation so far. 



