### PR TITLE
Download updates

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -9,6 +9,7 @@ Changelog
 0.13.1
 ~~~~~~
 
+ * ADD #1081 #1132: Add additional options for (not) downloading datasets ``openml.datasets.get_dataset`` and cache management.
  * ADD #1028: Add functions to delete runs, flows, datasets, and tasks (e.g., ``openml.datasets.delete_dataset``).
  * ADD #1144: Add locally computed results to the ``OpenMLRun`` object's representation if the run was created locally and not downloaded from the server.
  * ADD #1180: Improve the error message when the checksum of a downloaded dataset does not match the checksum provided by the API.

--- a/openml/datasets/data_feature.py
+++ b/openml/datasets/data_feature.py
@@ -62,5 +62,17 @@ class OpenMLDataFeature(object):
     def __repr__(self):
         return "[%d - %s (%s)]" % (self.index, self.name, self.data_type)
 
+    def __eq__(self, other):
+        if not isinstance(other, OpenMLDataFeature):
+            return False
+        else:
+            return (
+                self.index == other.index
+                and self.name == other.name
+                and self.data_type == other.data_type
+                and self.nominal_values == other.nominal_values
+                and self.number_missing_values == other.number_missing_values
+            )
+
     def _repr_pretty_(self, pp, cycle):
         pp.text(str(self))

--- a/openml/datasets/data_feature.py
+++ b/openml/datasets/data_feature.py
@@ -65,14 +65,14 @@ class OpenMLDataFeature(object):
     def __eq__(self, other):
         if not isinstance(other, OpenMLDataFeature):
             return False
-        else:
-            return (
-                self.index == other.index
-                and self.name == other.name
-                and self.data_type == other.data_type
-                and self.nominal_values == other.nominal_values
-                and self.number_missing_values == other.number_missing_values
-            )
+
+        return (
+            self.index == other.index
+            and self.name == other.name
+            and self.data_type == other.data_type
+            and self.nominal_values == other.nominal_values
+            and self.number_missing_values == other.number_missing_values
+        )
 
     def _repr_pretty_(self, pp, cycle):
         pp.text(str(self))

--- a/openml/datasets/data_feature.py
+++ b/openml/datasets/data_feature.py
@@ -66,13 +66,7 @@ class OpenMLDataFeature(object):
         if not isinstance(other, OpenMLDataFeature):
             return False
 
-        return (
-            self.index == other.index
-            and self.name == other.name
-            and self.data_type == other.data_type
-            and self.nominal_values == other.nominal_values
-            and self.number_missing_values == other.number_missing_values
-        )
+        return self.__dict__ == other.__dict__
 
     def _repr_pretty_(self, pp, cycle):
         pp.text(str(self))

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -800,7 +800,8 @@ class OpenMLDataset(OpenMLBase):
         qualities: bool (default=False)
             If True, load the `self.qualities` data if not already loaded.
         """
-        # Delayed Import to avoid circular imports or having to import all of dataset.functions to import OpenMLDataset
+        # Delayed Import to avoid circular imports or having to import all of dataset.functions to
+        # import OpenMLDataset
         from openml.datasets.functions import _get_dataset_metadata
 
         if self.dataset_id is None:

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -220,10 +220,10 @@ class OpenMLDataset(OpenMLBase):
             self._features = _read_features(features_file)
 
         if qualities_file == "":
-            # TODO: to switch to "qualities_file is not None" below
+            # TODO(0.15): to switch to "qualities_file is not None" below and remove warning
             warnings.warn(
-                "Starting from Version 0.14 `qualities_file` must be None and not an empty string.",
-                DeprecationWarning,
+                "Starting from Version 0.15 `qualities_file` must be None and not an empty string.",
+                FutureWarning,
             )
 
         if qualities_file:

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -809,10 +809,12 @@ class OpenMLDataset(OpenMLBase):
             )
 
         if features and self.features is None:
-            self.features = _parse_features_xml(_get_features_xml(self.dataset_id))
+            feature_xml = _get_features_xml(self.dataset_id)
+            self.features = _parse_features_xml(feature_xml)
 
         if qualities and self.qualities is None:
-            self.qualities = _parse_qualities_xml(_get_qualities_xml(self.dataset_id))
+            qualities_xml = _get_qualities_xml(self.dataset_id)
+            self.qualities = _parse_qualities_xml(qualities_xml)
 
     def retrieve_class_labels(self, target_name: str = "class") -> Union[None, List[str]]:
         """Reads the datasets arff to determine the class-labels.

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -789,7 +789,8 @@ class OpenMLDataset(OpenMLBase):
         return data, targets, categorical, attribute_names
 
     def load_metadata(self, features: bool = False, qualities: bool = False):
