### PR TITLE
scipy 1.11 sets scipy.stats.mode  `keepdims=Fales` as default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           - os: windows-latest
             sklearn-only: 'false'
             scikit-learn: 0.24.*
+            scipy: 1.10.0
       fail-fast:  false
       max-parallel: 4
 


### PR DESCRIPTION
which conflicts with internals of scikit-learn 0.24.2

<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this PR implement/fix? Explain your changes.


#### How should this PR be tested?


#### Any other comments?

