### PR TITLE
Add future warning dataset format

### DIFF
--- a/examples/20_basic/simple_flows_and_runs_tutorial.py
+++ b/examples/20_basic/simple_flows_and_runs_tutorial.py
@@ -23,7 +23,7 @@ openml.config.start_using_configuration_for_example()
 # NOTE: We are using dataset 20 from the test server: https://test.openml.org/d/20
 dataset = openml.datasets.get_dataset(20)
 X, y, categorical_indicator, attribute_names = dataset.get_data(
-    dataset_format="array", target=dataset.default_target_attribute
+    target=dataset.default_target_attribute
 )
 clf = neighbors.KNeighborsClassifier(n_neighbors=3)
 clf.fit(X, y)

--- a/examples/30_extended/datasets_tutorial.py
+++ b/examples/30_extended/datasets_tutorial.py
@@ -64,23 +64,16 @@ print(dataset.description[:500])
 ############################################################################
 # Get the actual data.
 #
-# The dataset can be returned in 3 possible formats: as a NumPy array, a SciPy
-# sparse matrix, or as a Pandas DataFrame. The format is
-# controlled with the parameter ``dataset_format`` which can be either 'array'
-# (default) or 'dataframe'. Let's first build our dataset from a NumPy array
-# and manually create a dataframe.
-X, y, categorical_indicator, attribute_names = dataset.get_data(
-    dataset_format="array", target=dataset.default_target_attribute
-)
-eeg = pd.DataFrame(X, columns=attribute_names)
-eeg["class"] = y
-print(eeg[:10])
+# openml-python returns data as pandas dataframes (stored in the `eeg` variable below),
+# and also some additional metadata that we don't care about right now.
+eeg, *_ = dataset.get_data()
 
 ############################################################################
-# Instead of manually creating the dataframe, you can already request a
-# dataframe with the correct dtypes.
+# You can optionally choose to have openml separate out a column from the
+# dataset. In particular, many datasets for supervised problems have a set
+# `default_target_attribute` which may help identify the target variable.
 X, y, categorical_indicator, attribute_names = dataset.get_data(
-    target=dataset.default_target_attribute, dataset_format="dataframe"
+    target=dataset.default_target_attribute
 )
 print(X.head())
 print(X.info())
@@ -91,6 +84,9 @@ print(X.info())
 # data file. The dataset object can be used as normal.
 # Whenever you use any functionality that requires the data,
 # such as `get_data`, the data will be downloaded.
+# Starting from 0.15, not downloading data will be the default behavior instead.
+# The data will be downloading automatically when you try to access it through
+# openml objects, e.g., using `dataset.features`.
 dataset = openml.datasets.get_dataset(1471, download_data=False)
 
 ############################################################################

--- a/examples/30_extended/datasets_tutorial.py
+++ b/examples/30_extended/datasets_tutorial.py
@@ -95,8 +95,8 @@ dataset = openml.datasets.get_dataset(1471, download_data=False)
 # * Explore the data visually.
 eegs = eeg.sample(n=1000)
 _ = pd.plotting.scatter_matrix(
-    eegs.iloc[:100, :4],
-    c=eegs[:100]["class"],
+    X.iloc[:100, :4],
+    c=y[:100],
     figsize=(10, 10),
     marker="o",
     hist_kwds={"bins": 20},

--- a/examples/30_extended/flows_and_runs_tutorial.py
+++ b/examples/30_extended/flows_and_runs_tutorial.py
@@ -27,7 +27,7 @@ openml.config.start_using_configuration_for_example()
 # NOTE: We are using dataset 68 from the test server: https://test.openml.org/d/68
 dataset = openml.datasets.get_dataset(68)
 X, y, categorical_indicator, attribute_names = dataset.get_data(
-    dataset_format="array", target=dataset.default_target_attribute
+    target=dataset.default_target_attribute
 )
 clf = neighbors.KNeighborsClassifier(n_neighbors=1)
 clf.fit(X, y)
@@ -38,7 +38,7 @@ clf.fit(X, y)
 # * e.g. categorical features -> do feature encoding
 dataset = openml.datasets.get_dataset(17)
 X, y, categorical_indicator, attribute_names = dataset.get_data(
-    dataset_format="array", target=dataset.default_target_attribute
+    target=dataset.default_target_attribute
 )
 print(f"Categorical features: {categorical_indicator}")
 transformer = compose.ColumnTransformer(
@@ -160,7 +160,7 @@ pipe = pipeline.Pipeline(
     ]
 )
 
-run = openml.runs.run_model_on_task(pipe, task, avoid_duplicate_runs=False, dataset_format="array")
+run = openml.runs.run_model_on_task(pipe, task, avoid_duplicate_runs=False)
 myrun = run.publish()
 print(f"Uploaded to {myrun.openml_url}")
 
@@ -172,7 +172,7 @@ print(f"Uploaded to {myrun.openml_url}")
 
 # To perform the following line offline, it is required to have been called before
 # such that the task is cached on the local openml cache directory:
-task = openml.tasks.get_task(6)
+task = openml.tasks.get_task(96)
 
 # The following lines can then be executed offline:
 run = openml.runs.run_model_on_task(
@@ -180,7 +180,6 @@ run = openml.runs.run_model_on_task(
     task,
     avoid_duplicate_runs=False,
     upload_flow=False,
-    dataset_format="array",
 )
 
 # The run may be stored offline, and the flow will be stored along with it:

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -716,8 +716,10 @@ class OpenMLDataset(OpenMLBase):
             on the server in the dataset.
         dataset_format : string (default='dataframe')
             The format of returned dataset.
-            If ``array``, the returned dataset will be a NumPy array or a SciPy sparse matrix.
+            If ``array``, the returned dataset will be a NumPy array or a SciPy sparse
+            matrix. Support for ``array`` will be removed in 0.15.
             If ``dataframe``, the returned dataset will be a Pandas DataFrame.
+
 
         Returns
         -------
@@ -730,6 +732,16 @@ class OpenMLDataset(OpenMLBase):
         attribute_names : List[str]
             List of attribute names.
         """
+        # TODO: [0.15]
+        if dataset_format == "array":
+            warnings.warn(
+                "Support for `dataset_format='array'` will be removed in 0.15,"
+                "start using `dataset_format='dataframe' to ensure your code "
+                "will continue to work. You can use the dataframe's `to_numpy` "
+                "function to continue using numpy arrays.",
+                category=FutureWarning,
+                stacklevel=2,
+            )
         data, categorical, attribute_names = self._load_data()
 
         to_exclude = []

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -1,5 +1,5 @@
 # License: BSD 3-Clause
-
+import warnings
 from abc import ABC
 from collections import OrderedDict
 from enum import Enum
@@ -256,6 +256,16 @@ class OpenMLSupervisedTask(OpenMLTask, ABC):
         tuple - X and y
 
         """
+        # TODO: [0.15]
+        if dataset_format == "array":
+            warnings.warn(
+                "Support for `dataset_format='array'` will be removed in 0.15,"
+                "start using `dataset_format='dataframe' to ensure your code "
+                "will continue to work. You can use the dataframe's `to_numpy` "
+                "function to continue using numpy arrays.",
+                category=FutureWarning,
+                stacklevel=2,
+            )
         dataset = self.get_dataset()
         if self.task_type_id not in (
             TaskType.SUPERVISED_CLASSIFICATION,


### PR DESCRIPTION
Adds warnings about 0.15 no longer supporting ``array`` and update some of the example text to stop explaining about ``array``.