### PR TITLE
Change default server, fix bug writing config to file

### DIFF
--- a/openml/config.py
+++ b/openml/config.py
@@ -148,7 +148,7 @@ def _resolve_default_cache_dir() -> Path:
 
 _defaults: _Config = {
     "apikey": "",
-    "server": "https://www.openml.org/api/v1/xml",
+    "server": "https://api.openml.org/api/v1/xml",
     "cachedir": _resolve_default_cache_dir(),
     "avoid_duplicate_runs": True,
     "retry_policy": "human",
@@ -164,13 +164,15 @@ server = _defaults["server"]
 def get_server_base_url() -> str:
     """Return the base URL of the currently configured server.
 
-    Turns ``"https://www.openml.org/api/v1/xml"`` in ``"https://www.openml.org/"``
+    Turns ``"https://api.openml.org/api/v1/xml"`` in ``"https://www.openml.org/"``
+    and ``"https://test.openml.org/api/v1/xml"`` in ``"https://test.openml.org/"``
 
     Returns
     -------
     str
     """
-    return server.split("/api")[0]
+    domain, path = server.split("/api", maxsplit=1)
+    return domain.replace("api", "www")
 
 
 apikey: str = _defaults["apikey"]
@@ -400,10 +402,9 @@ def set_field_in_config_file(field: str, value: Any) -> None:
             # There doesn't seem to be a way to avoid writing defaults to file with configparser,
             # because it is impossible to distinguish from an explicitly set value that matches
             # the default value, to one that was set to its default because it was omitted.
-            value = config.get("FAKE_SECTION", f)  # type: ignore
-            if f == field:
-                value = globals()[f]
-            fh.write(f"{f} = {value}\n")
+            value = globals()[f] if f == field else config.get(f)  # type: ignore
+            if value is not None:
+                fh.write(f"{f} = {value}\n")
 
 
 def _parse_config(config_file: str | Path) -> _Config:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* this pull requests is against the `develop` branch
* you updated all docs, this includes the changelog (doc/progress.rst)
* for any new function or class added, please add it to doc/api.rst
    * the list of classes and functions should be alphabetical 
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Reference Issue
<!-- Example: Fixes #1234 -->
None, recent issues with proxy.

#### What does this PR implement/fix? Explain your changes.
Sets the default url to use the `api` subdomain, which avoids a layer of indirection and subsequently should be stable.
It also fixes an issue with the CLI tool so that it's possible again to set variables through it.

#### How should this PR be tested?
Affects all endpoints. Not really that suitable for manual testing.

#### Any other comments?

