### PR TITLE
Pin NumPy to be lower than 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "python-dateutil",  # Installed through pandas anyway.
   "pandas>=1.0.0",
   "scipy>=0.13.3",
-  "numpy>=1.6.2",
+  "numpy>=1.6.2,<2.0.0",
   "minio",
   "pyarrow",
 ]


### PR DESCRIPTION
Fixes ```AttributeError: `np.sctypes` was removed in the NumPy 2.0 release.``` on newer NumPy versions and poetry installation

<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->

None

#### What does this PR implement/fix? Explain your changes.

Fixes the 
```
AttributeError: `np.sctypes` was removed in the NumPy 2.0 release. Access dtypes explicitly instead.. Did you mean: 'dtypes'?
```
in the ```sklearn``` extension. (line 53, ```sklearn/extension.py```)

You might say "but nobody has ever experienced this issue!". True. For some reason, pip can figure out that the dependency should be lower than 2.0; I don't how it does it. However, I use poetry as a package manager, and if installing openml via poetry, it uses numpy 2.1 as a dependency, which breaks openml.

#### How should this PR be tested?

Install poetry. Then:
```
mkdir test && cd test && poetry init -q && poetry add openml && poetry run python -m openml
```
This would throw before the changes, but would not after the changes.

#### Any other comments?

Should be pretty easy to merge.
