### PR TITLE
Hotfix/arff

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -23,6 +23,7 @@ console_handler: logging.StreamHandler | None = None
 file_handler: logging.handlers.RotatingFileHandler | None = None
 
 OPENML_CACHE_DIR_ENV_VAR = "OPENML_CACHE_DIR"
+OPENML_SKIP_PARQUET_ENV_VAR = "OPENML_SKIP_PARQUET"
 
 
 class _Config(TypedDict):

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -18,6 +18,7 @@ import scipy.sparse
 import xmltodict
 
 from openml.base import OpenMLBase
+from openml.config import OPENML_SKIP_PARQUET_ENV_VAR
 from openml.exceptions import PyOpenMLError
 
 from .data_feature import OpenMLDataFeature
@@ -359,7 +360,7 @@ class OpenMLDataset(OpenMLBase):
         # import required here to avoid circular import.
         from .functions import _get_dataset_arff, _get_dataset_parquet
 
-        skip_parquet = os.environ.get("OPENML_SKIP_PQ", "false").casefold() == "true"
+        skip_parquet = os.environ.get(OPENML_SKIP_PARQUET_ENV_VAR, "false").casefold() == "true"
         if self._parquet_url is not None and not skip_parquet:
             parquet_file = _get_dataset_parquet(self)
             self.parquet_file = None if parquet_file is None else str(parquet_file)

--- a/openml/datasets/dataset.py
+++ b/openml/datasets/dataset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import gzip
 import logging
+import os
 import pickle
 import re
 import warnings
@@ -358,8 +359,10 @@ class OpenMLDataset(OpenMLBase):
         # import required here to avoid circular import.
         from .functions import _get_dataset_arff, _get_dataset_parquet
 
-        if self._parquet_url is not None:
-            self.parquet_file = str(_get_dataset_parquet(self))
+        skip_parquet = os.environ.get("OPENML_SKIP_PQ", "false").casefold() == "true"
+        if self._parquet_url is not None and not skip_parquet:
+            parquet_file = _get_dataset_parquet(self)
+            self.parquet_file = None if parquet_file is None else str(parquet_file)
         if self.parquet_file is None:
             self.data_file = str(_get_dataset_arff(self))
 

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -21,6 +21,7 @@ from scipy.sparse import coo_matrix
 
 import openml._api_calls
 import openml.utils
+from openml.config import OPENML_SKIP_PARQUET_ENV_VAR
 from openml.exceptions import (
     OpenMLHashException,
     OpenMLPrivateDatasetError,
@@ -562,7 +563,7 @@ def get_dataset(  # noqa: C901, PLR0912
             qualities_file = _get_dataset_qualities_file(did_cache_dir, dataset_id)
 
         parquet_file = None
-        skip_parquet = os.environ.get("OPENML_SKIP_PQ", "false").casefold() == "true"
+        skip_parquet = os.environ.get(OPENML_SKIP_PARQUET_ENV_VAR, "false").casefold() == "true"
         download_parquet = "oml:parquet_url" in description and not skip_parquet
         if download_parquet and (download_data or download_all_files):
             try:


### PR DESCRIPTION
This introduces a backdoor for disabling attempting to download parquet files through the `OPENML_SKIP_PQ` variable.
If `OPENML_SKIP_PQ` is set to `true` (case insensitive), then parquet files will not be downloaded in the `get_dataset` and `OpenMLDataset.get_data` calls.

The PR also fixes a bug where an error would be raised if the parquet file failed to download. The `str(_get_dataset_parquet_file(self))` would return `None` if it failed to download, but by converting it to a string the next check is always false and thus it would not fall back to arff.

The reason for using an environment variable:
 - It's a bit quicker to implement than a configuration option, and it makes it easier to turn it on for a single call.
 - Compared to adding function arguments, the environment variable (or configuration option) don't need changes to existing scripts. Making it easier for people to start using it now, and stop using it later. We can issue a warning if the environment variable remains set in a later release.