### PR TITLE
Clarify dataset_id docstring in get_dataset (fixes #1066)

### DIFF
--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -479,7 +479,7 @@ def get_dataset(  # noqa: C901, PLR0912
     Parameters
     ----------
     dataset_id : int or str
-        The ID or name of the dataset to download.
+    Dataset ID (integer) or dataset name (string) of the dataset to download.
     download_data : bool (default=False)
         If True, also download the data file. Beware that some datasets are large and it might
         make the operation noticeably slower. Metadata is also still retrieved.

--- a/openml/datasets/functions.py
+++ b/openml/datasets/functions.py
@@ -479,7 +479,7 @@ def get_dataset(  # noqa: C901, PLR0912
     Parameters
     ----------
     dataset_id : int or str
-    Dataset ID (integer) or dataset name (string) of the dataset to download.
+        Dataset ID (integer) or dataset name (string) of the dataset to download.
     download_data : bool (default=False)
         If True, also download the data file. Beware that some datasets are large and it might
         make the operation noticeably slower. Metadata is also still retrieved.


### PR DESCRIPTION
This pull request updates the docstring of the get_dataset function in openml/datasets/functions.py to clarify that the dataset_id parameter can be either:

an integer ID (e.g., 61), or

a dataset name as a string (e.g., "iris").

This improves clarity for users reading the documentation and aligns with the function's actual behavior.

Related Issue
Fixes #1066

