### PR TITLE
maint: docu for split object

### DIFF
--- a/openml/tasks/split.py
+++ b/openml/tasks/split.py
@@ -21,11 +21,18 @@ class Split(NamedTuple):
 class OpenMLSplit:
     """OpenML Split object.
 
+    This class manages train-test splits for a dataset across multiple
+    repetitions, folds, and samples.
+
     Parameters
     ----------
     name : int or str
+        The name or ID of the split.
     description : str
+        A description of the split.
     split : dict
+        A dictionary containing the splits organized by repetition, fold,
+        and sample.
     """
 
     def __init__(


### PR DESCRIPTION
Add more documentation to the split object.

Rel.: #1385
