### PR TITLE
Add HTTP headers to all requests

### DIFF
--- a/doc/progress.rst
+++ b/doc/progress.rst
@@ -10,6 +10,7 @@ next
 ~~~~~~
 
  * MAINT #1340: Add Numpy 2.0 support. Update tests to work with scikit-learn <= 1.5.
+ * ADD #1342: Add HTTP header to requests to indicate they are from openml-python.
 
 0.14.2
 ~~~~~~

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -19,12 +19,15 @@ import xmltodict
 from urllib3 import ProxyManager
 
 from . import config
+from .__version__ import __version__
 from .exceptions import (
     OpenMLHashException,
     OpenMLServerError,
     OpenMLServerException,
     OpenMLServerNoResult,
 )
+
+_HEADERS = {"user-agent": f"openml-python/{__version__}"}
 
 DATA_TYPE = Dict[str, Union[str, int]]
 FILE_ELEMENTS_TYPE = Dict[str, Union[str, Tuple[str, str]]]
@@ -164,6 +167,7 @@ def _download_minio_file(
             bucket_name=bucket,
             object_name=object_name,
             file_path=str(destination),
+            request_headers=_HEADERS,
         )
         if destination.is_file() and destination.suffix == ".zip":
             with zipfile.ZipFile(destination, "r") as zip_ref:
@@ -350,11 +354,11 @@ def _send_request(  # noqa: C901
         for retry_counter in range(1, n_retries + 1):
             try:
                 if request_method == "get":
-                    response = session.get(url, params=data)
+                    response = session.get(url, params=data, headers=_HEADERS)
                 elif request_method == "delete":
-                    response = session.delete(url, params=data)
+                    response = session.delete(url, params=data, headers=_HEADERS)
                 elif request_method == "post":
-                    response = session.post(url, data=data, files=files)
+                    response = session.post(url, data=data, files=files, headers=_HEADERS)
                 else:
                     raise NotImplementedError()
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -1768,11 +1768,9 @@ def test_delete_dataset_not_owned(mock_delete, test_files_directory, test_api_ke
     ):
         openml.datasets.delete_dataset(40_000)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/data/40000",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    dataset_url = "https://test.openml.org/api/v1/xml/data/40000"
+    assert dataset_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -1792,11 +1790,9 @@ def test_delete_dataset_with_run(mock_delete, test_files_directory, test_api_key
     ):
         openml.datasets.delete_dataset(40_000)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/data/40000",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    dataset_url = "https://test.openml.org/api/v1/xml/data/40000"
+    assert dataset_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -1813,11 +1809,9 @@ def test_delete_dataset_success(mock_delete, test_files_directory, test_api_key)
     success = openml.datasets.delete_dataset(40000)
     assert success
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/data/40000",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    dataset_url = "https://test.openml.org/api/v1/xml/data/40000"
+    assert dataset_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -1837,11 +1831,9 @@ def test_delete_unknown_dataset(mock_delete, test_files_directory, test_api_key)
     ):
         openml.datasets.delete_dataset(9_999_999)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/data/9999999",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    dataset_url = "https://test.openml.org/api/v1/xml/data/9999999"
+    assert dataset_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 def _assert_datasets_have_id_and_valid_status(datasets: pd.DataFrame):

--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -460,11 +460,9 @@ def test_delete_flow_not_owned(mock_delete, test_files_directory, test_api_key):
     ):
         openml.flows.delete_flow(40_000)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/flow/40000",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    flow_url = "https://test.openml.org/api/v1/xml/flow/40000"
+    assert flow_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -482,11 +480,9 @@ def test_delete_flow_with_run(mock_delete, test_files_directory, test_api_key):
     ):
         openml.flows.delete_flow(40_000)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/flow/40000",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    flow_url = "https://test.openml.org/api/v1/xml/flow/40000"
+    assert flow_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -504,11 +500,9 @@ def test_delete_subflow(mock_delete, test_files_directory, test_api_key):
     ):
         openml.flows.delete_flow(40_000)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/flow/40000",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    flow_url = "https://test.openml.org/api/v1/xml/flow/40000"
