### PR TITLE
Fix coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,8 @@ jobs:
         if [ ${{ matrix.code-cov }} ]; then codecov='--cov=openml --long  --cov-report=xml'; fi
         # Most of the time, running only the scikit-learn tests is sufficient
         if [ ${{ matrix.sklearn-only }} = 'true' ]; then sklearn='-m sklearn'; fi
-        echo pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
-        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1
+        echo pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1 -o log_cli=true
+        pytest -n 4 --durations=20 --timeout=600 --timeout-method=thread --dist load -sv $codecov $sklearn --reruns 5 --reruns-delay 1 -o log_cli=true
     - name: Run tests on Windows
       if: matrix.os == 'windows-latest'
       run: |  # we need a separate step because of the bash-specific if-statement in the previous one.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ Possible Future: class TestBase from openml/testing.py can be included
 
 import os
 import logging
+import pathlib
 from typing import List
 import pytest
 
@@ -51,26 +52,20 @@ def worker_id() -> str:
         return "master"
 
 
-def read_file_list() -> List[str]:
+def read_file_list() -> List[pathlib.Path]:
     """Returns a list of paths to all files that currently exist in 'openml/tests/files/'
 
-    :return: List[str]
+    :return: List[pathlib.Path]
     """
-    this_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
-    directory = os.path.join(this_dir, "..")
-    logger.info("Collecting file lists from: {}".format(directory))
-    file_list = []
-    for root, _, filenames in os.walk(directory):
-        for filename in filenames:
-            file_list.append(os.path.join(root, filename))
-    return file_list
+    test_files_dir = pathlib.Path(__file__).parent / "files"
+    return [f for f in test_files_dir.rglob("*") if f.is_file()]
 
 
-def compare_delete_files(old_list, new_list) -> None:
+def compare_delete_files(old_list: List[pathlib.Path], new_list: List[pathlib.Path]) -> None:
     """Deletes files that are there in the new_list but not in the old_list
 
-    :param old_list: List[str]
-    :param new_list: List[str]
+    :param old_list: List[pathlib.Path]
+    :param new_list: List[pathlib.Path]
     :return: None
     """
     file_list = list(set(new_list) - set(old_list))


### PR DESCRIPTION
The problem was that test cleanup cleaned up more than intended: all files in `openml-python/` instead of `openml-python/tests/files/`.

Also, I embarrassingly [already fixed this 2 years ago](https://github.com/openml/openml-python/commit/27825380568cd2b7c0de1ab0126986c64117e697), not sure why it didn't make it to a PR.