### PR TITLE
ux: Provide helpful link to documentation when error due to missing API token

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -10,9 +10,10 @@ import os
 import platform
 import shutil
 import warnings
+from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Iterator, cast
 from typing_extensions import Literal, TypedDict
 from urllib.parse import urlparse
 
@@ -495,6 +496,18 @@ start_using_configuration_for_example = (
     ConfigurationForExamples.start_using_configuration_for_example
 )
 stop_using_configuration_for_example = ConfigurationForExamples.stop_using_configuration_for_example
+
+
+@contextmanager
+def set_context(config: dict[str, Any]) -> Iterator[_Config]:
+    """A context manager to temporarily override variables in the configuration."""
+    existing_config = get_config_as_dict()
+    merged_config = {**existing_config, **config}
+
+    _setup(merged_config)  # type: ignore
+    yield merged_config  # type: ignore
+
+    _setup(existing_config)
 
 
 __all__ = [

--- a/openml/config.py
+++ b/openml/config.py
@@ -175,11 +175,11 @@ def get_server_base_url() -> str:
 apikey: str = _defaults["apikey"]
 show_progress: bool = _defaults["show_progress"]
 # The current cache directory (without the server name)
-_root_cache_directory = Path(_defaults["cachedir"])
+_root_cache_directory: Path = Path(_defaults["cachedir"])
 avoid_duplicate_runs = _defaults["avoid_duplicate_runs"]
 
-retry_policy = _defaults["retry_policy"]
-connection_n_retries = _defaults["connection_n_retries"]
+retry_policy: Literal["human", "robot"] = _defaults["retry_policy"]
+connection_n_retries: int = _defaults["connection_n_retries"]
 
 
 def set_retry_policy(value: Literal["human", "robot"], n_retries: int | None = None) -> None:

--- a/openml/config.py
+++ b/openml/config.py
@@ -499,7 +499,7 @@ stop_using_configuration_for_example = ConfigurationForExamples.stop_using_confi
 
 
 @contextmanager
-def set_context(config: dict[str, Any]) -> Iterator[_Config]:
+def overwrite_config_context(config: dict[str, Any]) -> Iterator[_Config]:
     """A context manager to temporarily override variables in the configuration."""
     existing_config = get_config_as_dict()
     merged_config = {**existing_config, **config}

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -461,12 +461,10 @@ def list_evaluations_setups(
                 )
             else:
                 parameters.append({})
-        print(parameters)  # noqa: T201
         setup_data["parameters"] = parameters
         # Merge setups with evaluations
         _df = evals.merge(setup_data, on="setup_id", how="left")
 
-    print(_df)  # noqa: T201
     if parameters_in_separate_columns:
         _df = pd.concat(
             [_df.drop("parameters", axis=1), _df["parameters"].apply(pd.Series)],

--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -461,10 +461,12 @@ def list_evaluations_setups(
                 )
             else:
                 parameters.append({})
+        print(parameters)  # noqa: T201
         setup_data["parameters"] = parameters
         # Merge setups with evaluations
         _df = evals.merge(setup_data, on="setup_id", how="left")
 
+    print(_df)  # noqa: T201
     if parameters_in_separate_columns:
         _df = pd.concat(
             [_df.drop("parameters", axis=1), _df["parameters"].apply(pd.Series)],

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -234,7 +234,7 @@ def _delete_entity(entity_type: str, entity_id: int) -> bool:
                     " please open an issue at: https://github.com/openml/openml/issues/new"
                 ),
             ) from e
-        raise
+        raise e
 
 
 @overload

--- a/tests/test_evaluations/test_evaluations_example.py
+++ b/tests/test_evaluations/test_evaluations_example.py
@@ -3,35 +3,47 @@ from __future__ import annotations
 
 import unittest
 
+from openml.config import overwrite_config_context
+
 
 class TestEvaluationsExample(unittest.TestCase):
     def test_example_python_paper(self):
         # Example script which will appear in the upcoming OpenML-Python paper
         # This test ensures that the example will keep running!
+        with overwrite_config_context(
+            {
+                "server": "https://www.openml.org/api/v1/xml",
+                "apikey": None,
+            }
+        ):
+            import matplotlib.pyplot as plt
+            import numpy as np
 
-        import matplotlib.pyplot as plt
-        import numpy as np
+            import openml
 
-        import openml
+            df = openml.evaluations.list_evaluations_setups(
+                "predictive_accuracy",
+                flows=[8353],
+                tasks=[6],
+                output_format="dataframe",
+                parameters_in_separate_columns=True,
+            )  # Choose an SVM flow, for example 8353, and a task.
 
-        df = openml.evaluations.list_evaluations_setups(
-            "predictive_accuracy",
-            flows=[8353],
-            tasks=[6],
-            output_format="dataframe",
-            parameters_in_separate_columns=True,
-        )  # Choose an SVM flow, for example 8353, and a task.
+            assert len(df) > 0, (
+                "No evaluation found for flow 8353 on task 6, could "
+                "be that this task is not available on the test server."
+            )
 
-        hp_names = ["sklearn.svm.classes.SVC(16)_C", "sklearn.svm.classes.SVC(16)_gamma"]
-        df[hp_names] = df[hp_names].astype(float).apply(np.log)
-        C, gamma, score = df[hp_names[0]], df[hp_names[1]], df["value"]
+            hp_names = ["sklearn.svm.classes.SVC(16)_C", "sklearn.svm.classes.SVC(16)_gamma"]
+            df[hp_names] = df[hp_names].astype(float).apply(np.log)
+            C, gamma, score = df[hp_names[0]], df[hp_names[1]], df["value"]
 
-        cntr = plt.tricontourf(C, gamma, score, levels=12, cmap="RdBu_r")
-        plt.colorbar(cntr, label="accuracy")
-        plt.xlim((min(C), max(C)))
-        plt.ylim((min(gamma), max(gamma)))
-        plt.xlabel("C (log10)", size=16)
-        plt.ylabel("gamma (log10)", size=16)
-        plt.title("SVM performance landscape", size=20)
+            cntr = plt.tricontourf(C, gamma, score, levels=12, cmap="RdBu_r")
+            plt.colorbar(cntr, label="accuracy")
+            plt.xlim((min(C), max(C)))
+            plt.ylim((min(gamma), max(gamma)))
+            plt.xlabel("C (log10)", size=16)
+            plt.ylabel("gamma (log10)", size=16)
+            plt.title("SVM performance landscape", size=20)
 
-        plt.tight_layout()
+            plt.tight_layout()

--- a/tests/test_openml/test_api_calls.py
+++ b/tests/test_openml/test_api_calls.py
@@ -9,6 +9,7 @@ import minio
 import pytest
 
 import openml
+from openml.config import ConfigurationForExamples
 import openml.testing
 from openml._api_calls import _download_minio_bucket, API_TOKEN_HELP_LINK
 
@@ -118,5 +119,7 @@ def test_authentication_endpoints_requiring_api_key_show_relevant_help_link(
     endpoint: str,
     method: str,
 ) -> None:
-    with pytest.raises(openml.exceptions.OpenMLNotAuthorizedError, match=API_TOKEN_HELP_LINK) as e:
-        openml._api_calls._perform_api_call(call=endpoint, request_method=method, data=None)
+    # We need to temporarily disable the API key to test the error message
+    with openml.config.set_context({"apikey": None}):
+        with pytest.raises(openml.exceptions.OpenMLNotAuthorizedError, match=API_TOKEN_HELP_LINK):
+            openml._api_calls._perform_api_call(call=endpoint, request_method=method, data=None)

--- a/tests/test_openml/test_api_calls.py
+++ b/tests/test_openml/test_api_calls.py
@@ -120,6 +120,6 @@ def test_authentication_endpoints_requiring_api_key_show_relevant_help_link(
     method: str,
 ) -> None:
     # We need to temporarily disable the API key to test the error message
-    with openml.config.set_context({"apikey": None}):
+    with openml.config.overwrite_config_context({"apikey": None}):
         with pytest.raises(openml.exceptions.OpenMLNotAuthorizedError, match=API_TOKEN_HELP_LINK):
             openml._api_calls._perform_api_call(call=endpoint, request_method=method, data=None)

--- a/tests/test_openml/test_api_calls.py
+++ b/tests/test_openml/test_api_calls.py
@@ -10,7 +10,7 @@ import pytest
 
 import openml
 import openml.testing
-from openml._api_calls import _download_minio_bucket
+from openml._api_calls import _download_minio_bucket, API_TOKEN_HELP_LINK
 
 
 class TestConfig(openml.testing.TestBase):
@@ -99,3 +99,24 @@ def test_download_minio_failure(mock_minio, tmp_path: Path) -> None:
 
     with pytest.raises(ValueError):
         _download_minio_bucket(source=some_url, destination=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "endpoint, method",
+    [
+        # https://github.com/openml/OpenML/blob/develop/openml_OS/views/pages/api_new/v1/xml/pre.php
+        ("flow/exists", "post"),  # 102
+        ("dataset", "post"),  # 137
+        ("dataset/42", "delete"),  # 350
+        # ("flow/owned", "post"),  # 310 - Couldn't find what would trigger this
+        ("flow/42", "delete"),  # 320
+        ("run/42", "delete"),  # 400
+        ("task/42", "delete"),  # 460
+    ],
+)
+def test_authentication_endpoints_requiring_api_key_show_relevant_help_link(
+    endpoint: str,
+    method: str,
+) -> None:
+    with pytest.raises(openml.exceptions.OpenMLNotAuthorizedError, match=API_TOKEN_HELP_LINK) as e:
+        openml._api_calls._perform_api_call(call=endpoint, request_method=method, data=None)

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -8,37 +8,6 @@ import openml
 from openml.testing import _check_dataset
 
 
-@pytest.fixture(autouse=True)
-def as_robot():
-    policy = openml.config.retry_policy
-    n_retries = openml.config.connection_n_retries
-    openml.config.set_retry_policy("robot", n_retries=20)
-    yield
-    openml.config.set_retry_policy(policy, n_retries)
-
-
-@pytest.fixture(autouse=True)
-def with_test_server():
-    openml.config.start_using_configuration_for_example()
-    yield
-    openml.config.stop_using_configuration_for_example()
-
-
-@pytest.fixture(autouse=True)
-def with_test_cache(test_files_directory, request):
-    if not test_files_directory.exists():
-        raise ValueError(
-            f"Cannot find test cache dir, expected it to be {test_files_directory!s}!",
-        )
-    _root_cache_directory = openml.config._root_cache_directory
-    tmp_cache = test_files_directory / request.node.name
-    openml.config.set_root_cache_directory(tmp_cache)
-    yield
-    openml.config.set_root_cache_directory(_root_cache_directory)
-    if tmp_cache.exists():
-        shutil.rmtree(tmp_cache)
-
-
 @pytest.fixture()
 def min_number_tasks_on_test_server() -> int:
     """After a reset at least 1068 tasks are on the test server"""


### PR DESCRIPTION
* Closes #1089 

Simply provides a direct link to the following whenever there is an error with a [specific code](https://github.com/openml/OpenML/blob/develop/openml_OS/views/pages/api_new/v1/xml/pre.php) (search "provide API key") when requesting to an endpoint.

Link given: https://openml.github.io/openml-python/main/examples/20_basic/introduction_tutorial.html#authentication


---

EDIT: Also found out that some `autouse` fixtures were not being triggered if `pytest` was only being called on a particular file. I moved these `autouse` fixtures into `tests/conftest.py` which means they will now be triggered.

Also I required temporarily disabling the `"apikey"` in the config, hence there was a small context manager added to enable this behaviour.