### PR TITLE
read file in read mode

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -252,11 +252,11 @@ def _setup(config: _Config | None = None) -> None:
     if config is None:
         config = _parse_config(config_file)
 
-    avoid_duplicate_runs = config.get("avoid_duplicate_runs", False)
+    avoid_duplicate_runs = bool(config.get("avoid_duplicate_runs", False))
     apikey = config["apikey"]
     server = config["server"]
-    short_cache_dir = config["cachedir"]
-    n_retries = config["connection_n_retries"]
+    short_cache_dir = Path(config["cachedir"])
+    n_retries = int(config["connection_n_retries"])
 
     set_retry_policy(config["retry_policy"], n_retries)
 

--- a/openml/config.py
+++ b/openml/config.py
@@ -252,7 +252,7 @@ def _setup(config: _Config | None = None) -> None:
     if config is None:
         config = _parse_config(config_file)
 
-    avoid_duplicate_runs = bool(config.get("avoid_duplicate_runs", False))
+    avoid_duplicate_runs = config.get("avoid_duplicate_runs", "").lower() == "true"
     apikey = config["apikey"]
     server = config["server"]
     short_cache_dir = Path(config["cachedir"])

--- a/openml/config.py
+++ b/openml/config.py
@@ -252,7 +252,7 @@ def _setup(config: _Config | None = None) -> None:
     if config is None:
         config = _parse_config(config_file)
 
-    avoid_duplicate_runs = config.get("avoid_duplicate_runs", "").lower() == "true"
+    avoid_duplicate_runs = config["avoid_duplicate_runs"]
     apikey = config["apikey"]
     server = config["server"]
     short_cache_dir = Path(config["cachedir"])
@@ -328,6 +328,10 @@ def _parse_config(config_file: str | Path) -> _Config:
         logger.info("Error opening file %s: %s", config_file, e.args[0])
     config_file_.seek(0)
     config.read_file(config_file_)
+    if isinstance(config["FAKE_SECTION"]["avoid_duplicate_runs"], str):
+        config["FAKE_SECTION"]["avoid_duplicate_runs"] = config["FAKE_SECTION"].getboolean(
+            "avoid_duplicate_runs"
+        )  # type: ignore
     return dict(config.items("FAKE_SECTION"))  # type: ignore
 
 

--- a/openml/config.py
+++ b/openml/config.py
@@ -319,7 +319,7 @@ def _parse_config(config_file: str | Path) -> _Config:
     config_file_ = StringIO()
     config_file_.write("[FAKE_SECTION]\n")
     try:
-        with config_file.open("w") as fh:
+        with config_file.open("r") as fh:
             for line in fh:
                 config_file_.write(line)
     except FileNotFoundError:

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -116,3 +116,20 @@ class TestConfigurationForExamples(openml.testing.TestBase):
 
         assert openml.config.apikey == "610344db6388d9ba34f6db45a3cf71de"
         assert openml.config.server == self.production_server
+
+
+def test_configuration_file_not_overwritten_on_load():
+    """ Regression test for #1337 """
+    config_file_content = "apikey = abcd"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_file_path = Path(tmpdir) / "config"
+        with config_file_path.open("w") as config_file:
+            config_file.write(config_file_content)
+
+        read_config = openml.config._parse_config(config_file_path)
+
+        with config_file_path.open("r") as config_file:
+            new_file_content = config_file.read()
+
+    assert config_file_content == new_file_content
+    assert "abcd" == read_config["apikey"]


### PR DESCRIPTION
#### Reference Issue
Fixes #1337 

#### What does this PR implement/fix? Explain your changes.
It changes the mode that config_file is being opened, so it will not be overwritten. It also casts the variables of the config_file to the expected types, otherwise, everything is read as str.

#### How should this PR be tested?
1 - Create a new config file .../.config/openml/config
2 - do ```import openml```
3 - check that the config file is preserved
