### PR TITLE
Mark test as production

### DIFF
--- a/tests/test_setups/test_setup_functions.py
+++ b/tests/test_setups/test_setup_functions.py
@@ -115,6 +115,7 @@ class TestSetupFunctions(TestBase):
             ),
         )
 
+    @pytest.mark.production()
     def test_get_setup(self):
         # no setups in default test server
         openml.config.server = "https://www.openml.org/api/v1/xml/"


### PR DESCRIPTION
Turns out I already pretty exhaustively marked tests using the production server before, but this one was forgotten (useful for #1378). 