### PR TITLE
 Add integration test for regression task split integrity (Task 2280)

### DIFF
--- a/tests/test_tasks/test_regression_task_splits.py
+++ b/tests/test_tasks/test_regression_task_splits.py
@@ -1,0 +1,54 @@
+# License: BSD 3-Clause
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import openml
+from openml.testing import TestBase
+
+class OpenMLRegressionTaskSplitTest(TestBase):
+    __test__ = True
+
+    def setUp(self):
+        super().setUp()
+        self.use_production_server()
+
+    @pytest.mark.production()
+    def test_10_fold_cv_splits_integrity(self):
+        # task 2280; regression; 10-fold cv
+        task_id = 2280
+        task = openml.tasks.get_task(task_id)
+        
+        self.assertEqual(task.task_type_id, openml.tasks.TaskType.SUPERVISED_REGRESSION)
+        
+        repeats, folds, _ = task.get_split_dimensions()
+        self.assertEqual(folds, 10, "Task 2280 should have 10 folds")
+        self.assertEqual(repeats, 1, "Task 2280 should have 1 repeat")
+        
+        # track all test indices to ensure full coverage
+        all_test_indices = set()
+        
+        X, _ = task.get_X_and_y()
+        n_instances = X.shape[0]
+        
+        for fold in range(folds):
+            train_indices, test_indices = task.get_train_test_split_indices(fold=fold)
+            
+            self.assertIsInstance(train_indices, np.ndarray)
+            self.assertIsInstance(test_indices, np.ndarray)
+            
+            intersection = np.intersect1d(train_indices, test_indices)
+            self.assertEqual(len(intersection), 0, f"Fold {fold}: Train and test indices overlap")
+            
+            self.assertTrue(np.all(train_indices < n_instances), f"Fold {fold}: Train indices out of bounds")
+            self.assertTrue(np.all(test_indices < n_instances), f"Fold {fold}: Test indices out of bounds")
+            self.assertTrue(np.all(train_indices >= 0), f"Fold {fold}: Train indices negative")
+            self.assertTrue(np.all(test_indices >= 0), f"Fold {fold}: Test indices negative")
+            
+            all_test_indices.update(test_indices)
+            
+        # assert that the union of all test sets covers the entire dataset
+        # specific to cross validation (not holdout)
+        self.assertEqual(len(all_test_indices), n_instances, "Union of all test sets should cover the entire dataset")
+        expected_indices = set(range(n_instances))
+        self.assertEqual(all_test_indices, expected_indices, "Test indices should match all instance indices")


### PR DESCRIPTION
## Metadata
| Item                     | Value |
|--------------------------|-------|
| **Reference Issue**      | NA |
| **New Tests Added**      | Yes |
| **Documentation Updated**| No |
| **Change Log Entry**     | Add integration test for regression task split integrity (Task 2280) |

## Description
### What does this PR implement?
- Adds a new integration test [tests/test_tasks/test_regression_task_splits.py](cci:7://file:///home/hxrshxz/Desktop/openml-python/tests/test_tasks/test_regression_task_splits.py:0:0-0:0).
- The test validates the split logic of a real regression task (OpenML task 2280):
  1. Confirms the task type is `SUPERVISED_REGRESSION`.
  2. Checks that the task uses 10‑fold cross‑validation with a single repeat.
  3. Verifies that train and test indices are NumPy arrays, non‑overlapping, and within dataset bounds.
  4. Ensures the union of all test indices covers the entire dataset.

### Why is this change necessary?
- Existing tests cover classification and clustering tasks but lack regression split verification.
- Correct split handling is essential for reproducible experiments and for downstream UI components that consume OpenML data.

### How to run the test
```bash
# From the repository root (virtual environment activated)
pytest tests/test_tasks/test_regression_task_splits.py