### PR TITLE
Migrate test_extensions to pytest

### DIFF
--- a/tests/test_extensions/test_functions.py
+++ b/tests/test_extensions/test_functions.py
@@ -5,7 +5,7 @@ import inspect
 
 import pytest
 
-import openml.testing
+import openml
 from openml.extensions import get_extension_by_flow, get_extension_by_model, register_extension
 
 
@@ -59,35 +59,38 @@ def _unregister():
             break
 
 
-class TestInit(openml.testing.TestBase):
-    def setUp(self):
-        super().setUp()
-        _unregister()
+@pytest.fixture()
+def clean_test_extensions():
+    _unregister()
+    yield
+    _unregister()
 
-    def test_get_extension_by_flow(self):
-        assert get_extension_by_flow(DummyFlow()) is None
-        with pytest.raises(ValueError, match="No extension registered which can handle flow:"):
-            get_extension_by_flow(DummyFlow(), raise_if_no_extension=True)
-        register_extension(DummyExtension1)
-        assert isinstance(get_extension_by_flow(DummyFlow()), DummyExtension1)
-        register_extension(DummyExtension2)
-        assert isinstance(get_extension_by_flow(DummyFlow()), DummyExtension1)
-        register_extension(DummyExtension1)
-        with pytest.raises(
-            ValueError, match="Multiple extensions registered which can handle flow:"
-        ):
-            get_extension_by_flow(DummyFlow())
 
-    def test_get_extension_by_model(self):
-        assert get_extension_by_model(DummyModel()) is None
-        with pytest.raises(ValueError, match="No extension registered which can handle model:"):
-            get_extension_by_model(DummyModel(), raise_if_no_extension=True)
-        register_extension(DummyExtension1)
-        assert isinstance(get_extension_by_model(DummyModel()), DummyExtension1)
-        register_extension(DummyExtension2)
-        assert isinstance(get_extension_by_model(DummyModel()), DummyExtension1)
-        register_extension(DummyExtension1)
-        with pytest.raises(
-            ValueError, match="Multiple extensions registered which can handle model:"
-        ):
-            get_extension_by_model(DummyModel())
+def test_get_extension_by_flow(clean_test_extensions):
+    assert get_extension_by_flow(DummyFlow()) is None
+    with pytest.raises(ValueError, match="No extension registered which can handle flow:"):
+        get_extension_by_flow(DummyFlow(), raise_if_no_extension=True)
+    register_extension(DummyExtension1)
+    assert isinstance(get_extension_by_flow(DummyFlow()), DummyExtension1)
+    register_extension(DummyExtension2)
+    assert isinstance(get_extension_by_flow(DummyFlow()), DummyExtension1)
+    register_extension(DummyExtension1)
+    with pytest.raises(
+        ValueError, match="Multiple extensions registered which can handle flow:"
+    ):
+        get_extension_by_flow(DummyFlow())
+
+
+def test_get_extension_by_model(clean_test_extensions):
+    assert get_extension_by_model(DummyModel()) is None
+    with pytest.raises(ValueError, match="No extension registered which can handle model:"):
+        get_extension_by_model(DummyModel(), raise_if_no_extension=True)
+    register_extension(DummyExtension1)
+    assert isinstance(get_extension_by_model(DummyModel()), DummyExtension1)
+    register_extension(DummyExtension2)
+    assert isinstance(get_extension_by_model(DummyModel()), DummyExtension1)
+    register_extension(DummyExtension1)
+    with pytest.raises(
+        ValueError, match="Multiple extensions registered which can handle model:"
+    ):
+        get_extension_by_model(DummyModel())


### PR DESCRIPTION
#### Metadata
* Reference Issue: Part of https://github.com/openml/openml-python/issues/1252
* New Tests Added: Yes (migrate existing tests to pytest style)  
* Documentation Updated: No
* Change Log Entry: “Migrate test_extensions/test_functions.py to pytest-style tests”


#### Details 
- This PR migrates test_functions.py from `unittest.TestCase`-based tests (`openml.testing.TestBase`) to pure pytest-style tests.  
- It replaces the class-based `TestInit` with module-level test functions and introduces a small pytest fixture to manage the registration state of dummy extensions used in the tests.  
- The new `clean_test_extensions` fixture calls the existing `_unregister()` helper before and after each test, ensuring the global extension registry is not polluted across tests.  
- Assertions continue to use `assert` and `pytest.raises`, consistent with the style already used in test_utils.py.  
- No functional changes to the OpenML extensions API are introduced; only the test implementation is refactored.

