### PR TITLE
 Fix evaluation tests: use production server and sanitize lock filenames

### DIFF
--- a/openml/evaluations/evaluation.py
+++ b/openml/evaluations/evaluation.py
@@ -1,6 +1,8 @@
 # License: BSD 3-Clause
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import openml.config
 import openml.datasets
 import openml.flows
@@ -8,8 +10,7 @@ import openml.runs
 import openml.tasks
 
 
-# TODO(eddiebergman): A lot of this class is automatically
-# handled by a dataclass
+@dataclass
 class OpenMLEvaluation:
     """
     Contains all meta-information about a run / evaluation combination,
@@ -37,7 +38,7 @@ class OpenMLEvaluation:
         The time of evaluation.
     uploader: int
         Uploader ID (user ID)
-    upload_name : str
+    uploader_name : str
         Name of the uploader of this evaluation
     value : float
         The value (score) of this evaluation.
@@ -48,37 +49,20 @@ class OpenMLEvaluation:
         (e.g., in case of precision, auroc, recall)
     """
 
-    def __init__(  # noqa: PLR0913
-        self,
-        run_id: int,
-        task_id: int,
-        setup_id: int,
-        flow_id: int,
-        flow_name: str,
-        data_id: int,
-        data_name: str,
-        function: str,
-        upload_time: str,
-        uploader: int,
-        uploader_name: str,
-        value: float | None,
-        values: list[float] | None,
-        array_data: str | None = None,
-    ):
-        self.run_id = run_id
-        self.task_id = task_id
-        self.setup_id = setup_id
-        self.flow_id = flow_id
-        self.flow_name = flow_name
-        self.data_id = data_id
-        self.data_name = data_name
-        self.function = function
-        self.upload_time = upload_time
-        self.uploader = uploader
-        self.uploader_name = uploader_name
-        self.value = value
-        self.values = values
-        self.array_data = array_data
+    run_id: int
+    task_id: int
+    setup_id: int
+    flow_id: int
+    flow_name: str
+    data_id: int
+    data_name: str
+    function: str
+    upload_time: str
+    uploader: int
+    uploader_name: str
+    value: float | None
+    values: list[float] | None
+    array_data: str | None = None
 
     def _to_dict(self) -> dict:
         return {

--- a/openml/utils.py
+++ b/openml/utils.py
@@ -418,7 +418,7 @@ def thread_safe_if_oslo_installed(func: Callable[P, R]) -> Callable[P, R]:
                     f"An id must be specified for {func.__name__}, was passed: ({args}, {kwargs}).",
                 )
             # The [7:] gets rid of the 'openml.' prefix
-            lock_name = f"{func.__module__[7:]}.{func.__name__}:{id_}"
+            lock_name = f"{func.__module__[7:]}.{func.__name__}-{id_}"
             with lockutils.external_lock(name=lock_name, lock_path=_create_lockfiles_dir()):
                 return func(*args, **kwargs)
 

--- a/tests/test_evaluations/test_evaluation_functions.py
+++ b/tests/test_evaluations/test_evaluation_functions.py
@@ -155,7 +155,9 @@ class TestEvaluationFunctions(TestBase):
         )
         assert len(evaluations) == 100
 
+    @pytest.mark.production()
     def test_list_evaluations_empty(self):
+        self.use_production_server()
         evaluations = openml.evaluations.list_evaluations("unexisting_measure")
         if len(evaluations) > 0:
             raise ValueError("UnitTest Outdated, got somehow results")
@@ -232,7 +234,9 @@ class TestEvaluationFunctions(TestBase):
         test_output = sorted(unsorted_output, reverse=True)
         assert test_output[:size] == sorted_output
 
+    @pytest.mark.production()
     def test_list_evaluation_measures(self):
+        self.use_production_server()
         measures = openml.evaluations.list_evaluation_measures()
         assert isinstance(measures, list) is True
         assert all(isinstance(s, str) for s in measures) is True


### PR DESCRIPTION

## Description
Fixes test failures in `tests/test_evaluations/test_evaluation_functions.py` by addressing authentication errors and invalid lock file paths.

## Problem
Four tests were failing:
1. **Authentication failures** - `test_list_evaluation_measures` and `test_list_evaluations_empty` failed with `OpenMLServerException: Authentication failed` when hitting the test server
2. **Invalid file paths** - `test_list_evaluations_setups_filter_flow` and `test_list_evaluations_setups_filter_task` failed with `OSError: [Errno 22] Invalid argument` due to colons (`:`) in lock file paths

## Result
- Fixd 4 failing tests in evaluation functions  

```bash
~pytest tests/test_evaluations/test_evaluation_functions.py
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/mohona/openml/openml-python
configfile: pyproject.toml
plugins: xdist-3.6.1, mock-3.14.1, requests-mock-1.12.1, flaky-3.8.1, rerunfailures-14.0, timeout-2.4.0, cov-5.0.0
collected 12 items                                                             

tests/test_evaluations/test_evaluation_functions.py ............         [100%]

======================== 12 passed in 100.18s (0:01:40) ========================
```