### PR TITLE
Fix for numpy2.0 compatibility

### DIFF
--- a/openml/extensions/sklearn/extension.py
+++ b/openml/extensions/sklearn/extension.py
@@ -48,9 +48,10 @@ DEPENDENCIES_PATTERN = re.compile(
     r"(?P<version>(\d+\.)?(\d+\.)?(\d+)?(dev)?[0-9]*))?$",
 )
 
+sctypes = np.sctypes if LooseVersion(np.__version__) < "2.0" else np.core.sctypes
 SIMPLE_NUMPY_TYPES = [
     nptype
-    for type_cat, nptypes in np.sctypes.items()
+    for type_cat, nptypes in sctypes.items()
     for nptype in nptypes  # type: ignore
     if type_cat != "others"
 ]


### PR DESCRIPTION
Numpy2.0 cleaned up their namespace, so we have to alias for the new version.

The problem is that this is not covered in CI (tested versions do not support numpy 2.0), and in general tests need to be updated to support more recent scikit-learn versions that support 2.0 (1.5, maybe 1.4?). I don't know if I really have the time for that right now. Options:

 - Put a pin in the dependencies
 - Accept this as a best-effort, and hope that the tests that don't fail due to scikit-learn incompatibility sufficiently cover the code to raise any numpy1/2 issues
 - Wait until I find time to make tests support scikit-learn 1.5
