### PR TITLE
Allow fallback to ARFF on ServerError and make explicit in warning

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -11,10 +11,6 @@ Changelog
 
  * FIX: Fallback on downloading ARFF when failing to download parquet from MinIO due to a ServerError.
 
-=========
-Changelog
-=========
-
 0.14.0
 ~~~~~~
 

--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -6,6 +6,15 @@
 Changelog
 =========
 
+0.14.1
+~~~~~~
+
+ * FIX: Fallback on downloading ARFF when failing to download parquet from MinIO due to a ServerError.
+
+=========
+Changelog
+=========
+
 0.14.0
 ~~~~~~
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -7,6 +7,7 @@ from pyexpat import ExpatError
 from typing import List, Dict, Optional, Union, cast
 import warnings
 
+import minio.error
 import numpy as np
 import arff
 import pandas as pd
@@ -499,6 +500,8 @@ def get_dataset(
                 )
             except urllib3.exceptions.MaxRetryError:
                 parquet_file = None
+            if parquet_file is None and arff_file:
+                logger.warning("Failed to download parquet, fallback on ARFF.")
         else:
             parquet_file = None
         remove_dataset_cache = False
@@ -1095,7 +1098,7 @@ def _get_dataset_parquet(
             openml._api_calls._download_minio_file(
                 source=cast(str, url), destination=output_file_path
             )
-        except (FileNotFoundError, urllib3.exceptions.MaxRetryError) as e:
+        except (FileNotFoundError, urllib3.exceptions.MaxRetryError, minio.error.ServerError) as e:
             logger.warning("Could not download file from %s: %s" % (cast(str, url), e))
             return None
     return output_file_path


### PR DESCRIPTION
#### How should this PR be tested?
Execute the following code snippet for a dataset not in your cache:
```python
import openml
DID  = 31
d = openml.datasets.get_dataset(DID)
df, *_ = d.get_data()
print(df)
```

on `develop` it currently raises (due to server issues) on `get_dataset`:
```text
/Users/pietergijsbers/repositories/openml-python/openml/datasets/functions.py:437: FutureWarning: Starting from Version 0.15 `download_data`, `download_qualities`, and `download_features_meta_data` will all be ``False`` instead of ``True`` by default to enable lazy loading. To disable this message until version 0.15 explicitly set `download_data`, `download_qualities`, and `download_features_meta_data` to a bool while calling `get_dataset`.
  warnings.warn(
Traceback (most recent call last):
  File "/Users/pietergijsbers/repositories/openml-python/mwe.py", line 3, in <module>
    d = openml.datasets.get_dataset(DID)
  File "/Users/pietergijsbers/repositories/openml-python/openml/utils.py", line 403, in safe_func
    return func(*args, **kwargs)
  File "/Users/pietergijsbers/repositories/openml-python/openml/datasets/functions.py", line 497, in get_dataset
    parquet_file = _get_dataset_parquet(
  File "/Users/pietergijsbers/repositories/openml-python/openml/datasets/functions.py", line 1095, in _get_dataset_parquet
    openml._api_calls._download_minio_file(
  File "/Users/pietergijsbers/repositories/openml-python/openml/_api_calls.py", line 151, in _download_minio_file
    client.fget_object(
  File "/Users/pietergijsbers/repositories/openml-python/venv/lib/python3.10/site-packages/minio/api.py", line 1042, in fget_object
    stat = self.stat_object(
  File "/Users/pietergijsbers/repositories/openml-python/venv/lib/python3.10/site-packages/minio/api.py", line 1867, in stat_object
    response = self._execute(
  File "/Users/pietergijsbers/repositories/openml-python/venv/lib/python3.10/site-packages/minio/api.py", line 403, in _execute
    return self._url_open(
  File "/Users/pietergijsbers/repositories/openml-python/venv/lib/python3.10/site-packages/minio/api.py", line 368, in _url_open
    raise ServerError(
minio.error.ServerError: server failed with HTTP status code 503
```
on this branch, it instead only issues a warning and falls back to ~parquet~ arff:
```text
/Users/pietergijsbers/repositories/openml-python/openml/datasets/functions.py:438: FutureWarning: Starting from Version 0.15 `download_data`, `download_qualities`, and `download_features_meta_data` will all be ``False`` instead of ``True`` by default to enable lazy loading. To disable this message until version 0.15 explicitly set `download_data`, `download_qualities`, and `download_features_meta_data` to a bool while calling `get_dataset`.
  warnings.warn(
WARNING:openml.datasets.functions:Could not download file from http://openml1.win.tue.nl/dataset31/dataset_31.pq: server failed with HTTP status code 503
WARNING:openml.datasets.functions:Failed to download parquet, fallback on ARFF.
    checking_status  duration                  credit_history              purpose  ...  num_dependents own_telephone foreign_worker  class
0                <0         6  critical/other existing credit             radio/tv  ...               1           yes            yes   good
1          0<=X<200        48                   existing paid             radio/tv  ...               1          none            yes    bad
2       no checking        12  critical/other existing credit            education  ...               2          none            yes   good
3                <0        42                   existing paid  furniture/equipment  ...               2          none            yes   good
4                <0        24              delayed previously              new car  ...               2          none            yes    bad
..              ...       ...                             ...                  ...  ...             ...           ...            ...    ...
995     no checking        12                   existing paid  furniture/equipment  ...               1          none            yes   good
996              <0        30                   existing paid             used car  ...               1           yes            yes   good
997     no checking        12                   existing paid             radio/tv  ...               1          none            yes   good
998              <0        45                   existing paid             radio/tv  ...               1           yes            yes    bad
999        0<=X<200        45  critical/other existing credit             used car  ...               1          none            yes   good

[1000 rows x 21 columns]
```