### PR TITLE
fix: carefully replaced minio_url with parquet_url

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -6,6 +6,11 @@
 Changelog
 =========
 
+next
+~~~~~~
+
+ * MAINT #1280: Use the server-provided ``parquet_url`` instead of ``minio_url`` to determine the location of the parquet file.
+
 0.14.1
 ~~~~~~
 

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -97,7 +97,7 @@ class OpenMLDataset(OpenMLBase):
     dataset: string, optional
         Serialized arff dataset string.
     parquet_url: string, optional
-        URL to the Parquet bucket with dataset files
+        URL to the MinIO bucket with dataset files
     parquet_file: string, optional
         Path to the local parquet file.
     """

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -96,8 +96,8 @@ class OpenMLDataset(OpenMLBase):
         which maps a quality name to a quality value.
     dataset: string, optional
         Serialized arff dataset string.
-    minio_url: string, optional
-        URL to the MinIO bucket with dataset files
+    parquet_url: string, optional
+        URL to the Parquet bucket with dataset files
     parquet_file: string, optional
         Path to the local parquet file.
     """
@@ -132,7 +132,7 @@ class OpenMLDataset(OpenMLBase):
         features_file: Optional[str] = None,
         qualities_file: Optional[str] = None,
         dataset=None,
-        minio_url: Optional[str] = None,
+        parquet_url: Optional[str] = None,
         parquet_file: Optional[str] = None,
     ):
         def find_invalid_characters(string, pattern):
@@ -210,7 +210,7 @@ class OpenMLDataset(OpenMLBase):
         self.data_file = data_file
         self.parquet_file = parquet_file
         self._dataset = dataset
-        self._minio_url = minio_url
+        self._parquet_url = parquet_url
 
         self._features = None  # type: Optional[Dict[int, OpenMLDataFeature]]
         self._qualities = None  # type: Optional[Dict[str, float]]
@@ -329,7 +329,7 @@ class OpenMLDataset(OpenMLBase):
         from .functions import _get_dataset_arff, _get_dataset_parquet
 
         self.data_file = _get_dataset_arff(self)
-        if self._minio_url is not None:
+        if self._parquet_url is not None:
             self.parquet_file = _get_dataset_parquet(self)
 
     def _get_arff(self, format: str) -> Dict:

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -97,8 +97,8 @@ class OpenMLDataset(OpenMLBase):
     dataset: string, optional
         Serialized arff dataset string.
     parquet_url: string, optional
-        This is the URL to the storage location where the dataset files are hosted. 
-        This can be a MinIO bucket URL. If specified, the data will be accessed 
+        This is the URL to the storage location where the dataset files are hosted.
+        This can be a MinIO bucket URL. If specified, the data will be accessed
         from this URL when reading the files.
     parquet_file: string, optional
         Path to the local file.

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -97,9 +97,11 @@ class OpenMLDataset(OpenMLBase):
     dataset: string, optional
         Serialized arff dataset string.
     parquet_url: string, optional
-        URL to the MinIO bucket with dataset files
+        This is the URL to the storage location where the dataset files are hosted. 
+        This can be a MinIO bucket URL. If specified, the data will be accessed 
+        from this URL when reading the files.
     parquet_file: string, optional
-        Path to the local parquet file.
+        Path to the local file.
     """
 
     def __init__(

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -1051,7 +1051,7 @@ def _get_dataset_parquet(
     This function is NOT thread/multiprocessing safe.
     Unlike the ARFF equivalent, checksums are not available/used (for now).
 
-    Parametersparquet_url
+    Parameters
     ----------
     description : dictionary or OpenMLDataset
         Either a dataset description as dict or OpenMLDataset.
@@ -1062,7 +1062,7 @@ def _get_dataset_parquet(
 
     download_all_files: bool, optional (default=False)
         If `True`, download all data found in the bucket to which the description's
-        ```` points, only download the parquet file otherwise.
+        ``parquet_url`` points, only download the parquet file otherwise.
 
     Returns
     -------

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -495,7 +495,7 @@ def get_dataset(
             qualities_file = _get_dataset_qualities_file(did_cache_dir, dataset_id)
 
         arff_file = _get_dataset_arff(description) if download_data else None
-        if "oml:minio_url" in description and download_data:
+        if "oml:parquet_url" in description and download_data:
             try:
                 parquet_file = _get_dataset_parquet(
                     description, download_all_files=download_all_files
@@ -1051,7 +1051,7 @@ def _get_dataset_parquet(
     This function is NOT thread/multiprocessing safe.
     Unlike the ARFF equivalent, checksums are not available/used (for now).
 
-    Parameters
+    Parametersparquet_url
     ----------
     description : dictionary or OpenMLDataset
         Either a dataset description as dict or OpenMLDataset.
@@ -1062,7 +1062,7 @@ def _get_dataset_parquet(
 
     download_all_files: bool, optional (default=False)
         If `True`, download all data found in the bucket to which the description's
-        ``minio_url`` points, only download the parquet file otherwise.
+        ```` points, only download the parquet file otherwise.
 
     Returns
     -------
@@ -1070,10 +1070,10 @@ def _get_dataset_parquet(
         Location of the Parquet file if successfully downloaded, None otherwise.
     """
     if isinstance(description, dict):
