### PR TITLE
Fix 1124: provide clear naming for cache directories

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -343,6 +343,17 @@ def get_config_as_dict():
 def get_cache_directory():
     """Get the current cache directory.
 
+    This gets the cache directory for the current server relative
+    to the base cache directory that can be set via
+    ``set_base_cache_directory()``. The cache directory is the
+    ``base_cache_directory`` with additional information on which
+    subdirectory to use based on the server name. By default it is
+    ``base_cache_directory / org / openml / www`` for the standard
+    OpenML.org server and is defined as
+    ``base_cache_directory / top-level domain / second-level domain /
+    hostname``
+    ```
+
     Returns
     -------
     cachedir : string
@@ -355,14 +366,19 @@ def get_cache_directory():
     return _cachedir
 
 
-def set_cache_directory(cachedir):
-    """Set module-wide cache directory.
+def set_base_cache_directory(base_cache_directory):
+    """Set module-wide base cache directory.
 
-    Sets the cache directory into which to download datasets, tasks etc.
+    Sets the base cache directory that defines how the actual cache
+    directory for the server being used is derived. This is
+    ``base_cache_directory / top-level domain / second-level domain /
+    hostname``, and by default is set to
+    ``base_cache_directory / org / openml / www`` for the standard
+    OpenML.org server.
 
     Parameters
     ----------
-    cachedir : string
+    base_cache_directory : string
          Path to use as cache directory.
 
     See also
@@ -371,7 +387,7 @@ def set_cache_directory(cachedir):
     """
 
     global _cache_directory
