### PR TITLE
Add CLI commands for browsing and searching OpenML tasks

### DIFF
--- a/tests/test_openml/test_cli.py
+++ b/tests/test_openml/test_cli.py
@@ -1,0 +1,218 @@
+# License: BSD 3-Clause
+from __future__ import annotations
+
+import argparse
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from openml import cli
+
+
+class TestTasksCLI:
+    """Test suite for tasks CLI commands."""
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_list_basic(self, mock_list):
+        """Test basic task listing."""
+        mock_df = pd.DataFrame({
+            "tid": [1, 2, 3],
+            "task_type": ["Supervised Classification", "Supervised Regression", "Clustering"],
+            "did": [61, 62, 63],
+        })
+        mock_list.return_value = mock_df
+
+        args = argparse.Namespace(
+            offset=None,
+            size=10,
+            tag=None,
+            task_type=None,
+            status=None,
+            data_name=None,
+            format="table",
+            verbose=False,
+        )
+
+        cli.tasks_list(args)
+        mock_list.assert_called_once_with(offset=None, size=10)
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_list_with_filters(self, mock_list):
+        """Test task listing with filters."""
+        mock_df = pd.DataFrame({
+            "tid": [1],
+            "task_type": ["Supervised Classification"],
+        })
+        mock_list.return_value = mock_df
+
+        args = argparse.Namespace(
+            offset=0,
+            size=5,
+            tag="study_14",
+            task_type="Supervised Classification",
+            status="active",
+            data_name=None,
+            format="table",
+            verbose=False,
+        )
+
+        cli.tasks_list(args)
+        mock_list.assert_called_once_with(
+            offset=0,
+            size=5,
+            tag="study_14",
+            task_type="Supervised Classification",
+            status="active",
+        )
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_list_empty_results(self, mock_list):
+        """Test handling of empty results."""
+        mock_list.return_value = pd.DataFrame()
+
+        args = argparse.Namespace(
+            offset=None,
+            size=None,
+            tag=None,
+            task_type=None,
+            status=None,
+            data_name=None,
+            format="table",
+            verbose=False,
+        )
+
+        cli.tasks_list(args)
+        mock_list.assert_called_once()
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_list_json_format(self, mock_list):
+        """Test JSON output format."""
+        mock_df = pd.DataFrame({"tid": [1], "task_type": ["Supervised Classification"]})
+        mock_list.return_value = mock_df
+
+        args = argparse.Namespace(
+            offset=None,
+            size=10,
+            tag=None,
+            task_type=None,
+            status=None,
+            data_name=None,
+            format="json",
+            verbose=False,
+        )
+
+        cli.tasks_list(args)
+        mock_list.assert_called_once()
+
+    @mock.patch("openml.tasks.get_task")
+    def test_tasks_info(self, mock_get):
+        """Test task info display."""
+        mock_task = mock.Mock()
+        mock_task.task_id = 1
+        mock_task.task_type = "Supervised Classification"
+        mock_task.dataset_id = 61
+        mock_task.estimation_procedure = {"type": "crossvalidation"}
+        mock_task.evaluation_measure = "predictive_accuracy"
+        mock_task.target_name = "class"
+        mock_task.class_labels = ["Iris-setosa", "Iris-versicolor", "Iris-virginica"]
+        mock_get.return_value = mock_task
+
+        args = argparse.Namespace(task_id="1")
+
+        cli.tasks_info(args)
+        mock_get.assert_called_once_with(1)
+
+    @mock.patch("openml.tasks.get_task")
+    def test_tasks_info_error(self, mock_get):
+        """Test task info with invalid ID."""
+        mock_get.side_effect = Exception("Task not found")
+
+        args = argparse.Namespace(task_id="99999")
+
+        with pytest.raises(SystemExit):
+            cli.tasks_info(args)
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_search_found(self, mock_list):
+        """Test search with results."""
+        mock_df = pd.DataFrame({
+            "tid": [1],
+            "data_name": ["iris"],
+        })
+        mock_list.return_value = mock_df
+
+        args = argparse.Namespace(
+            query="iris",
+            size=20,
+            format="table",
+            verbose=False,
+        )
+
+        cli.tasks_search(args)
+        mock_list.assert_called()
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_search_not_found(self, mock_list):
+        """Test search with no results."""
+        mock_list.return_value = pd.DataFrame()
+
+        args = argparse.Namespace(
+            query="nonexistent",
+            size=20,
+            format="table",
+            verbose=False,
+        )
+
+        cli.tasks_search(args)
+        assert mock_list.call_count >= 1
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_search_case_insensitive(self, mock_list):
+        """Test case-insensitive search."""
+        # First call returns empty (no exact match)
+        # Second call returns all tasks for client-side filtering
+        mock_list.side_effect = [
+            pd.DataFrame(),  # No exact match
+            pd.DataFrame({
+                "tid": [1, 2],
+                "data_name": ["Iris", "IRIS-versicolor"],
+            }),
+        ]
+
+        args = argparse.Namespace(
+            query="iris",
+            size=20,
+            format="table",
+            verbose=False,
+        )
+
+        cli.tasks_search(args)
+        assert mock_list.call_count == 2
+
+    def test_tasks_handler_no_action(self):
+        """Test tasks handler with no action specified."""
+        args = argparse.Namespace(tasks_action=None)
+
+        with pytest.raises(SystemExit):
+            cli.tasks_handler(args)
+
+    @mock.patch("openml.tasks.list_tasks")
+    def test_tasks_handler_list_action(self, mock_list):
+        """Test tasks handler routes list action correctly."""
+        mock_list.return_value = pd.DataFrame({"tid": [1], "task_type": ["test"]})
+
+        args = argparse.Namespace(
+            tasks_action="list",
+            offset=None,
+            size=5,
+            tag=None,
+            task_type=None,
+            status=None,
+            data_name=None,
+            format="table",
+            verbose=False,
+        )
+
+        cli.tasks_handler(args)
+        mock_list.assert_called_once()


