### PR TITLE
labeler.yml workflow added

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,155 @@
+# Configuration for automated PR labeling
+# Labels are applied based on file paths changed in pull requests
+
+# Documentation
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**/*'
+      - '**/*.md'
+      - '**/*.rst'
+      - 'README.*'
+      - 'mkdocs.yml'
+
+# Dependencies
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - 'setup.py'
+      - 'setup.cfg'
+      - 'Pipfile'
+      - 'Pipfile.lock'
+      - 'poetry.lock'
+
+# Frontend (if applicable)
+frontend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**/*.css'
+      - 'docs/**/*.js'
+      - 'docs/**/*.html'
+      - 'docs/stylesheets/**/*'
+
+# Backend/Core
+backend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'openml/**/*.py'
+      - '!openml/**/test_*.py'
+      - '!tests/**/*'
+
+# Database (data-related modules)
+database:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'openml/datasets/**/*'
+      - 'openml/tasks/**/*'
+
+# Docker
+docker:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docker/**/*'
+      - '**/Dockerfile'
+      - '**/.dockerignore'
+      - 'docker-compose*.yml'
+
+# CI/CD
+ci-cd:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**/*'
+      - '.github/workflows/**/*'
+      - '.gitlab-ci.yml'
+      - '.circleci/**/*'
+      - 'Makefile'
+
+# API
+api:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'openml/_api_calls.py'
+      - 'openml/base.py'
+      - 'openml/**/functions.py'
+
+# Security
+security:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/security/**/*'
+      - '**/*security*.py'
+      - '.github/workflows/codeql*.yml'
+
+# Tests
+tests:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tests/**/*'
+      - '**/test_*.py'
+      - '**/*_test.py'
+      - 'conftest.py'
+
+# Configuration
+configuration:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'openml/config.py'
+      - '**/*.cfg'
+      - '**/*.conf'
+      - '**/*.ini'
+      - '**/*.json'
+      - '**/*.yaml'
+      - '**/*.yml'
+      - '!.github/**/*'
+
+# Examples
+examples:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/**/*'
+
+# Module-specific labels
+datasets:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/datasets/**/*'
+
+evaluations:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/evaluations/**/*'
+
+extensions:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/extensions/**/*'
+
+flows:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/flows/**/*'
+
+runs:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/runs/**/*'
+
+setups:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/setups/**/*'
+
+study:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/study/**/*'
+
+tasks:
+  - changed-files:
+    - any-glob-to-any-file: 'openml/tasks/**/*'
+
+# Build and packaging
+build:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'setup.cfg'
+      - 'MANIFEST.in'
+      - 'Makefile'
+      - '.github/workflows/dist.yaml'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,48 @@
+name: Pull Request Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Label PRs based on changed file paths
+      - name: Label PRs based on file paths
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
+      # Step 2: Label PRs by size
+      - name: Label PR by size
+        uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: 10
+          s_label: 'size/s'
+          s_max_size: 100
+          m_label: 'size/m'
+          m_max_size: 500
+          l_label: 'size/l'
+          l_max_size: 1000
+          xl_label: 'size/xl'
+          fail_if_xl: false
+          message_if_xl: >
+            ⚠️ This PR is quite large (over 1000 lines changed). 
+            Consider breaking it down into smaller, focused PRs for easier review and maintenance.
+          files_to_ignore: |
+            *.md
+            *.txt
+            *.json
+            *.lock
+            tests/**
+            docs/**
+            examples/**


### PR DESCRIPTION
Fixes: #1467 

This pull request introduces automated labeling for pull requests using GitHub Actions. The changes make it easier to categorize and track PRs by applying labels based on file paths and PR size.

**Automated PR labeling:**

* Added `.github/labeler.yml` to define label rules based on file paths, including categories like documentation, dependencies, frontend, backend, database, docker, CI/CD, API, security, tests, and configuration.
* Created `.github/workflows/labeler.yml` workflow to automatically apply labels to PRs using the defined rules whenever a PR is opened, synchronized, or reopened.

**PR size labeling:**

* Added a workflow step in `.github/workflows/labeler.yml` to label PRs by size (xs, s, m, l, xl) and optionally warn for extremely large PRs, ignoring certain files from size calculation.