### PR TITLE
[MNT] Define `__version__` in `__init__.py`

### DIFF
--- a/openml/__init__.py
+++ b/openml/__init__.py
@@ -18,6 +18,8 @@ In particular, this module implements a python interface for the
 # License: BSD 3-Clause
 from __future__ import annotations
 
+__version__ = "0.16.0"
+
 from . import (
     _api_calls,
     config,
@@ -87,9 +89,6 @@ def populate_cache(
     if run_ids is not None:
         for run_id in run_ids:
             runs.functions.get_run(run_id)
-
-
-__version__ = "0.16.0"
 
 
 __all__ = [

--- a/openml/__init__.py
+++ b/openml/__init__.py
@@ -32,7 +32,6 @@ from . import (
     tasks,
     utils,
 )
-from .__version__ import __version__
 from .datasets import OpenMLDataFeature, OpenMLDataset
 from .evaluations import OpenMLEvaluation
 from .flows import OpenMLFlow
@@ -107,7 +106,6 @@ __all__ = [
     "OpenMLStudy",
     "OpenMLSupervisedTask",
     "OpenMLTask",
-    "__version__",
     "_api_calls",
     "config",
     "datasets",
@@ -121,3 +119,6 @@ __all__ = [
     "tasks",
     "utils",
 ]
+
+
+__version__ = "0.16.0"

--- a/openml/__init__.py
+++ b/openml/__init__.py
@@ -89,6 +89,9 @@ def populate_cache(
             runs.functions.get_run(run_id)
 
 
+__version__ = "0.16.0"
+
+
 __all__ = [
     "OpenMLBenchmarkSuite",
     "OpenMLClassificationTask",
@@ -106,6 +109,7 @@ __all__ = [
     "OpenMLStudy",
     "OpenMLSupervisedTask",
     "OpenMLTask",
+    "__version__",
     "_api_calls",
     "config",
     "datasets",
@@ -119,6 +123,3 @@ __all__ = [
     "tasks",
     "utils",
 ]
-
-
-__version__ = "0.16.0"

--- a/openml/__version__.py
+++ b/openml/__version__.py
@@ -1,8 +1,0 @@
-"""Version information."""
-
-# License: BSD 3-Clause
-
-# The following line *must* be the last in the module, exactly as formatted:
-from __future__ import annotations
-
-__version__ = "0.16.0"

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -19,8 +19,7 @@ import requests.utils
 import xmltodict
 from urllib3 import ProxyManager
 
-from . import config
-from .__version__ import __version__
+from . import __version__, config
 from .exceptions import (
     OpenMLHashException,
     OpenMLNotAuthorizedError,

--- a/openml/cli.py
+++ b/openml/cli.py
@@ -9,8 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import urlparse
 
-from openml import config
-from openml.__version__ import __version__
+from openml import __version__, config
 
 
 def is_hex(string_: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openml"
-dynamic = ["version"]  # Will take it from the __version__ file, update there
+dynamic = ["version"]  # Will take it from the __init__ file, update there
 dependencies = [
   "liac-arff>=2.4.0",
   "xmltodict",
@@ -122,7 +122,7 @@ namespaces = false
 openml = ["*.txt", "*.md", "py.typed"]
 
 [tool.setuptools.dynamic]
-version = {attr = "openml.__version__.__version__"}
+version = {attr = "openml.__init__.__version__"}
 
 # https://docs.pytest.org/en/7.2.x/reference/reference.html#ini-options-ref
 [tool.pytest.ini_options]
@@ -191,9 +191,6 @@ exclude = [
 "openml/cli.py" = [
   "T201",   # print found
   "T203",   # pprint found
-]
-"openml/__version__.py" = [
-  "D100",   # Undocumented public module
 ]
 "__init__.py" = [
   "I002",   # Missing required import (i.e. from __future__ import annotations)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ namespaces = false
 openml = ["*.txt", "*.md", "py.typed"]
 
 [tool.setuptools.dynamic]
-version = {attr = "openml.__init__.__version__"}
+version = {attr = "openml.__version__"}
 
 # https://docs.pytest.org/en/7.2.x/reference/reference.html#ini-options-ref
 [tool.pytest.ini_options]


### PR DESCRIPTION
Fixes #1642

This PR removes ` __version__.py` module and defines `__version__` in `__init__.py`, along with changing imports and pyproject configs

cc @geetu040 