-        """Load the missing medata information from the server and store it in the server.
+        """Load the missing metadata information from the server and store it in the
+        dataset object.
 
         The purpose of the function is to support lazy loading.
 

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -249,7 +249,7 @@ class OpenMLDataset(OpenMLBase):
         """Collect all information to display in the __repr__ body."""
 
         # Obtain number of features in accordance with lazy loading.
-        if self.qualities is not None:
+        if self.qualities is not None and self.qualities["NumberOfFeatures"] is not None:
             n_features = int(self.qualities["NumberOfFeatures"])  # type: Optional[int]
         else:
             n_features = len(self.features) if self.features is not None else None

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -30,9 +30,9 @@ from ..utils import (
     _create_cache_directory_for_id,
 )
 
-
 DATASETS_CACHE_DIR_NAME = "datasets"
 logger = logging.getLogger(__name__)
+
 
 ############################################################################
 # Local getters/accessors to the cache directory
@@ -355,6 +355,7 @@ def get_dataset(
     error_if_multiple: bool = False,
     cache_format: str = "pickle",
     download_qualities: bool = True,
+    download_features_meta_data: bool = True,
     download_all_files: bool = False,
 ) -> OpenMLDataset:
     """Download the OpenML dataset representation, optionally also download actual data file.
@@ -389,6 +390,8 @@ def get_dataset(
         no.of.rows is very high.
     download_qualities : bool (default=True)
         Option to download 'qualities' meta-data in addition to the minimal dataset description.
+    download_features_meta_data : bool (default=True)
+        Option to download 'features' meta-data in addition to the minimal dataset description.
     download_all_files: bool (default=False)
         EXPERIMENTAL. Download all files related to the dataset that reside on the server.
         Useful for datasets which refer to auxiliary files (e.g., meta-album).
@@ -427,7 +430,11 @@ def get_dataset(
     remove_dataset_cache = True
     try:
         description = _get_dataset_description(did_cache_dir, dataset_id)
-        features_file = _get_dataset_features_file(did_cache_dir, dataset_id)
+
+        if download_features_meta_data:
+            features_file = _get_dataset_features_file(did_cache_dir, dataset_id)
+        else:
+            features_file = None
 
         try:
             if download_qualities:
@@ -1171,8 +1178,8 @@ def _get_dataset_qualities_file(did_cache_dir, dataset_id):
 
 def _create_dataset_from_description(
     description: Dict[str, str],
-    features_file: str,
-    qualities_file: str,
+    features_file: Optional[str] = None,
+    qualities_file: Optional[str] = None,
     arff_file: Optional[str] = None,
     parquet_file: Optional[str] = None,
     cache_format: str = "pickle",

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -418,17 +418,19 @@ def get_dataset(
     dataset : :class:`openml.OpenMLDataset`
         The downloaded dataset.
     """
