### PR TITLE
[MNT] Remove temporary dummy jobs from CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,30 +165,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         verbose: true
-
-  dummy_windows_py_sk024:
-    name: (windows-latest, Py, sk0.24.*, sk-only:false)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dummy step
-        run: |
-          echo "This is a temporary dummy job."
-          echo "Always succeeds."
-
-  dummy_windows_py_sk023:
-    name: (ubuntu-latest, Py3.8, sk0.23.1, sk-only:false)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dummy step
-        run: |
-          echo "This is a temporary dummy job."
-          echo "Always succeeds."
-
-  dummy_docker:
-    name: docker
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dummy step
-        run: |
-          echo "This is a temporary dummy docker job."
-          echo "Always succeeds."


### PR DESCRIPTION

- Removed 3 temporary dummy jobs from `.github/workflows/test.yml`:
  - `dummy_windows_py_sk024`
  - `dummy_windows_py_sk023`
  - `dummy_docker`

These jobs were added in PR #1572 as a temporary workaround when branch protection rules required jobs that no longer existed. They are no longer needed and should be removed.

Fixes #1573