### PR TITLE
Add/1034

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -416,8 +416,8 @@ def _name_to_id(
 
 def get_datasets(
     dataset_ids: list[str | int],
-    download_data: bool = True,  # noqa: FBT001, FBT002
-    download_qualities: bool = True,  # noqa: FBT001, FBT002
+    download_data: bool = False,  # noqa: FBT001, FBT002
+    download_qualities: bool = False,  # noqa: FBT001, FBT002
 ) -> list[OpenMLDataset]:
     """Download datasets.
 
@@ -450,14 +450,14 @@ def get_datasets(
 
 
 @openml.utils.thread_safe_if_oslo_installed
-def get_dataset(  # noqa: C901, PLR0912, PLR0915
+def get_dataset(  # noqa: C901, PLR0912
     dataset_id: int | str,
-    download_data: bool | None = None,  # Optional for deprecation warning; later again only bool
+    download_data: bool = False,  # noqa: FBT002, FBT001
     version: int | None = None,
     error_if_multiple: bool = False,  # noqa: FBT002, FBT001
     cache_format: Literal["pickle", "feather"] = "pickle",
-    download_qualities: bool | None = None,  # Same as above
-    download_features_meta_data: bool | None = None,  # Same as above
+    download_qualities: bool = False,  # noqa: FBT002, FBT001
+    download_features_meta_data: bool = False,  # noqa: FBT002, FBT001
     download_all_files: bool = False,  # noqa: FBT002, FBT001
     force_refresh_cache: bool = False,  # noqa: FBT001, FBT002
 ) -> OpenMLDataset:
@@ -485,7 +485,7 @@ def get_dataset(  # noqa: C901, PLR0912, PLR0915
     ----------
     dataset_id : int or str
         Dataset ID of the dataset to download
-    download_data : bool (default=True)
+    download_data : bool (default=False)
         If True, also download the data file. Beware that some datasets are large and it might
         make the operation noticeably slower. Metadata is also still retrieved.
         If False, create the OpenMLDataset and only populate it with the metadata.
@@ -499,12 +499,12 @@ def get_dataset(  # noqa: C901, PLR0912, PLR0915
         Format for caching the dataset - may be feather or pickle
         Note that the default 'pickle' option may load slower than feather when
         no.of.rows is very high.
-    download_qualities : bool (default=True)
+    download_qualities : bool (default=False)
         Option to download 'qualities' meta-data in addition to the minimal dataset description.
         If True, download and cache the qualities file.
         If False, create the OpenMLDataset without qualities metadata. The data may later be added
         to the OpenMLDataset through the `OpenMLDataset.load_metadata(qualities=True)` method.
-    download_features_meta_data : bool (default=True)
+    download_features_meta_data : bool (default=False)
         Option to download 'features' meta-data in addition to the minimal dataset description.
         If True, download and cache the features file.
         If False, create the OpenMLDataset without features metadata. The data may later be added
@@ -523,28 +523,6 @@ def get_dataset(  # noqa: C901, PLR0912, PLR0915
     dataset : :class:`openml.OpenMLDataset`
         The downloaded dataset.
     """
-    # TODO(0.15): Remove the deprecation warning and make the default False; adjust types above
-    #   and documentation. Also remove None-to-True-cases below
-    if any(
-        download_flag is None
-        for download_flag in [download_data, download_qualities, download_features_meta_data]
-    ):
-        warnings.warn(
-            "Starting from Version 0.15 `download_data`, `download_qualities`, and `download_featu"
-            "res_meta_data` will all be ``False`` instead of ``True`` by default to enable lazy "
-            "loading. To disable this message until version 0.15 explicitly set `download_data`, "
-            "`download_qualities`, and `download_features_meta_data` to a bool while calling "
-            "`get_dataset`.",
-            FutureWarning,
-            stacklevel=2,
-        )
-
-    download_data = True if download_data is None else download_data
-    download_qualities = True if download_qualities is None else download_qualities
-    download_features_meta_data = (
-        True if download_features_meta_data is None else download_features_meta_data
-    )
-
     if download_all_files:
         warnings.warn(
             "``download_all_files`` is experimental and is likely to break with new releases.",

--- a/openml/testing.py
+++ b/openml/testing.py
@@ -56,7 +56,7 @@ class TestBase(unittest.TestCase):
     logger = logging.getLogger("unit_tests_published_entities")
     logger.setLevel(logging.DEBUG)
 
-    def setUp(self, n_levels: int = 1) -> None:
+    def setUp(self, n_levels: int = 1, tmpdir_suffix: str = "") -> None:
         """Setup variables and temporary directories.
 
         In particular, this methods:
@@ -92,7 +92,7 @@ class TestBase(unittest.TestCase):
         self.static_cache_dir = static_cache_dir
         self.cwd = Path.cwd()
         workdir = Path(__file__).parent.absolute()
-        tmp_dir_name = self.id()
+        tmp_dir_name = self.id() + tmpdir_suffix
         self.workdir = workdir / tmp_dir_name
         shutil.rmtree(self.workdir, ignore_errors=True)
 

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -105,6 +105,7 @@ class TestOpenMLDataset(TestBase):
         for did in datasets:
             self._check_dataset(datasets[did])
 
+    def test_tag_untag_dataset(self):
         tag = "test_tag_%d" % random.randint(1, 1000000)
         all_tags = _tag_entity("data", 1, tag)
         assert tag in all_tags

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 import itertools
 import os
-import uuid
-from pathlib import Path
 import random
 import shutil
 import time
+import uuid
 from itertools import product
+from pathlib import Path
 from typing import Iterable
 from unittest import mock
 
@@ -169,7 +169,6 @@ class TestOpenMLDataset(TestBase):
         except openml.exceptions.OpenMLServerException as e:
             assert e.code == 477
 
-
     @pytest.mark.production()
     def test__name_to_id_with_deactivated(self):
         """Check that an activated dataset is returned if an earlier deactivated one exists."""
@@ -275,7 +274,6 @@ class TestOpenMLDataset(TestBase):
         df, _, _, _ = dataset.get_data()
         assert df["carbon"].dtype == "uint8"
 
-
     @pytest.mark.production()
     def test_get_dataset_cannot_access_private_data(self):
         # Issue324 Properly handle private datasets when trying to access them
@@ -285,7 +283,9 @@ class TestOpenMLDataset(TestBase):
     @pytest.mark.skip("Need to find dataset name of private dataset")
     def test_dataset_by_name_cannot_access_private_data(self):
         openml.config.server = self.production_server
-        self.assertRaises(OpenMLPrivateDatasetError, openml.datasets.get_dataset, "NAME_GOES_HERE")
+        self.assertRaises(
+            OpenMLPrivateDatasetError, openml.datasets.get_dataset, "NAME_GOES_HERE"
+        )
 
     def test_get_dataset_lazy_all_functions(self):
         """Test that all expected functionality is available without downloading the dataset."""
@@ -294,7 +294,9 @@ class TestOpenMLDataset(TestBase):
 
         def ensure_absence_of_real_data():
             assert not os.path.exists(
-                os.path.join(openml.config.get_cache_directory(), "datasets", "1", "dataset.arff")
+                os.path.join(
+                    openml.config.get_cache_directory(), "datasets", "1", "dataset.arff"
+                )
             )
 
         tag = "test_lazy_tag_%d" % random.randint(1, 1000000)
@@ -516,8 +518,12 @@ class TestOpenMLDataset(TestBase):
     @mock.patch("openml.datasets.functions._get_dataset_description")
     def test_deletion_of_cache_dir_faulty_download(self, patch):
         patch.side_effect = Exception("Boom!")
-        self.assertRaisesRegex(Exception, "Boom!", openml.datasets.get_dataset, dataset_id=1)
-        datasets_cache_dir = os.path.join(self.workdir, "org", "openml", "test", "datasets")
+        self.assertRaisesRegex(
+            Exception, "Boom!", openml.datasets.get_dataset, dataset_id=1
+        )
+        datasets_cache_dir = os.path.join(
+            self.workdir, "org", "openml", "test", "datasets"
+        )
         assert len(os.listdir(datasets_cache_dir)) == 0
 
     def test_publish_dataset(self):
@@ -558,7 +564,9 @@ class TestOpenMLDataset(TestBase):
         # Test workaround for string-typed class labels
         custom_ds = openml.datasets.get_dataset(2)
         custom_ds.features[31].data_type = "string"
-        labels = custom_ds.retrieve_class_labels(target_name=custom_ds.features[31].name)
+        labels = custom_ds.retrieve_class_labels(
+            target_name=custom_ds.features[31].name
+        )
         assert labels == ["COIL", "SHEET"]
 
     def test_upload_dataset_with_url(self):
@@ -601,7 +609,9 @@ class TestOpenMLDataset(TestBase):
         )
         dataset.publish()
         TestBase._mark_entity_for_removal("data", dataset.id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], dataset.id))
+        TestBase.logger.info(
+            "collected from {}: {}".format(__file__.split("/")[-1], dataset.id)
+        )
         did = dataset.id
 
         # admin key for test server (only adminds can activate datasets.
@@ -651,7 +661,11 @@ class TestOpenMLDataset(TestBase):
         # Test column names are automatically converted to str if needed (#819)
         df = pd.DataFrame({0: [1, 2, 3], 0.5: [4, 5, 6], "target": [0, 1, 1]})
         attributes = attributes_arff_from_df(df)
-        assert attributes == [("0", "INTEGER"), ("0.5", "INTEGER"), ("target", "INTEGER")]
+        assert attributes == [
+            ("0", "INTEGER"),
+            ("0.5", "INTEGER"),
+            ("target", "INTEGER"),
+        ]
 
     def test_attributes_arff_from_df_mixed_dtype_categories(self):
         # liac-arff imposed categorical attributes to be of sting dtype. We
@@ -673,7 +687,8 @@ class TestOpenMLDataset(TestBase):
         for arr, dt in zip(data, dtype):
             df = pd.DataFrame(arr)
             err_msg = (
-                f"The dtype '{dt}' of the column '0' is not currently " "supported by liac-arff"
+                f"The dtype '{dt}' of the column '0' is not currently "
+                "supported by liac-arff"
             )
             with pytest.raises(ValueError, match=err_msg):
                 attributes_arff_from_df(df)
@@ -704,12 +719,16 @@ class TestOpenMLDataset(TestBase):
 
         dataset.publish()
         TestBase._mark_entity_for_removal("data", dataset.id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], dataset.id))
+        TestBase.logger.info(
+            "collected from {}: {}".format(__file__.split("/")[-1], dataset.id)
+        )
 
         assert (
             _get_online_dataset_arff(dataset.id) == dataset._dataset
         ), "Uploaded arff does not match original one"
-        assert _get_online_dataset_format(dataset.id) == "arff", "Wrong format for dataset"
+        assert (
+            _get_online_dataset_format(dataset.id) == "arff"
+        ), "Wrong format for dataset"
 
     def test_create_dataset_list(self):
         data = [
@@ -759,16 +778,23 @@ class TestOpenMLDataset(TestBase):
 
         dataset.publish()
         TestBase._mark_entity_for_removal("data", dataset.id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], dataset.id))
+        TestBase.logger.info(
+            "collected from {}: {}".format(__file__.split("/")[-1], dataset.id)
+        )
         assert (
             _get_online_dataset_arff(dataset.id) == dataset._dataset
         ), "Uploaded ARFF does not match original one"
-        assert _get_online_dataset_format(dataset.id) == "arff", "Wrong format for dataset"
+        assert (
+            _get_online_dataset_format(dataset.id) == "arff"
+        ), "Wrong format for dataset"
 
     def test_create_dataset_sparse(self):
         # test the scipy.sparse.coo_matrix
         sparse_data = scipy.sparse.coo_matrix(
-            ([0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], ([0, 1, 1, 2, 2, 3, 3], [0, 1, 2, 0, 2, 0, 1])),
+            (
+                [0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                ([0, 1, 1, 2, 2, 3, 3], [0, 1, 2, 0, 2, 0, 1]),
+            ),
         )
 
         column_names = [
@@ -914,7 +940,14 @@ class TestOpenMLDataset(TestBase):
             ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
             ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
         ]
-        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+        column_names = [
+            "rnd_str",
+            "outlook",
+            "temperature",
+            "humidity",
+            "windy",
+            "play",
+        ]
         df = pd.DataFrame(data, columns=column_names)
         # enforce the type of each column
         df["outlook"] = df["outlook"].astype("category")
@@ -950,19 +983,26 @@ class TestOpenMLDataset(TestBase):
         )
         dataset.publish()
         TestBase._mark_entity_for_removal("data", dataset.id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], dataset.id))
+        TestBase.logger.info(
+            "collected from {}: {}".format(__file__.split("/")[-1], dataset.id)
+        )
         assert (
             _get_online_dataset_arff(dataset.id) == dataset._dataset
         ), "Uploaded ARFF does not match original one"
 
         # Check that DataFrame with Sparse columns are supported properly
         sparse_data = scipy.sparse.coo_matrix(
-            ([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], ([0, 1, 1, 2, 2, 3, 3], [0, 1, 2, 0, 2, 0, 1])),
+            (
+                [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                ([0, 1, 1, 2, 2, 3, 3], [0, 1, 2, 0, 2, 0, 1]),
+            ),
         )
         column_names = ["input1", "input2", "y"]
         df = pd.DataFrame.sparse.from_spmatrix(sparse_data, columns=column_names)
         # meta-information
-        description = "Synthetic dataset created from a Pandas DataFrame with Sparse columns"
+        description = (
+            "Synthetic dataset created from a Pandas DataFrame with Sparse columns"
+        )
         dataset = openml.datasets.functions.create_dataset(
             name=name,
             description=description,
@@ -983,11 +1023,15 @@ class TestOpenMLDataset(TestBase):
         )
         dataset.publish()
         TestBase._mark_entity_for_removal("data", dataset.id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], dataset.id))
+        TestBase.logger.info(
+            "collected from {}: {}".format(__file__.split("/")[-1], dataset.id)
+        )
         assert (
             _get_online_dataset_arff(dataset.id) == dataset._dataset
         ), "Uploaded ARFF does not match original one"
-        assert _get_online_dataset_format(dataset.id) == "sparse_arff", "Wrong format for dataset"
+        assert (
+            _get_online_dataset_format(dataset.id) == "sparse_arff"
+        ), "Wrong format for dataset"
 
         # Check that we can overwrite the attributes
         data = [["a"], ["b"], ["c"], ["d"], ["e"]]
@@ -1015,9 +1059,13 @@ class TestOpenMLDataset(TestBase):
         )
         dataset.publish()
         TestBase._mark_entity_for_removal("data", dataset.id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], dataset.id))
+        TestBase.logger.info(
+            "collected from {}: {}".format(__file__.split("/")[-1], dataset.id)
+        )
         downloaded_data = _get_online_dataset_arff(dataset.id)
-        assert downloaded_data == dataset._dataset, "Uploaded ARFF does not match original one"
+        assert (
+            downloaded_data == dataset._dataset
+        ), "Uploaded ARFF does not match original one"
         assert "@ATTRIBUTE rnd_str {a, b, c, d, e, f, g}" in downloaded_data
 
     def test_ignore_attributes_dataset(self):
@@ -1028,7 +1076,14 @@ class TestOpenMLDataset(TestBase):
             ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
             ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
         ]
-        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+        column_names = [
+            "rnd_str",
+            "outlook",
+            "temperature",
+            "humidity",
+            "windy",
+            "play",
+        ]
         df = pd.DataFrame(data, columns=column_names)
         # enforce the type of each column
         df["outlook"] = df["outlook"].astype("category")
@@ -1122,7 +1177,14 @@ class TestOpenMLDataset(TestBase):
             ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
             ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
         ]
-        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+        column_names = [
+            "rnd_str",
+            "outlook",
+            "temperature",
+            "humidity",
+            "windy",
+            "play",
+        ]
         df = pd.DataFrame(data, columns=column_names)
         # enforce the type of each column
         df["outlook"] = df["outlook"].astype("category")
@@ -1164,14 +1226,18 @@ class TestOpenMLDataset(TestBase):
         # publish dataset
         dataset.publish()
         TestBase._mark_entity_for_removal("data", dataset.id)
-        TestBase.logger.info("collected from {}: {}".format(__file__.split("/")[-1], dataset.id))
+        TestBase.logger.info(
+            "collected from {}: {}".format(__file__.split("/")[-1], dataset.id)
+        )
         # test if publish was successful
         assert isinstance(dataset.id, int)
 
         downloaded_dataset = self._wait_for_dataset_being_processed(dataset.id)
         assert downloaded_dataset.ignore_attribute == ignore_attribute
 
-    def _wait_for_dataset_being_processed(self, dataset_id, poll_delay:int=10,max_waiting_time_seconds:int=600):
+    def _wait_for_dataset_being_processed(
+        self, dataset_id, poll_delay: int = 10, max_waiting_time_seconds: int = 600
+    ):
         start_time = time.time()
         while (time.time() - start_time) < max_waiting_time_seconds:
             try:
@@ -1346,7 +1412,9 @@ class TestOpenMLDataset(TestBase):
         cache_dir = openml.config.get_cache_directory()
         cache_dir_for_id = os.path.join(cache_dir, "datasets", "128")
         feather_file = os.path.join(cache_dir_for_id, "dataset.feather")
-        pickle_file = os.path.join(cache_dir_for_id, "dataset.feather.attributes.pkl.py3")
+        pickle_file = os.path.join(
+            cache_dir_for_id, "dataset.feather.attributes.pkl.py3"
+        )
         data = pd.read_feather(feather_file)
         assert os.path.isfile(feather_file), "Feather file is missing"
         assert os.path.isfile(pickle_file), "Attributes pickle file is missing"
@@ -1391,7 +1459,9 @@ class TestOpenMLDataset(TestBase):
         # for this, we need to first clone a dataset to do changes
         did = fork_dataset(1)
         self._wait_for_dataset_being_processed(did)
-        result = edit_dataset(did, default_target_attribute="shape", ignore_attribute="oil")
+        result = edit_dataset(
+            did, default_target_attribute="shape", ignore_attribute="oil"
+        )
         assert did == result
 
         n_tries = 10
@@ -1399,7 +1469,9 @@ class TestOpenMLDataset(TestBase):
         for i in range(n_tries):
             edited_dataset = openml.datasets.get_dataset(did)
             try:
-                assert edited_dataset.default_target_attribute == "shape", edited_dataset
+                assert (
+                    edited_dataset.default_target_attribute == "shape"
+                ), edited_dataset
                 assert edited_dataset.ignore_attribute == ["oil"], edited_dataset
                 break
             except AssertionError as e:
@@ -1408,7 +1480,9 @@ class TestOpenMLDataset(TestBase):
                 time.sleep(10)
                 # Delete the cache dir to get the newer version of the dataset
                 shutil.rmtree(
-                    os.path.join(self.workdir, "org", "openml", "test", "datasets", str(did)),
+                    os.path.join(
+                        self.workdir, "org", "openml", "test", "datasets", str(did)
+                    ),
                 )
 
     def test_data_edit_requires_field(self):
@@ -1423,7 +1497,6 @@ class TestOpenMLDataset(TestBase):
             data_id=64,  # blood-transfusion-service-center
         )
 
-
     def test_data_edit_requires_valid_dataset(self):
         # Check server exception when unknown dataset is provided
         self.assertRaisesRegex(
@@ -1433,7 +1506,6 @@ class TestOpenMLDataset(TestBase):
             data_id=999999,
             description="xor operation dataset",
         )
-
 
     def test_data_edit_cannot_edit_critical_field_if_dataset_has_task(self):
         # Need to own a dataset to be able to edit meta-data
@@ -1501,7 +1573,9 @@ class TestOpenMLDataset(TestBase):
         openml.config.server = self.production_server
 
         datasets_a = openml.datasets.list_datasets(output_format="dataframe")
-        datasets_b = openml.datasets.list_datasets(output_format="dataframe", size=np.inf)
+        datasets_b = openml.datasets.list_datasets(
+            output_format="dataframe", size=np.inf
+        )
 
         # Reverting to test server
         openml.config.server = self.test_server
@@ -1581,7 +1655,9 @@ def test_invalid_attribute_validations(
         (None, None, ["outlook", "windy"]),
     ],
 )
-def test_valid_attribute_validations(default_target_attribute, row_id_attribute, ignore_attribute):
+def test_valid_attribute_validations(
+    default_target_attribute, row_id_attribute, ignore_attribute
+):
     data = [
         ["a", "sunny", 85.0, 85.0, "FALSE", "no"],
         ["b", "sunny", 80.0, 90.0, "TRUE", "no"],
@@ -1632,7 +1708,14 @@ def test_valid_attribute_validations(default_target_attribute, row_id_attribute,
             ["d", "rainy", 70.0, 96.0, "FALSE", "yes"],
             ["e", "rainy", 68.0, 80.0, "FALSE", "yes"],
         ]
-        column_names = ["rnd_str", "outlook", "temperature", "humidity", "windy", "play"]
+        column_names = [
+            "rnd_str",
+            "outlook",
+            "temperature",
+            "humidity",
+            "windy",
+            "play",
+        ]
         df = pd.DataFrame(data, columns=column_names)
         # enforce the type of each column
         df["outlook"] = df["outlook"].astype("category")
@@ -1675,7 +1758,10 @@ def test_valid_attribute_validations(default_target_attribute, row_id_attribute,
 def test_delete_dataset_not_owned(mock_delete, test_files_directory, test_api_key):
     openml.config.start_using_configuration_for_example()
     content_file = (
-        test_files_directory / "mock_responses" / "datasets" / "data_delete_not_owned.xml"
+        test_files_directory
+        / "mock_responses"
+        / "datasets"
+        / "data_delete_not_owned.xml"
     )
     mock_delete.return_value = create_request_response(
         status_code=412,
@@ -1697,7 +1783,10 @@ def test_delete_dataset_not_owned(mock_delete, test_files_directory, test_api_ke
 def test_delete_dataset_with_run(mock_delete, test_files_directory, test_api_key):
     openml.config.start_using_configuration_for_example()
     content_file = (
-        test_files_directory / "mock_responses" / "datasets" / "data_delete_has_tasks.xml"
+        test_files_directory
+        / "mock_responses"
+        / "datasets"
+        / "data_delete_has_tasks.xml"
     )
     mock_delete.return_value = create_request_response(
         status_code=412,
@@ -1719,7 +1808,10 @@ def test_delete_dataset_with_run(mock_delete, test_files_directory, test_api_key
 def test_delete_dataset_success(mock_delete, test_files_directory, test_api_key):
     openml.config.start_using_configuration_for_example()
     content_file = (
-        test_files_directory / "mock_responses" / "datasets" / "data_delete_successful.xml"
+        test_files_directory
+        / "mock_responses"
+        / "datasets"
+        / "data_delete_successful.xml"
     )
     mock_delete.return_value = create_request_response(
         status_code=200,
@@ -1738,7 +1830,10 @@ def test_delete_dataset_success(mock_delete, test_files_directory, test_api_key)
 def test_delete_unknown_dataset(mock_delete, test_files_directory, test_api_key):
     openml.config.start_using_configuration_for_example()
     content_file = (
-        test_files_directory / "mock_responses" / "datasets" / "data_delete_not_exist.xml"
+        test_files_directory
+        / "mock_responses"
+        / "datasets"
+        / "data_delete_not_exist.xml"
     )
     mock_delete.return_value = create_request_response(
         status_code=412,
@@ -1775,7 +1870,9 @@ def test_list_datasets(all_datasets: pd.DataFrame):
 
 
 def test_list_datasets_by_tag(all_datasets: pd.DataFrame):
-    tag_datasets = openml.datasets.list_datasets(tag="study_14", output_format="dataframe")
+    tag_datasets = openml.datasets.list_datasets(
+        tag="study_14", output_format="dataframe"
+    )
     assert 0 < len(tag_datasets) < len(all_datasets)
     _assert_datasets_have_id_and_valid_status(tag_datasets)
 
@@ -1833,25 +1930,35 @@ def test_list_datasets_combined_filters(all_datasets: pd.DataFrame):
     _assert_datasets_have_id_and_valid_status(combined_filter_datasets)
 
 
-def _dataset_file_is_downloaded( did: int, file: str):
+def _dataset_file_is_downloaded(did: int, file: str):
     cache_directory = Path(openml.config.get_cache_directory()) / "datasets" / str(did)
     return (cache_directory / file).exists()
 
-def _dataset_description_is_downloaded( did: int):
+
+def _dataset_description_is_downloaded(did: int):
     return _dataset_file_is_downloaded(did, "description.xml")
 
-def _dataset_qualities_is_downloaded( did: int):
+
+def _dataset_qualities_is_downloaded(did: int):
     return _dataset_file_is_downloaded(did, "qualities.xml")
 
-def _dataset_features_is_downloaded( did: int):
+
+def _dataset_features_is_downloaded(did: int):
     return _dataset_file_is_downloaded(did, "features.xml")
 
-def _dataset_data_file_is_downloaded( did: int):
+
+def _dataset_data_file_is_downloaded(did: int):
     parquet_present = _dataset_file_is_downloaded(did, "dataset.pq")
     arff_present = _dataset_file_is_downloaded(did, "dataset.arff")
     return parquet_present or arff_present
 
-def _assert_datasets_retrieved_successfully( dids: Iterable[int], with_qualities:bool=False, with_features:bool=False, with_data:bool=False):
+
+def _assert_datasets_retrieved_successfully(
+    dids: Iterable[int],
+    with_qualities: bool = False,
+    with_features: bool = False,
+    with_data: bool = False,
+):
     """Checks that all files for the given dids have been downloaded.
 
     This includes:
@@ -1872,6 +1979,7 @@ def _assert_datasets_retrieved_successfully( dids: Iterable[int], with_qualities
         has_data = _dataset_data_file_is_downloaded(did)
         assert has_data if with_data else not has_data
 
+
 @pytest.fixture()
 def isolate_for_test():
     t = TestOpenMLDataset()
@@ -1881,18 +1989,36 @@ def isolate_for_test():
 
 
 @pytest.mark.parametrize(
-    "with_data, with_qualities, with_features",
-    itertools.product([True, False], repeat=3)
+    ("with_data", "with_qualities", "with_features"),
+    itertools.product([True, False], repeat=3),
 )
-def test_get_dataset_lazy_behavior(isolate_for_test, with_data: bool, with_qualities: bool, with_features: bool):
-    dataset = openml.datasets.get_dataset(1, download_data=with_data, download_qualities=with_qualities, download_features_meta_data=with_features)
+def test_get_dataset_lazy_behavior(
+    isolate_for_test, with_data: bool, with_qualities: bool, with_features: bool
+):
+    dataset = openml.datasets.get_dataset(
+        1,
+        download_data=with_data,
+        download_qualities=with_qualities,
+        download_features_meta_data=with_features,
+    )
     assert type(dataset) == OpenMLDataset
     assert dataset.name == "anneal"
 
-    _assert_datasets_retrieved_successfully([1], with_qualities=with_qualities,
-                                            with_features=with_features, with_data=with_data)
-    assert dataset.features, "Features should be downloaded on-demand if not during get_dataset"
-    assert dataset.qualities, "Qualities should be downloaded on-demand if not during get_dataset"
-    assert dataset.get_data(), "Data should be downloaded on-demand if not during get_dataset"
-    _assert_datasets_retrieved_successfully([1], with_qualities=True,
-                                            with_features=True, with_data=True)
+    _assert_datasets_retrieved_successfully(
+        [1],
+        with_qualities=with_qualities,
+        with_features=with_features,
+        with_data=with_data,
+    )
+    assert (
+        dataset.features
+    ), "Features should be downloaded on-demand if not during get_dataset"
+    assert (
+        dataset.qualities
+    ), "Qualities should be downloaded on-demand if not during get_dataset"
+    assert (
+        dataset.get_data()
+    ), "Data should be downloaded on-demand if not during get_dataset"
+    _assert_datasets_retrieved_successfully(
+        [1], with_qualities=True, with_features=True, with_data=True
+    )

--- a/tests/test_datasets/test_dataset_functions.py
+++ b/tests/test_datasets/test_dataset_functions.py
@@ -249,15 +249,6 @@ class TestOpenMLDataset(TestBase):
         assert len(dataset.features) > 1
         assert len(dataset.qualities) > 4
 
-    def test_get_dataset_by_id(self):
-        dataset = openml.datasets.get_dataset(1, download_data=True)
-        assert type(dataset) == OpenMLDataset
-        assert dataset.name == "anneal"
-        _assert_datasets_retrieved_successfully([1], with_data=True)
-
-        assert len(dataset.features) > 1
-        assert len(dataset.qualities) > 4
-
     @pytest.mark.skip("Feature is experimental, can not test against stable server.")
     def test_get_dataset_download_all_files(self):
         # openml.datasets.get_dataset(id, download_all_files=True)

--- a/tests/test_openml/test_config.py
+++ b/tests/test_openml/test_config.py
@@ -49,8 +49,9 @@ class TestConfig(openml.testing.TestBase):
         _config["avoid_duplicate_runs"] = False
         _config["connection_n_retries"] = 20
         _config["retry_policy"] = "robot"
+        _config["show_progress"] = False
         assert isinstance(config, dict)
-        assert len(config) == 6
+        assert len(config) == 7
         self.assertDictEqual(config, _config)
 
     def test_setup_with_config(self):
@@ -62,6 +63,7 @@ class TestConfig(openml.testing.TestBase):
         _config["avoid_duplicate_runs"] = True
         _config["retry_policy"] = "human"
         _config["connection_n_retries"] = 100
+        _config["show_progress"] = False
         orig_config = openml.config.get_config_as_dict()
         openml.config._setup(_config)
         updated_config = openml.config.get_config_as_dict()

--- a/tests/test_tasks/test_task_functions.py
+++ b/tests/test_tasks/test_task_functions.py
@@ -149,7 +149,7 @@ class TestTask(TestBase):
         openml.tasks.get_task(34536)
 
     def test_get_task(self):
-        task = openml.tasks.get_task(1)  # anneal; crossvalidation
+        task = openml.tasks.get_task(1, download_data=True)  # anneal; crossvalidation
         assert isinstance(task, OpenMLTask)
         assert os.path.exists(
             os.path.join(self.workdir, "org", "openml", "test", "tasks", "1", "task.xml")


### PR DESCRIPTION
Turn on lazy loading by default for datasets.
Leaving tasks for a separate PR as I notice the diff is getting big since I made some additional changes to the tests.
So only progress for #1034.

I couldn't clean up everything, but I tried to clean things up a little bit.
The use of parametrize required me to work outside of the unittest class. 
I tried to still make behavior similar as possible so its easier that they're not doing wildly different things (I do think that a lot of the setup/teardown that come with the general behavior isn't really needed though).