-    _cache_directory = cachedir
+    _cache_directory = base_cache_directory
 
 
 start_using_configuration_for_example = (
@@ -382,7 +398,7 @@ stop_using_configuration_for_example = ConfigurationForExamples.stop_using_confi
 
 __all__ = [
     "get_cache_directory",
-    "set_cache_directory",
+    "set_base_cache_directory",
     "start_using_configuration_for_example",
     "stop_using_configuration_for_example",
     "get_config_as_dict",

--- a/openml/config.py
+++ b/openml/config.py
@@ -344,13 +344,13 @@ def get_cache_directory():
     """Get the current cache directory.
 
     This gets the cache directory for the current server relative
-    to the base cache directory that can be set via
-    ``set_base_cache_directory()``. The cache directory is the
-    ``base_cache_directory`` with additional information on which
+    to the root cache directory that can be set via
+    ``set_root_cache_directory()``. The cache directory is the
+    ``root_cache_directory`` with additional information on which
     subdirectory to use based on the server name. By default it is
-    ``base_cache_directory / org / openml / www`` for the standard
+    ``root_cache_directory / org / openml / www`` for the standard
     OpenML.org server and is defined as
-    ``base_cache_directory / top-level domain / second-level domain /
+    ``root_cache_directory / top-level domain / second-level domain /
     hostname``
     ```
 
@@ -366,19 +366,19 @@ def get_cache_directory():
     return _cachedir
 
 
-def set_base_cache_directory(base_cache_directory):
+def set_root_cache_directory(root_cache_directory):
     """Set module-wide base cache directory.
 
     Sets the base cache directory that defines how the actual cache
     directory for the server being used is derived. This is
-    ``base_cache_directory / top-level domain / second-level domain /
+    ``root_cache_directory / top-level domain / second-level domain /
     hostname``, and by default is set to
-    ``base_cache_directory / org / openml / www`` for the standard
+    ``root_cache_directory / org / openml / www`` for the standard
     OpenML.org server.
 
     Parameters
     ----------
-    base_cache_directory : string
+    root_cache_directory : string
          Path to use as cache directory.
 
     See also
@@ -387,7 +387,7 @@ def set_base_cache_directory(base_cache_directory):
     """
 
     global _cache_directory
-    _cache_directory = base_cache_directory
+    _cache_directory = root_cache_directory
 
 
 start_using_configuration_for_example = (
@@ -398,7 +398,7 @@ stop_using_configuration_for_example = ConfigurationForExamples.stop_using_confi
 
 __all__ = [
     "get_cache_directory",
-    "set_base_cache_directory",
+    "set_root_cache_directory",
     "start_using_configuration_for_example",
     "stop_using_configuration_for_example",
     "get_config_as_dict",

--- a/openml/config.py
+++ b/openml/config.py
@@ -37,7 +37,7 @@ def _create_log_handlers(create_file_handler=True):
 
     if create_file_handler:
         one_mb = 2**20
-        log_path = os.path.join(_cache_directory, "openml_python.log")
+        log_path = os.path.join(_root_cache_directory, "openml_python.log")
         file_handler = logging.handlers.RotatingFileHandler(
             log_path, maxBytes=one_mb, backupCount=1, delay=True
         )
@@ -125,7 +125,7 @@ def get_server_base_url() -> str:
 
 apikey = _defaults["apikey"]
 # The current cache directory (without the server name)
-_cache_directory = str(_defaults["cachedir"])  # so mypy knows it is a string
+_root_cache_directory = str(_defaults["cachedir"])  # so mypy knows it is a string
 avoid_duplicate_runs = True if _defaults["avoid_duplicate_runs"] == "True" else False
 
 retry_policy = _defaults["retry_policy"]
@@ -226,7 +226,7 @@ def _setup(config=None):
     """
     global apikey
     global server
-    global _cache_directory
+    global _root_cache_directory
     global avoid_duplicate_runs
 
     config_file = determine_config_file_path()
@@ -266,15 +266,15 @@ def _setup(config=None):
 
     set_retry_policy(_get(config, "retry_policy"), n_retries)
 
-    _cache_directory = os.path.expanduser(short_cache_dir)
+    _root_cache_directory = os.path.expanduser(short_cache_dir)
     # create the cache subdirectory
-    if not os.path.exists(_cache_directory):
+    if not os.path.exists(_root_cache_directory):
         try:
-            os.makedirs(_cache_directory, exist_ok=True)
+            os.makedirs(_root_cache_directory, exist_ok=True)
         except PermissionError:
             openml_logger.warning(
                 "No permission to create openml cache directory at %s! This can result in "
-                "OpenML-Python not working properly." % _cache_directory
+                "OpenML-Python not working properly." % _root_cache_directory
             )
 
     if cache_exists:
@@ -333,7 +333,7 @@ def get_config_as_dict():
     config = dict()
     config["apikey"] = apikey
     config["server"] = server
-    config["cachedir"] = _cache_directory
+    config["cachedir"] = _root_cache_directory
     config["avoid_duplicate_runs"] = avoid_duplicate_runs
     config["connection_n_retries"] = connection_n_retries
     config["retry_policy"] = retry_policy
@@ -362,19 +362,19 @@ def get_cache_directory():
     """
     url_suffix = urlparse(server).netloc
     reversed_url_suffix = os.sep.join(url_suffix.split(".")[::-1])
-    _cachedir = os.path.join(_cache_directory, reversed_url_suffix)
+    _cachedir = os.path.join(_root_cache_directory, reversed_url_suffix)
     return _cachedir
 
 
 def set_root_cache_directory(root_cache_directory):
     """Set module-wide base cache directory.
 
-    Sets the base cache directory that defines how the actual cache
-    directory for the server being used is derived. This is
-    ``root_cache_directory / top-level domain / second-level domain /
-    hostname``, and by default is set to
-    ``root_cache_directory / org / openml / www`` for the standard
-    OpenML.org server.
+    Sets the root cache directory, wherin the cache directories are
+    created to store content from different OpenML servers. For example,
+    by default, cached data for the standard OpenML.org server is stored
+    at ``root_cache_directory / org / openml / www``, and the general
+    pattern is ``root_cache_directory / top-level domain / second-level
+    domain / hostname``.
 
     Parameters
     ----------
@@ -386,8 +386,8 @@ def set_root_cache_directory(root_cache_directory):
     get_cache_directory
     """
 
-    global _cache_directory
-    _cache_directory = root_cache_directory
+    global _root_cache_directory
+    _root_cache_directory = root_cache_directory
 
 
 start_using_configuration_for_example = (

--- a/openml/config.py
+++ b/openml/config.py
@@ -37,7 +37,7 @@ def _create_log_handlers(create_file_handler=True):
 
     if create_file_handler:
         one_mb = 2**20
-        log_path = os.path.join(cache_directory, "openml_python.log")
+        log_path = os.path.join(_cache_directory, "openml_python.log")
         file_handler = logging.handlers.RotatingFileHandler(
             log_path, maxBytes=one_mb, backupCount=1, delay=True
         )
@@ -125,7 +125,7 @@ def get_server_base_url() -> str:
 
 apikey = _defaults["apikey"]
 # The current cache directory (without the server name)
-cache_directory = str(_defaults["cachedir"])  # so mypy knows it is a string
+_cache_directory = str(_defaults["cachedir"])  # so mypy knows it is a string
 avoid_duplicate_runs = True if _defaults["avoid_duplicate_runs"] == "True" else False
 
 retry_policy = _defaults["retry_policy"]
@@ -226,7 +226,7 @@ def _setup(config=None):
     """
     global apikey
     global server
-    global cache_directory
+    global _cache_directory
     global avoid_duplicate_runs
 
     config_file = determine_config_file_path()
@@ -266,15 +266,15 @@ def _setup(config=None):
 
     set_retry_policy(_get(config, "retry_policy"), n_retries)
 
-    cache_directory = os.path.expanduser(short_cache_dir)
+    _cache_directory = os.path.expanduser(short_cache_dir)
     # create the cache subdirectory
-    if not os.path.exists(cache_directory):
+    if not os.path.exists(_cache_directory):
         try:
-            os.makedirs(cache_directory, exist_ok=True)
+            os.makedirs(_cache_directory, exist_ok=True)
         except PermissionError:
             openml_logger.warning(
                 "No permission to create openml cache directory at %s! This can result in "
-                "OpenML-Python not working properly." % cache_directory
+                "OpenML-Python not working properly." % _cache_directory
             )
 
     if cache_exists:
@@ -333,7 +333,7 @@ def get_config_as_dict():
     config = dict()
     config["apikey"] = apikey
     config["server"] = server
-    config["cachedir"] = cache_directory
+    config["cachedir"] = _cache_directory
     config["avoid_duplicate_runs"] = avoid_duplicate_runs
     config["connection_n_retries"] = connection_n_retries
     config["retry_policy"] = retry_policy
@@ -351,7 +351,7 @@ def get_cache_directory():
     """
     url_suffix = urlparse(server).netloc
     reversed_url_suffix = os.sep.join(url_suffix.split(".")[::-1])
-    _cachedir = os.path.join(cache_directory, reversed_url_suffix)
+    _cachedir = os.path.join(_cache_directory, reversed_url_suffix)
     return _cachedir
 
 
@@ -370,8 +370,8 @@ def set_cache_directory(cachedir):
     get_cache_directory
     """
 
-    global cache_directory
-    cache_directory = cachedir
+    global _cache_directory
+    _cache_directory = cachedir
 
 
 start_using_configuration_for_example = (

--- a/openml/testing.py
+++ b/openml/testing.py
@@ -93,7 +93,7 @@ class TestBase(unittest.TestCase):
         self.production_server = "https://openml.org/api/v1/xml"
         openml.config.server = TestBase.test_server
         openml.config.avoid_duplicate_runs = False
-        openml.config.cache_directory = self.workdir
+        openml.config._cache_directory = self.workdir
 
         # Increase the number of retries to avoid spurious server failures
         self.retry_policy = openml.config.retry_policy

--- a/openml/testing.py
+++ b/openml/testing.py
@@ -93,7 +93,7 @@ class TestBase(unittest.TestCase):
         self.production_server = "https://openml.org/api/v1/xml"
         openml.config.server = TestBase.test_server
         openml.config.avoid_duplicate_runs = False
-        openml.config._cache_directory = self.workdir
+        openml.config.set_root_cache_directory(self.workdir)
 
         # Increase the number of retries to avoid spurious server failures
         self.retry_policy = openml.config.retry_policy

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -420,7 +420,7 @@ class TestOpenMLDataset(TestBase):
         self.assertTrue(os.path.exists(description_xml_path))
 
     def test__getarff_path_dataset_arff(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         description = _get_dataset_description(self.workdir, 2)
         arff_path = _get_dataset_arff(description, cache_directory=self.workdir)
         self.assertIsInstance(arff_path, str)
@@ -494,7 +494,7 @@ class TestOpenMLDataset(TestBase):
 
     @mock.patch("openml._api_calls._download_minio_file")
     def test__get_dataset_parquet_is_cached(self, patch):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         patch.side_effect = RuntimeError(
             "_download_minio_file should not be called when loading from cache"
         )
@@ -594,7 +594,7 @@ class TestOpenMLDataset(TestBase):
         self.assertIsInstance(dataset.dataset_id, int)
 
     def test__retrieve_class_labels(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         labels = openml.datasets.get_dataset(2, download_data=False).retrieve_class_labels()
         self.assertEqual(labels, ["1", "2", "3", "4", "5", "U"])
         labels = openml.datasets.get_dataset(2, download_data=False).retrieve_class_labels(

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -420,7 +420,7 @@ class TestOpenMLDataset(TestBase):
         self.assertTrue(os.path.exists(description_xml_path))
 
     def test__getarff_path_dataset_arff(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         description = _get_dataset_description(self.workdir, 2)
         arff_path = _get_dataset_arff(description, cache_directory=self.workdir)
         self.assertIsInstance(arff_path, str)
@@ -494,7 +494,7 @@ class TestOpenMLDataset(TestBase):
 
     @mock.patch("openml._api_calls._download_minio_file")
     def test__get_dataset_parquet_is_cached(self, patch):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         patch.side_effect = RuntimeError(
             "_download_minio_file should not be called when loading from cache"
         )
@@ -594,7 +594,7 @@ class TestOpenMLDataset(TestBase):
         self.assertIsInstance(dataset.dataset_id, int)
 
     def test__retrieve_class_labels(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         labels = openml.datasets.get_dataset(2, download_data=False).retrieve_class_labels()
         self.assertEqual(labels, ["1", "2", "3", "4", "5", "U"])
         labels = openml.datasets.get_dataset(2, download_data=False).retrieve_class_labels(

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -1569,11 +1569,11 @@ class TestRun(TestBase):
             self.assertEqual(len(row), 12)
 
     def test_get_cached_run(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         openml.runs.functions._get_cached_run(1)
 
     def test_get_uncached_run(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         with self.assertRaises(openml.exceptions.OpenMLCacheException):
             openml.runs.functions._get_cached_run(10)
 

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -1569,11 +1569,11 @@ class TestRun(TestBase):
             self.assertEqual(len(row), 12)
 
     def test_get_cached_run(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         openml.runs.functions._get_cached_run(1)
 
     def test_get_uncached_run(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         with self.assertRaises(openml.exceptions.OpenMLCacheException):
             openml.runs.functions._get_cached_run(10)
 

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -182,10 +182,10 @@ class TestSetupFunctions(TestBase):
         self.assertEqual(len(all), size * 2)
 
     def test_get_cached_setup(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         openml.setups.functions._get_cached_setup(1)
 
     def test_get_uncached_setup(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         with self.assertRaises(openml.exceptions.OpenMLCacheException):
             openml.setups.functions._get_cached_setup(10)

--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -182,10 +182,10 @@ class TestSetupFunctions(TestBase):
         self.assertEqual(len(all), size * 2)
 
     def test_get_cached_setup(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         openml.setups.functions._get_cached_setup(1)
 
     def test_get_uncached_setup(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         with self.assertRaises(openml.exceptions.OpenMLCacheException):
             openml.setups.functions._get_cached_setup(10)

--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -25,19 +25,19 @@ class TestTask(TestBase):
         super(TestTask, self).tearDown()
 
     def test__get_cached_tasks(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         tasks = openml.tasks.functions._get_cached_tasks()
         self.assertIsInstance(tasks, dict)
         self.assertEqual(len(tasks), 3)
         self.assertIsInstance(list(tasks.values())[0], OpenMLTask)
 
     def test__get_cached_task(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         task = openml.tasks.functions._get_cached_task(1)
         self.assertIsInstance(task, OpenMLTask)
 
     def test__get_cached_task_not_cached(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         self.assertRaisesRegex(
             OpenMLCacheException,
             "Task file for tid 2 not cached",
@@ -129,7 +129,7 @@ class TestTask(TestBase):
                     self._check_task(tasks[tid])
 
     def test__get_task(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         openml.tasks.get_task(1882)
 
     @unittest.skip(
@@ -224,7 +224,7 @@ class TestTask(TestBase):
         self.assertFalse(os.path.exists(os.path.join(os.getcwd(), "tasks", "1", "tasks.xml")))
 
     def test_get_task_with_cache(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         task = openml.tasks.get_task(1)
         self.assertIsInstance(task, OpenMLTask)
 

--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -25,19 +25,19 @@ class TestTask(TestBase):
         super(TestTask, self).tearDown()
 
     def test__get_cached_tasks(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         tasks = openml.tasks.functions._get_cached_tasks()
         self.assertIsInstance(tasks, dict)
         self.assertEqual(len(tasks), 3)
         self.assertIsInstance(list(tasks.values())[0], OpenMLTask)
 
     def test__get_cached_task(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         task = openml.tasks.functions._get_cached_task(1)
         self.assertIsInstance(task, OpenMLTask)
 
     def test__get_cached_task_not_cached(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         self.assertRaisesRegex(
             OpenMLCacheException,
             "Task file for tid 2 not cached",
@@ -129,7 +129,7 @@ class TestTask(TestBase):
                     self._check_task(tasks[tid])
 
     def test__get_task(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         openml.tasks.get_task(1882)
 
     @unittest.skip(
@@ -224,7 +224,7 @@ class TestTask(TestBase):
         self.assertFalse(os.path.exists(os.path.join(os.getcwd(), "tasks", "1", "tasks.xml")))
 
     def test_get_task_with_cache(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         task = openml.tasks.get_task(1)
         self.assertIsInstance(task, OpenMLTask)
 

--- a/tests/test_tasks/test_task_methods.py
+++ b/tests/test_tasks/test_task_methods.py
@@ -28,7 +28,7 @@ class OpenMLTaskMethodsTest(TestBase):
         self.assertEqual(len(task_list), 0)
 
     def test_get_train_and_test_split_indices(self):
-        openml.config._cache_directory = self.static_cache_dir
+        openml.config.set_root_cache_directory(self.static_cache_dir)
         task = openml.tasks.get_task(1882)
         train_indices, test_indices = task.get_train_test_split_indices(0, 0)
         self.assertEqual(16, train_indices[0])

--- a/tests/test_tasks/test_task_methods.py
+++ b/tests/test_tasks/test_task_methods.py
@@ -28,7 +28,7 @@ class OpenMLTaskMethodsTest(TestBase):
         self.assertEqual(len(task_list), 0)
 
     def test_get_train_and_test_split_indices(self):
-        openml.config.cache_directory = self.static_cache_dir
+        openml.config._cache_directory = self.static_cache_dir
         task = openml.tasks.get_task(1882)
         train_indices, test_indices = task.get_train_test_split_indices(0, 0)
         self.assertEqual(16, train_indices[0])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
Fixes #1124


#### What does this PR implement/fix? Explain your changes.
* Introduce the concept of a `root_cache_directory`, i.e. the cache directory in which the concrete cache directories for the different servers reside
* Rename the function `set_root_directory` to `set_root_cache_directory`
* Improve the docstring of both functions

#### How should this PR be tested?
Regular unit tests.

#### Any other comments?
No.
