### PR TITLE
Rework Tagging Tests for New Server Specification 

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -12,6 +12,7 @@ next
  * MAINT #1280: Use the server-provided ``parquet_url`` instead of ``minio_url`` to determine the location of the parquet file.
  * ADD #716: add documentation for remaining attributes of classes and functions.
  * ADD #1261: more annotations for type hints.
+ * MAINT #1294: update tests to new tag specification.
 
 0.14.1
 ~~~~~~

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -301,7 +301,7 @@ class OpenMLDatasetTestOnTestServer(TestBase):
         self.dataset = openml.datasets.get_dataset(125, download_data=False)
 
     def test_tagging(self):
-        tag = "testing_tag_{}_{}".format(self.id(), time())
+        tag = "test_tag_OpenMLDatasetTestOnTestServer_{}".format(time())
         datasets = openml.datasets.list_datasets(tag=tag, output_format="dataframe")
         self.assertTrue(datasets.empty)
         self.dataset.push_tag(tag)

--- a/tests/test_flows/test_flow.py
+++ b/tests/test_flows/test_flow.py
@@ -102,7 +102,7 @@ class TestFlow(TestBase):
         flows = openml.flows.list_flows(size=1, output_format="dataframe")
         flow_id = flows["id"].iloc[0]
         flow = openml.flows.get_flow(flow_id)
-        tag = "testing_tag_{}_{}".format(self.id(), time.time())
+        tag = "test_tag_TestFlow_{}".format(time.time())
         flows = openml.flows.list_flows(tag=tag, output_format="dataframe")
         self.assertEqual(len(flows), 0)
         flow.push_tag(tag)

--- a/tests/test_runs/test_run.py
+++ b/tests/test_runs/test_run.py
@@ -30,7 +30,7 @@ class TestRun(TestBase):
         assert not runs.empty, "Test server state is incorrect"
         run_id = runs["run_id"].iloc[0]
         run = openml.runs.get_run(run_id)
-        tag = "testing_tag_{}_{}".format(self.id(), time())
+        tag = "test_tag_TestRun_{}".format(time())
         runs = openml.runs.list_runs(tag=tag, output_format="dataframe")
         self.assertEqual(len(runs), 0)
         run.push_tag(tag)

--- a/tests/test_tasks/test_task_methods.py
+++ b/tests/test_tasks/test_task_methods.py
@@ -16,7 +16,7 @@ class OpenMLTaskMethodsTest(TestBase):
 
     def test_tagging(self):
         task = openml.tasks.get_task(1)  # anneal; crossvalidation
-        tag = "testing_tag_{}_{}".format(self.id(), time())
+        tag = "test_tag_OpenMLTaskMethodsTest_{}".format(time())
         tasks = openml.tasks.list_tasks(tag=tag, output_format="dataframe")
         self.assertEqual(len(tasks), 0)
         task.push_tag(tag)


### PR DESCRIPTION
This PR resolves errors in the hard-coded tags used during tests that were outdated for the current server specification. 

I did not adopt the tag logic itself, as I think the server's error message is detailed enough to inform the user. 
Moreover, if the logic would change again, this would not break. 