### PR TITLE
Modernize _delete_entity with Literal typing and f-string formatting

### DIFF
--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -147,22 +147,18 @@ class BaseStudy(OpenMLBase):
         # some can not be uploaded, e.g., id, creator, creation_date
         simple_props = ["alias", "main_entity_type", "name", "description"]
 
-        # TODO(eddiebergman): Begging for a walrus if we can drop 3.7
         simple_prop_values = {}
         for prop_name in simple_props:
-            content = getattr(self, prop_name, None)
-            if content is not None:
+            if (content := getattr(self, prop_name, None)) is not None:
                 simple_prop_values["oml:" + prop_name] = content
 
         # maps from attribute name (which is used as outer tag name) to immer
         # tag name e.g., self.tasks -> <oml:tasks><oml:task_id>1987</oml:task_id></oml:tasks>
         complex_props = {"tasks": "task_id", "runs": "run_id"}
 
-        # TODO(eddiebergman): Begging for a walrus if we can drop 3.7
         complex_prop_values = {}
         for prop_name, inner_name in complex_props.items():
-            content = getattr(self, prop_name, None)
-            if content is not None:
+            if (content := getattr(self, prop_name, None)) is not None:
                 complex_prop_values["oml:" + prop_name] = {"oml:" + inner_name: content}
 
         return {


### PR DESCRIPTION
Modernizes _to_dict by replacing temporary variables with walrus operator assignments and removing outdated Python 3.7 comments.

- Replaced content = getattr(...) + if with walrus operator for brevity.
- Removed legacy TODO notes about dropping Python 3.7.
- Improved readability and reduced repetition in both simple and complex property handling.