### PR TITLE
Add greetings workflow to welcome first-time contributors

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -24,14 +24,12 @@ jobs:
             **A few tips to get your issue processed quickly**
             * Please add a minimal reproduction or example (if relevant).
             * Link to any related issue or PR.
-            * See our contribution guide: http://openml.github.io/openml-python/latest/#contributing
+            * See our contribution guide: https://openml.github.io/openml-python/latest/#contributing
             
             If you're new to contributing, welcome — maintainers will review this shortly.
           pr-opened-msg: |
             Hi @${{ github.actor }} :tada: — thanks for your first pull request to **openml-python**!
             
-            **To help reviewers:**
-            * Please follow our Pull Request template when opening a PR.
-
+            Please follow our Pull Request template when opening a PR.
             
-            Read our contribution guidelines here: http://openml.github.io/openml-python/latest/#contributing
+            Read our contribution guidelines here: https://openml.github.io/openml-python/latest/#contributing


### PR DESCRIPTION
### Summary
This PR adds a GitHub Actions workflow `.github/workflows/greetings.yml` that posts friendly guidance when a first-time contributor opens an issue or a pull request. It uses `actions/first-interaction@v3`.

### What I changed
- Added `.github/workflows/greetings.yml` with messages linking to CONTRIBUTING.md and quick tips for issue/PR descriptions.

### Why
Improve contributor experience and reduce review friction by prompting new contributors to include key details.

### Test plan
1. After the merge, open a test issue/PR from an account that hasn't interacted with this repo to verify the comment is posted.
2. Confirm the workflow run in Actions shows success and that the comment contains the supplied links.
3. If permission errors occur, check Actions run logs and repository settings for workflow permissions.

### Notes
- The message text is editable; maintainers can tweak links or tone.
- We used `pull_request_target` to allow commenting on PRs created from forks.
