### PR TITLE
Fix CI Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,15 @@ jobs:
           - python-version: 3.6
             scikit-learn: 0.18.2
             scipy: 1.2.0
-            os: ubuntu-latest
+            os: ubuntu-20.04 
             sklearn-only: 'true'
           - python-version: 3.6
             scikit-learn: 0.19.2
-            os: ubuntu-latest
+            os: ubuntu-20.04 
             sklearn-only: 'true'
           - python-version: 3.6
             scikit-learn: 0.20.2
-            os: ubuntu-latest
+            os: ubuntu-20.04 
             sklearn-only: 'true'
           - python-version: 3.8
             scikit-learn: 0.23.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         scikit-learn: [0.21.2, 0.22.2, 0.23.1, 0.24]
         os: [ubuntu-latest]
         sklearn-only: ['true']
@@ -27,6 +27,22 @@ jobs:
             sklearn-only: 'true'
           - python-version: 3.6
             scikit-learn: 0.20.2
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.21.2
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.22.2
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.23.1
+            os: ubuntu-20.04 
+            sklearn-only: 'true'
+          - python-version: 3.6
+            scikit-learn: 0.24
             os: ubuntu-20.04 
             sklearn-only: 'true'
           - python-version: 3.8


### PR DESCRIPTION
by using Ubuntu 20.04 instead of the latest Ubuntu (22.04).