### PR TITLE
Enhanced `.github/dependabot.yml` to include Python (pip) package monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,32 @@
 version: 2
 
 updates:
-  # This will check for updates to github actions every day
-  # https://docs.github.com/en/enterprise-server@3.4/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+  # Check for updates to GitHub Actions daily
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Check for Python dependency updates weekly
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    # Group minor and patch updates together
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Fixes: #1473 

### Description
Enhanced Dependabot configuration for automated weekly dependency updates.

### Tasks
- [x] Update `.github/dependabot.yml`
- [x] Enable weekly checks for Python (pip) packages
- [x] Configure proper labels for dependency PRs
- [x] Group minor and patch updates to reduce PR volume
- [x] Submit a PR with the enhanced configuration

### Changes
Updated the existing Dependabot configuration to monitor:
- **GitHub Actions**: Daily updates (already configured)
- **Python (pip)**: Weekly updates every Monday (newly added)

Added features:
- PR limits to prevent overwhelming the repository
- Automatic labeling (`dependencies`, `python`, `github-actions`)
- Grouped minor and patch updates for cleaner PR management
