### PR TITLE
test: pytest scope to be function as tests might change server

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,7 +263,7 @@ def as_robot() -> Iterator[None]:
     openml.config.set_retry_policy(policy, n_retries)
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="function")
 def with_test_server():
     openml.config.start_using_configuration_for_example()
     yield


### PR DESCRIPTION
To make sure that each test runs on the test server by default, we need to change the scope to "function," as another test might overwrite this otherwise.

@eddiebergman Was there a reasons to set this to session?  