### PR TITLE
[BUG] remove accidental skip of `test_get_flow_with_reinstantiate_strict_with_wrong_version_raises_exception`

### DIFF
--- a/tests/test_flows/test_flow_functions.py
+++ b/tests/test_flows/test_flow_functions.py
@@ -338,7 +338,6 @@ class TestFlowFunctions(TestBase):
         reason="Requires scikit-learn!=0.19.1, because target flow is from that version.",
     )
     @pytest.mark.production()
-    @pytest.mark.xfail(reason="failures_issue_1544", strict=False)
     def test_get_flow_with_reinstantiate_strict_with_wrong_version_raises_exception(self):
         self.use_production_server()
         flow = 8175


### PR DESCRIPTION
#### Metadata
* Reference Issue: fixes #1617 
* New Tests Added: No
* Documentation Updated: No

