### PR TITLE
Fix TaskID for Example Custom Flow

### DIFF
--- a/examples/30_extended/custom_flow_.py
+++ b/examples/30_extended/custom_flow_.py
@@ -124,7 +124,7 @@ parameters = [
     OrderedDict([("oml:name", "time"), ("oml:value", 120), ("oml:component", flow_id)]),
 ]
 
-task_id = 1965  # Iris Task
+task_id = 1200  # Iris Task
 task = openml.tasks.get_task(task_id)
 dataset_id = task.get_dataset().dataset_id
 


### PR DESCRIPTION
Closes #1241 

Moreover, we might want to add or rework the process for the examples if the IDs can change, maybe in relation to #1227. 