### PR TITLE
ci: Remove Python 3.6/7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,35 +20,6 @@ jobs:
           - python-version: 3.8
             scikit-learn: 0.21.2
         include:
-          #- python-version: 3.6
-            #scikit-learn: 0.18.2
-            #scipy: 1.2.0
-            #os: ubuntu-20.04 
-            #sklearn-only: 'true'
-          #- python-version: 3.6
-            #scikit-learn: 0.19.2
-            #os: ubuntu-20.04 
-            #sklearn-only: 'true'
-          #- python-version: 3.6
-            #scikit-learn: 0.20.2
-            #os: ubuntu-20.04 
-            #sklearn-only: 'true'
-          #- python-version: 3.6
-            #scikit-learn: 0.21.2
-            #os: ubuntu-20.04 
-            #sklearn-only: 'true'
-          #- python-version: 3.6
-            #scikit-learn: 0.22.2
-            #os: ubuntu-20.04 
-            #sklearn-only: 'true'
-          #- python-version: 3.6
-            #scikit-learn: 0.23.1
-            #os: ubuntu-20.04 
-            #sklearn-only: 'true'
-          #- python-version: 3.6
-            #scikit-learn: 0.24
-            #os: ubuntu-20.04 
-            #sklearn-only: 'true'
           - python-version: 3.8
             scikit-learn: 0.23.1
             code-cov: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "minio",
   "pyarrow",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 authors = [
   { name = "Matthias Feurer", email="feurerm@informatik.uni-freiburg.de" },
   { name = "Jan van Rijn" },
@@ -45,8 +45,6 @@ classifiers = [
   "Operating System :: Unix",
   "Operating System :: MacOS",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
We removed python 3.6 and python 3.7 in accordance to an undocumented policy #1083:

> We follow the Numpy end-of-life schedule: https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table

We will also remove python 3.8 once we work on moving out the sklearn-extensions to their own dedicated repository.