+    # TODO(0.15): Remove the deprecation warning and make the default False; adjust types above
+    #   and documentation. Also remove None-to-True-cases below
     if any(
         download_flag is None
         for download_flag in [download_data, download_qualities, download_features_meta_data]
     ):
         warnings.warn(
-            "Starting from Version 0.14 `download_data`, `download_qualities`, and `download_featu"
+            "Starting from Version 0.15 `download_data`, `download_qualities`, and `download_featu"
             "res_meta_data` will all be ``False`` instead of ``True`` by default to enable lazy "
-            "loading. To disable this message until version 0.14 explicitly set `download_data`, "
+            "loading. To disable this message until version 0.15 explicitly set `download_data`, "
             "`download_qualities`, and `download_features_meta_data` to a bool while calling "
             "`get_dataset`.",
-            DeprecationWarning,
+            FutureWarning,
         )
 
     download_data = True if download_data is None else download_data

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -427,7 +427,8 @@ def get_dataset(
             "res_meta_data` will all be ``False`` instead of ``True`` by default to enable lazy "
             "loading. To disable this message until version 0.14 explicitly set `download_data`, "
             "`download_qualities`, and `download_features_meta_data` to a bool while calling "
-            "`get_dataset`."
+            "`get_dataset`.",
+            DeprecationWarning,
         )
 
     download_data = True if download_data is None else download_data

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -102,8 +102,8 @@ def run_model_on_task(
         warnings.warn(
             "avoid_duplicate_runs is set to True, but no API key is set. "
             "Please set your API key in the OpenML configuration file, see"
-            "https://openml.github.io/openml-python/main/examples/20_basic/introduction_tutorial.html#authentication"
-            "for more information on authentication.",
+            "https://openml.github.io/openml-python/main/examples/20_basic/introduction_tutorial"
+            + ".html#authenticatio for more information on authentication.",
         )
 
     # TODO: At some point in the future do not allow for arguments in old order (6-2018).

--- a/openml/runs/functions.py
+++ b/openml/runs/functions.py
@@ -103,7 +103,7 @@ def run_model_on_task(
             "avoid_duplicate_runs is set to True, but no API key is set. "
             "Please set your API key in the OpenML configuration file, see"
             "https://openml.github.io/openml-python/main/examples/20_basic/introduction_tutorial"
-            + ".html#authenticatio for more information on authentication.",
+            + ".html#authentication for more information on authentication.",
         )
 
     # TODO: At some point in the future do not allow for arguments in old order (6-2018).

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -288,9 +288,10 @@ def __list_tasks(api_call, output_format="dict"):
             tasks[tid] = task
         except KeyError as e:
             if tid is not None:
-                raise KeyError("Invalid xml for task %d: %s\nFrom %s" % (tid, e, task_))
+                warnings.warn("Invalid xml for task %d: %s\nFrom %s" % (tid, e, task_))
             else:
-                raise KeyError("Could not find key %s in %s!" % (e, task_))
+                warnings.warn("Could not find key %s in %s!" % (e, task_))
+            continue
 
     if output_format == "dataframe":
         tasks = pd.DataFrame.from_dict(tasks, orient="index")

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -370,7 +370,7 @@ def get_task(
         download_splits = get_dataset_kwargs.get("download_data", True)
 
     if not isinstance(task_id, int):
-        # TODO(0.14): Remove warning
+        # TODO(0.15): Remove warning
         warnings.warn(
             "Task id must be specified as `int` from 0.14.0 onwards.",
             FutureWarning,

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -23,7 +23,6 @@ from .task import (
 import openml.utils
 import openml._api_calls
 
-
 TASKS_CACHE_DIR_NAME = "tasks"
 
 
@@ -327,27 +326,39 @@ def get_tasks(
 
 @openml.utils.thread_safe_if_oslo_installed
 def get_task(
-    task_id: int, download_data: bool = True, download_qualities: bool = True
+    task_id: int, *dataset_args, download_splits: Optional[bool] = None, **get_dataset_kwargs
 ) -> OpenMLTask:
     """Download OpenML task for a given task ID.
 
-    Downloads the task representation, while the data splits can be
-    downloaded optionally based on the additional parameter. Else,
-    splits will either way be downloaded when the task is being used.
+    Downloads the task representation, while the data splits can be downloaded optionally based on
+    the additional parameter that are passed to :meth:`openml.datasets.get_dataset`.
+    Else, splits will either way be downloaded when the task is being used.
 
     Parameters
     ----------
     task_id : int
         The OpenML task id of the task to download.
-    download_data : bool (default=True)
-        Option to trigger download of data along with the meta data.
-    download_qualities : bool (default=True)
-        Option to download 'qualities' meta-data in addition to the minimal dataset description.
+    download_splits: bool (default=True)
+        Whether to download the splits as well. From version 0.14.0 onwards this is independent
+        of download_data and will default to ``False``.
+    dataset_args, get_dataset_kwargs :
+        Args and kwargs can be used pass optional parameters to :meth:`openml.datasets.get_dataset`.
+        This includes `download_data`. If set to True the splits are downloaded as well
+        (deprecated from Version 0.14.0 onwards). The args are only present for backwards
+        compatibility and will be removed from version 0.14.0 onwards.
 
     Returns
     -------
-    task
+    task: OpenMLTask
     """
+    if download_splits is None:
+        warnings.warn(
+            "Starting from Version 0.14.0 `download_splits` will default to ``False`` instead "
+            "of ``True`` and be independent from `download_data`.",
+            DeprecationWarning,
+        )
+        download_splits = get_dataset_kwargs.get("download_data", True)
+
     if not isinstance(task_id, int):
         warnings.warn(
             "Task id must be specified as `int` from 0.14.0 onwards.",
@@ -366,15 +377,15 @@ def get_task(
 
     try:
         task = _get_task_description(task_id)
-        dataset = get_dataset(task.dataset_id, download_data, download_qualities=download_qualities)
-        # List of class labels availaible in dataset description
+        dataset = get_dataset(task.dataset_id, *dataset_args, **get_dataset_kwargs)
+        # List of class labels available in dataset description
         # Including class labels as part of task meta data handles
         #   the case where data download was initially disabled
         if isinstance(task, (OpenMLClassificationTask, OpenMLLearningCurveTask)):
             task.class_labels = dataset.retrieve_class_labels(task.target_name)
         # Clustering tasks do not have class labels
         # and do not offer download_split
-        if download_data:
+        if download_splits:
             if isinstance(task, OpenMLSupervisedTask):
                 task.download_split()
     except Exception as e:

--- a/openml/tasks/functions.py
+++ b/openml/tasks/functions.py
@@ -330,39 +330,50 @@ def get_task(
 ) -> OpenMLTask:
     """Download OpenML task for a given task ID.
 
-    Downloads the task representation, while the data splits can be downloaded optionally based on
-    the additional parameter that are passed to :meth:`openml.datasets.get_dataset`.
-    Else, splits will either way be downloaded when the task is being used.
+    Downloads the task representation. By default, this will also download the data splits and
+    the dataset. From version 0.15.0 onwards, the splits will not be downloaded by default
+    nor the dataset.
+
+    Use the `download_splits` parameter to control whether the splits are downloaded.
+    Moreover, you may pass additional parameter (args or kwargs) that are passed to
+    :meth:`openml.datasets.get_dataset`.
+    For backwards compatibility, if `download_data` is passed as an additional parameter and
+    `download_splits` is not explicitly set, `download_data` also overrules `download_splits`'s
+    value (deprecated from Version 0.15.0 onwards).
 
     Parameters
     ----------
     task_id : int
         The OpenML task id of the task to download.
     download_splits: bool (default=True)
-        Whether to download the splits as well. From version 0.14.0 onwards this is independent
+        Whether to download the splits as well. From version 0.15.0 onwards this is independent
         of download_data and will default to ``False``.
     dataset_args, get_dataset_kwargs :
         Args and kwargs can be used pass optional parameters to :meth:`openml.datasets.get_dataset`.
         This includes `download_data`. If set to True the splits are downloaded as well
-        (deprecated from Version 0.14.0 onwards). The args are only present for backwards
-        compatibility and will be removed from version 0.14.0 onwards.
+        (deprecated from Version 0.15.0 onwards). The args are only present for backwards
+        compatibility and will be removed from version 0.15.0 onwards.
 
     Returns
     -------
     task: OpenMLTask
     """
     if download_splits is None:
+        # TODO(0.15): Switch download splits to False by default, adjust typing above, adjust
+        #  documentation above, and remove warning.
         warnings.warn(
-            "Starting from Version 0.14.0 `download_splits` will default to ``False`` instead "
-            "of ``True`` and be independent from `download_data`.",
-            DeprecationWarning,
+            "Starting from Version 0.15.0 `download_splits` will default to ``False`` instead "
+            "of ``True`` and be independent from `download_data`. To disable this message until "
+            "version 0.15 explicitly set `download_splits` to a bool.",
+            FutureWarning,
         )
         download_splits = get_dataset_kwargs.get("download_data", True)
 
     if not isinstance(task_id, int):
+        # TODO(0.14): Remove warning
         warnings.warn(
             "Task id must be specified as `int` from 0.14.0 onwards.",
-            DeprecationWarning,
+            FutureWarning,
         )
 
     try:

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -18,7 +18,6 @@ from . import config
 if TYPE_CHECKING:
     from openml.base import OpenMLBase
 
-
 oslo_installed = False
 try:
     # Currently, importing oslo raises a lot of warning that it will stop working
@@ -303,16 +302,31 @@ def _list_all(listing_call, output_format="dict", *args, **filters):
     return result
 
 
-def _create_cache_directory(key):
+def _get_cache_dir_for_key(key):
     cache = config.get_cache_directory()
-    cache_dir = os.path.join(cache, key)
+    return os.path.join(cache, key)
+
+
+def _create_cache_directory(key):
+    cache_dir = _get_cache_dir_for_key(key)
+
     try:
         os.makedirs(cache_dir, exist_ok=True)
     except Exception as e:
         raise openml.exceptions.OpenMLCacheException(
             f"Cannot create cache directory {cache_dir}."
         ) from e
+
     return cache_dir
+
+
+def _get_cache_dir_for_id(key, id_, create=False):
+    if create:
+        cache_dir = _create_cache_directory(key)
+    else:
+        cache_dir = _get_cache_dir_for_key(key)
+
+    return os.path.join(cache_dir, str(id_))
 
 
 def _create_cache_directory_for_id(key, id_):
@@ -336,7 +350,7 @@ def _create_cache_directory_for_id(key, id_):
     str
         Path of the created dataset cache directory.
     """
-    cache_dir = os.path.join(_create_cache_directory(key), str(id_))
+    cache_dir = _get_cache_dir_for_id(key, id_, create=True)
     if os.path.isdir(cache_dir):
         pass
     elif os.path.exists(cache_dir):

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -262,6 +262,19 @@ class OpenMLDatasetTest(TestBase):
         self.assertIsInstance(xy, pd.DataFrame)
         self.assertEqual(xy.shape, (150, 5))
 
+    def test_load_metadata(self):
+        _compare_dataset = openml.datasets.get_dataset(
+            2, download_data=False, download_features_meta_data=True, download_qualities=True
+        )
+
+        _dataset = openml.datasets.get_dataset(
+            2, download_data=False, download_features_meta_data=False, download_qualities=False
+        )
+        _dataset.load_metadata(features=True, qualities=True)
+
+        self.assertEqual(_dataset.features, _compare_dataset.features)
+        self.assertEqual(_dataset.qualities, _compare_dataset.qualities)
+
 
 class OpenMLDatasetTestOnTestServer(TestBase):
     def setUp(self):

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -263,15 +263,33 @@ class OpenMLDatasetTest(TestBase):
         self.assertEqual(xy.shape, (150, 5))
 
     def test_load_metadata(self):
+        # Initial Setup
+        did_cache_dir = openml.utils._create_cache_directory_for_id(openml.datasets.functions.DATASETS_CACHE_DIR_NAME,
+                                                                    2)
         _compare_dataset = openml.datasets.get_dataset(
             2, download_data=False, download_features_meta_data=True, download_qualities=True
         )
+        change_time = os.stat(did_cache_dir).st_mtime
+
+        # Test with cache
+        _dataset = openml.datasets.get_dataset(
+            2, download_data=False, download_features_meta_data=False, download_qualities=False
+        )
+        _dataset.load_metadata(features=True, qualities=True)
+
+        self.assertEqual(change_time, os.stat(did_cache_dir).st_mtime)
+        self.assertEqual(_dataset.features, _compare_dataset.features)
+        self.assertEqual(_dataset.qualities, _compare_dataset.qualities)
+
+        # -- Test without cache
+        openml.utils._remove_cache_dir_for_id(openml.datasets.functions.DATASETS_CACHE_DIR_NAME, did_cache_dir)
 
         _dataset = openml.datasets.get_dataset(
             2, download_data=False, download_features_meta_data=False, download_qualities=False
         )
         _dataset.load_metadata(features=True, qualities=True)
 
+        self.assertNotEqual(change_time, os.stat(did_cache_dir).st_mtime)
         self.assertEqual(_dataset.features, _compare_dataset.features)
         self.assertEqual(_dataset.qualities, _compare_dataset.qualities)
 

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -262,7 +262,7 @@ class OpenMLDatasetTest(TestBase):
         self.assertIsInstance(xy, pd.DataFrame)
         self.assertEqual(xy.shape, (150, 5))
 
-    def test_load_metadata(self):
+    def test_lazy_loading_metadata(self):
         # Initial Setup
         did_cache_dir = openml.utils._create_cache_directory_for_id(
             openml.datasets.functions.DATASETS_CACHE_DIR_NAME, 2
@@ -276,8 +276,6 @@ class OpenMLDatasetTest(TestBase):
         _dataset = openml.datasets.get_dataset(
             2, download_data=False, download_features_meta_data=False, download_qualities=False
         )
-        _dataset.load_metadata(features=True, qualities=True)
-
         self.assertEqual(change_time, os.stat(did_cache_dir).st_mtime)
         self.assertEqual(_dataset.features, _compare_dataset.features)
         self.assertEqual(_dataset.qualities, _compare_dataset.qualities)
@@ -290,8 +288,6 @@ class OpenMLDatasetTest(TestBase):
         _dataset = openml.datasets.get_dataset(
             2, download_data=False, download_features_meta_data=False, download_qualities=False
         )
-        _dataset.load_metadata(features=True, qualities=True)
-
         self.assertNotEqual(change_time, os.stat(did_cache_dir).st_mtime)
         self.assertEqual(_dataset.features, _compare_dataset.features)
         self.assertEqual(_dataset.qualities, _compare_dataset.qualities)

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -264,8 +264,9 @@ class OpenMLDatasetTest(TestBase):
 
     def test_load_metadata(self):
         # Initial Setup
-        did_cache_dir = openml.utils._create_cache_directory_for_id(openml.datasets.functions.DATASETS_CACHE_DIR_NAME,
-                                                                    2)
+        did_cache_dir = openml.utils._create_cache_directory_for_id(
+            openml.datasets.functions.DATASETS_CACHE_DIR_NAME, 2
+        )
         _compare_dataset = openml.datasets.get_dataset(
             2, download_data=False, download_features_meta_data=True, download_qualities=True
         )
@@ -282,7 +283,9 @@ class OpenMLDatasetTest(TestBase):
         self.assertEqual(_dataset.qualities, _compare_dataset.qualities)
 
         # -- Test without cache
-        openml.utils._remove_cache_dir_for_id(openml.datasets.functions.DATASETS_CACHE_DIR_NAME, did_cache_dir)
+        openml.utils._remove_cache_dir_for_id(
+            openml.datasets.functions.DATASETS_CACHE_DIR_NAME, did_cache_dir
+        )
 
         _dataset = openml.datasets.get_dataset(
             2, download_data=False, download_features_meta_data=False, download_qualities=False

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -549,8 +549,12 @@ class TestOpenMLDataset(TestBase):
         dataset = openml.datasets.get_dataset(
             2, download_qualities=False, download_features_meta_data=False
         )
-        self.assertIsNone(dataset.qualities)
-        self.assertIsNone(dataset.features)
+        # Internal representation without lazy loading
+        self.assertIsNone(dataset._qualities)
+        self.assertIsNone(dataset._features)
+        # External representation with lazy loading
+        self.assertIsNotNone(dataset.qualities)
+        self.assertIsNotNone(dataset.features)
 
     def test_get_dataset_force_refresh_cache(self):
         did_cache_dir = _create_cache_directory_for_id(

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -546,8 +546,43 @@ class TestOpenMLDataset(TestBase):
         self.assertTrue(os.path.exists(qualities_xml_path))
 
     def test__get_dataset_skip_download(self):
-        qualities = openml.datasets.get_dataset(2, download_qualities=False).qualities
-        self.assertIsNone(qualities)
+        dataset = openml.datasets.get_dataset(
+            2, download_qualities=False, download_features_meta_data=False
+        )
+        self.assertIsNone(dataset.qualities)
+        self.assertIsNone(dataset.features)
+
+    def test_get_dataset_force_refresh_cache(self):
+        did_cache_dir = _create_cache_directory_for_id(
+            DATASETS_CACHE_DIR_NAME,
+            2,
+        )
+        openml.datasets.get_dataset(2)
+        change_time = os.stat(did_cache_dir).st_mtime
+
+        # Test default
+        openml.datasets.get_dataset(2)
+        self.assertEqual(change_time, os.stat(did_cache_dir).st_mtime)
+
+        # Test refresh
+        openml.datasets.get_dataset(2, force_refresh_cache=True)
+        self.assertNotEqual(change_time, os.stat(did_cache_dir).st_mtime)
+
+        # Clean up
+        openml.utils._remove_cache_dir_for_id(
+            DATASETS_CACHE_DIR_NAME,
+            did_cache_dir,
+        )
+
+        # Test clean start
+        openml.datasets.get_dataset(2, force_refresh_cache=True)
+        self.assertTrue(os.path.exists(did_cache_dir))
+
+        # Final clean up
+        openml.utils._remove_cache_dir_for_id(
+            DATASETS_CACHE_DIR_NAME,
+            did_cache_dir,
+        )
 
     def test_deletion_of_cache_dir(self):
         # Simple removal


### PR DESCRIPTION
Related to #1034 #1081 #1132 
Closes #1081 #1132 

In detail, in relation to #1034, I have added a deprecation warning for `get_dataset`, making clear that we will default to not downloading the data in the future (starting from version 1.4, but this is just my guess for now). 

In relation to #1081, I added an option to disable downloading features. Moreover, I adjusted the `repr` method and added semi-lazy loading for features by the use of the function `OpenMLDataset.load_metadata`. As part of this, I also added the option to load qualities after calling `get_dataset`, which seems to have been missing so far. 

In relation to #1132, I added the option `force_refresh_cache` to force refresh the cache by deleting the existing cache initially. 

Note, I have also changed the docstring of `get_dataset` and adjusted the parts about being threading/multiprocessing safe, which were incorrect from my previous experiences and observations w.r.t. the cache. This might open a discussion to make this threading/multiprocessing safe based on an option that only downloads the data and ignores the cache entirely. I advise against this, for now, see [here ](https://github.com/openml/openml-python/pull/1256/files#diff-9cc0e191426810b9a76098707c2ddc9ec73a7f1852024a72445ddcb08b52f09bR361-R367) for more details on this.  