+    assert flow_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -523,11 +517,9 @@ def test_delete_flow_success(mock_delete, test_files_directory, test_api_key):
     success = openml.flows.delete_flow(33364)
     assert success
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/flow/33364",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    flow_url = "https://test.openml.org/api/v1/xml/flow/33364"
+    assert flow_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -545,8 +537,6 @@ def test_delete_unknown_flow(mock_delete, test_files_directory, test_api_key):
     ):
         openml.flows.delete_flow(9_999_999)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/flow/9999999",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    flow_url = "https://test.openml.org/api/v1/xml/flow/9999999"
+    assert flow_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")

--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -1907,11 +1907,9 @@ def test_delete_run_not_owned(mock_delete, test_files_directory, test_api_key):
     ):
         openml.runs.delete_run(40_000)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/run/40000",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    run_url = "https://test.openml.org/api/v1/xml/run/40000"
+    assert run_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -1926,11 +1924,9 @@ def test_delete_run_success(mock_delete, test_files_directory, test_api_key):
     success = openml.runs.delete_run(10591880)
     assert success
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/run/10591880",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    run_url = "https://test.openml.org/api/v1/xml/run/10591880"
+    assert run_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -1948,8 +1944,6 @@ def test_delete_unknown_run(mock_delete, test_files_directory, test_api_key):
     ):
         openml.runs.delete_run(9_999_999)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/run/9999999",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    run_url = "https://test.openml.org/api/v1/xml/run/9999999"
+    assert run_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")

--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -249,11 +249,9 @@ def test_delete_task_not_owned(mock_delete, test_files_directory, test_api_key):
     ):
         openml.tasks.delete_task(1)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/task/1",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    task_url = "https://test.openml.org/api/v1/xml/task/1"
+    assert task_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -271,11 +269,9 @@ def test_delete_task_with_run(mock_delete, test_files_directory, test_api_key):
     ):
         openml.tasks.delete_task(3496)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/task/3496",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    task_url = "https://test.openml.org/api/v1/xml/task/3496"
+    assert task_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -290,11 +286,9 @@ def test_delete_success(mock_delete, test_files_directory, test_api_key):
     success = openml.tasks.delete_task(361323)
     assert success
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/task/361323",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    task_url = "https://test.openml.org/api/v1/xml/task/361323"
+    assert task_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")
 
 
 @mock.patch.object(requests.Session, "delete")
@@ -312,8 +306,6 @@ def test_delete_unknown_task(mock_delete, test_files_directory, test_api_key):
     ):
         openml.tasks.delete_task(9_999_999)
 
-    expected_call_args = [
-        ("https://test.openml.org/api/v1/xml/task/9999999",),
-        {"params": {"api_key": test_api_key}},
-    ]
-    assert expected_call_args == list(mock_delete.call_args)
+    task_url = "https://test.openml.org/api/v1/xml/task/9999999"
+    assert task_url == mock_delete.call_args.args[0]
+    assert test_api_key == mock_delete.call_args.kwargs.get("params", {}).get("api_key")


### PR DESCRIPTION
This allows us to better understand the traffic we see to our server API. It is not identifiable to a person.

Motivated after seeing large spikes in traffic recently. Some of them coming from `requests/1.x.x` agents - which leaves us wondering if this is from Python API users (potentially indirectly through e.g., the automlbenchmark), or scripts/bots that don't identify themselves as such.

On top of this PR, I think we might want to make our user-agent configurable so that services building on top of `openml-python` can identify themselves (e.g., automl benchmark, experiment bots). But I don't want to get into that right now.

I updated the unit tests that would otherwise crash. I explicitly did not add a check for the agent with these tests.
To me it feels that would be outside the scope of those tests. In general, it's a thin line the way its set up - should our tests even fail if they would just keyword argument instead of a positional one? But that too felt out of scope, so I change it to a (in my opinion) slightly better version of the same tests.

I do not feel this warrants its own unit test. If I should make one, could you recommend an approach? Just mocking the requests library and then calling `_api_call` for all types of requests? I just thought that wasn't particularly useful.