-        url = cast(str, description.get("oml:minio_url"))
+        url = cast(str, description.get("oml:parquet_url"))
         did = description.get("oml:id")
     elif isinstance(description, OpenMLDataset):
-        url = cast(str, description._minio_url)
+        url = cast(str, description._parquet_url)
         did = description.dataset_id
     else:
         raise TypeError("`description` should be either OpenMLDataset or Dict.")
@@ -1316,7 +1316,7 @@ def _create_dataset_from_description(
         cache_format=cache_format,
         features_file=features_file,
         qualities_file=qualities_file,
-        minio_url=description.get("oml:minio_url"),
+        parquet_url=description.get("oml:parquet_url"),
         parquet_file=parquet_file,
     )
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -439,7 +439,7 @@ class TestOpenMLDataset(TestBase):
 
     def test__get_dataset_parquet_not_cached(self):
         description = {
-            "oml:minio_url": "http://openml1.win.tue.nl/dataset20/dataset_20.pq",
+            "oml:parquet_url": "http://openml1.win.tue.nl/dataset20/dataset_20.pq",
             "oml:id": "20",
         }
         path = _get_dataset_parquet(description, cache_directory=self.workdir)
@@ -450,10 +450,10 @@ class TestOpenMLDataset(TestBase):
     def test__get_dataset_parquet_is_cached(self, patch):
         openml.config.set_root_cache_directory(self.static_cache_dir)
         patch.side_effect = RuntimeError(
-            "_download_minio_file should not be called when loading from cache"
+            "_download_parquet_url should not be called when loading from cache"
         )
         description = {
-            "oml:minio_url": "http://openml1.win.tue.nl/dataset30/dataset_30.pq",
+            "oml:parquet_url": "http://openml1.win.tue.nl/dataset30/dataset_30.pq",
             "oml:id": "30",
         }
         path = _get_dataset_parquet(description, cache_directory=None)
@@ -462,7 +462,7 @@ class TestOpenMLDataset(TestBase):
 
     def test__get_dataset_parquet_file_does_not_exist(self):
         description = {
-            "oml:minio_url": "http://openml1.win.tue.nl/dataset20/does_not_exist.pq",
+            "oml:parquet_url": "http://openml1.win.tue.nl/dataset20/does_not_exist.pq",
             "oml:id": "20",
         }
         path = _get_dataset_parquet(description, cache_directory=self.workdir)
@@ -1412,11 +1412,11 @@ class TestOpenMLDataset(TestBase):
 
     def test_get_dataset_cache_format_feather(self):
         # This test crashed due to using the parquet file by default, which is downloaded
-        # from minio. However, there is a mismatch between OpenML test server and minio IDs.
-        # The parquet file on minio with ID 128 is not the iris dataset from the test server.
+        # from parquet. However, there is a mismatch between OpenML test server and parquet IDs.
+        # The parquet file on parquet with ID 128 is not the iris dataset from the test server.
         dataset = openml.datasets.get_dataset(128, cache_format="feather")
         # Workaround
-        dataset._minio_url = None
+        dataset._parquet_url = None
         dataset.parquet_file = None
         dataset.get_data()
 
@@ -1561,7 +1561,7 @@ class TestOpenMLDataset(TestBase):
         # There is no parquet-copy of the test server yet.
         openml.config.server = self.production_server
         dataset = openml.datasets.get_dataset(61)
-        self.assertIsNotNone(dataset._minio_url)
+        self.assertIsNotNone(dataset._parquet_url)
         self.assertIsNotNone(dataset.parquet_file)
         self.assertTrue(os.path.isfile(dataset.parquet_file))
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1412,8 +1412,8 @@ class TestOpenMLDataset(TestBase):
 
     def test_get_dataset_cache_format_feather(self):
         # This test crashed due to using the parquet file by default, which is downloaded
-        # from parquet. However, there is a mismatch between OpenML test server and parquet IDs.
-        # The parquet file on parquet with ID 128 is not the iris dataset from the test server.
+        # from minio. However, there is a mismatch between OpenML test server and minio IDs.
+        # The parquet file on minio with ID 128 is not the iris dataset from the test server.
         dataset = openml.datasets.get_dataset(128, cache_format="feather")
         # Workaround
         dataset._parquet_url = None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

[x] this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
- Fixes #1142 

#### What does this PR implement/fix? Explain your changes.

The minio_url field in the dataset description URL is deprecated and will be fully replaced by parquet_url in the future (in the mean time, both are available).

#### How should this PR be tested?

This PR could be tested by checking the **dataset sent from the server**, which is the `xml response` as it was with the `minio_url` parameter and the relevant **parsing for data download** is happening correctly or not.

#### Any other comments?

It's my first PR so might make mistakes and I haven't tested this on my local machine. I am still setting-up the testing environment.