### PR DESCRIPTION
#### Metadata
* Reference Issue:   [(Enhancement: Add CLI commands for browsing and searching OpenML flows)](feat: Add CLI Commands for Browsing and Searching OpenML Tasks #1504)](https://github.com/openml/openml-python/issues/1504)
* New Tests Added: Yes
* Documentation Updated: No (CLI help text serves as documentation)
* Change Log Entry: "Add CLI commands for browsing and searching OpenML tasks: `openml tasks list`, `openml tasks info`, and `openml tasks search`"

#### Details 

**What does this PR implement/fix?**

This PR adds three new CLI subcommands under `openml tasks` to improve the user experience of the task catalogue:

- `openml tasks list` - List tasks with optional filtering (tag, task-type, status, data-name, pagination, output format)
- `openml tasks info <task_id>` - Display detailed information about a specific task including task type, dataset, target feature, evaluation measure, and class labels
- `openml tasks search <query>` - Search tasks by associated dataset name with case-insensitive matching

**Why is this change necessary? What is the problem it solves?**

Currently, users must write Python code to browse or search OpenML tasks, even for simple operations like listing available tasks or finding tasks for a specific dataset. This creates a barrier to entry and makes the task catalogue less accessible. Adding CLI commands allows users to interact with the task catalogue directly from the command line without writing code.

This directly addresses the ESoC 2025 goal of "Improving user experience of the task catalogue in AIoD and OpenML".

**How can I reproduce the issue this PR is solving and its solution?**

**Before (requires Python code):**
```python
import openml
tasks = openml.tasks.list_tasks(size=10)
for tid in tasks:
    task = openml.tasks.get_task(tid)
    print(f"{tid}: {task.task_type}")```
After (CLI commands):
```
bash
# List first 10 tasks
openml tasks list --size 10

# Search for tasks related to iris dataset
openml tasks search iris

# Get detailed info about a task
openml tasks info 1

# List classification tasks with a specific tag
openml tasks list --task-type "Supervised Classification" --tag study_14 --format table

# List tasks with pagination
openml tasks list --offset 20 --size 10```
**Implementation Details:**

Added three new functions in 
openml/cli.py: tasks_list(), tasks_info() , and  tasks_search()
Added handler function 
tasks_handler() to route subcommands
Integrated into main CLI parser with proper argument handling
Added comprehensive test suite in  tests/test_openml/test_cli.py
 
Uses existing openml.tasks.list_tasks() and openml.tasks.get_task() functions - no changes to core API
Follows existing CLI patterns (similar to 
configure
 command)
All tests use mocked API calls to avoid requiring server connections
**Any other comments?**

All pre-commit hooks pass (ruff, mypy, formatting)
No breaking changes
Follows project code style and patterns
Ready for review

