### PR TITLE
Pass kwargs through task to ```get_dataset```

### DIFF
--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -145,7 +145,7 @@ class OpenMLTask(OpenMLBase):
         ]
         return [(key, fields[key]) for key in order if key in fields]
 
-    def get_dataset(self, /, **kwargs) -> datasets.OpenMLDataset:
+    def get_dataset(self, **kwargs) -> datasets.OpenMLDataset:
         """Download dataset associated with task.
 
         Accepts the same keyword arguments as the `openml.datasets.get_dataset`.

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -145,8 +145,11 @@ class OpenMLTask(OpenMLBase):
         ]
         return [(key, fields[key]) for key in order if key in fields]
 
-    def get_dataset(self, **kwargs) -> datasets.OpenMLDataset:
-        """Download dataset associated with task."""
+    def get_dataset(self, /, **kwargs) -> datasets.OpenMLDataset:
+        """Download dataset associated with task.
+
+        Accepts the same keyword arguments as the `openml.datasets.get_dataset`.
+        """
         return datasets.get_dataset(self.dataset_id, **kwargs)
 
     def get_train_test_split_indices(

--- a/openml/tasks/task.py
+++ b/openml/tasks/task.py
@@ -145,9 +145,9 @@ class OpenMLTask(OpenMLBase):
         ]
         return [(key, fields[key]) for key in order if key in fields]
 
-    def get_dataset(self) -> datasets.OpenMLDataset:
+    def get_dataset(self, **kwargs) -> datasets.OpenMLDataset:
         """Download dataset associated with task."""
-        return datasets.get_dataset(self.dataset_id)
+        return datasets.get_dataset(self.dataset_id, **kwargs)
 
     def get_train_test_split_indices(
         self,


### PR DESCRIPTION
Allows to follow the directions in the FutureWarning ```Starting from Version 0.15 `download_data`, `download_qualities`, and `download_features_meta_data` will all be ``False`` instead of ``True`` by default to enable lazy loading.```

<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->

None

#### What does this PR implement/fix? Explain your changes.

When doing something like 
```
dataset = task.get_dataset()
```
which takes no parameters one gets the warning. Now it takes any parameters that the ```datasets.get_dataset``` takes, thus allowing to set the optional parameters.

#### How should this PR be tested?

Test that the suite passes, I guess; there is not really a short way to test.

#### Any other comments?

Maybe kwargs-passing behaviour should be added to all the other methods in the ```OpenMLTask```?

(this PR might be noise again, though I checked that the issue is present on dev, sorry if I am wrong though)
