### PR TITLE
Add information about automated Copilot reviewing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,10 @@ Drafts often benefit from the inclusion of a
 [task list](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
 in the PR description.
 
+We integrated automated Copilot reviews for new pull requests as an experimental features. 
+If you have tokens available the Copilot bot will automatically submit a review.
+If you experience issues with this feature, please create an issue
+
 --- 
 
 # Appendix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ in the PR description.
 
 We integrated automated Copilot reviews for new pull requests as an experimental features. 
 If you have tokens available the Copilot bot will automatically submit a review.
-If you experience issues with this feature, please create an issue
+If you experience issues with this feature, please create an issue.
 
 --- 
 


### PR DESCRIPTION
This change informs a user in the contributing document that we have copilot reviewing enabled.