### PR TITLE
Improve error message for estimation_procedure by showing readable names instead of IDs

### DIFF
--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -1,6 +1,7 @@
 # License: BSD 3-Clause
 from __future__ import annotations
-
+from openml.tasks.functions import _get_estimation_procedure_list
+import re
 import contextlib
 import hashlib
 import logging
@@ -507,7 +508,31 @@ def __parse_server_exception(
             additional_information,
         )
     else:
-        full_message = f"{message} - {additional_information}"
+     full_message = f"{message} - {additional_information}"
+
+    # Improve estimation_procedure error message
+    if additional_information and "acceptable inputs" in additional_information:
+        try:
+            import re
+            from openml.tasks.functions import _get_estimation_procedure_list
+
+            # Extract IDs
+            ids = list(map(int, re.findall(r"\d+", additional_information)))
+
+            # Get mapping
+            procedures = _get_estimation_procedure_list()
+            mapping = {p["id"]: p["name"] for p in procedures}
+
+            # Format
+            pretty = [f"{i}: {mapping.get(i, 'Unknown')}" for i in ids]
+
+            full_message = (
+                f"{message} - problematic input: [estimation_procedure],\n"
+                "acceptable inputs:\n" + "\n".join(pretty)
+            )
+
+        except Exception:
+            pass
 
     if code in [
         102,  # flow/exists post

--- a/openml/_api_calls.py
+++ b/openml/_api_calls.py
@@ -1,7 +1,6 @@
 # License: BSD 3-Clause
 from __future__ import annotations
-from openml.tasks.functions import _get_estimation_procedure_list
-import re
+
 import contextlib
 import hashlib
 import logging
@@ -508,12 +507,13 @@ def __parse_server_exception(
             additional_information,
         )
     else:
-     full_message = f"{message} - {additional_information}"
+        full_message = f"{message} - {additional_information}"
 
     # Improve estimation_procedure error message
     if additional_information and "acceptable inputs" in additional_information:
         try:
             import re
+
             from openml.tasks.functions import _get_estimation_procedure_list
 
             # Extract IDs


### PR DESCRIPTION
closes  #1091 
### Summary
Improved error message for invalid estimation procedures by replacing numeric IDs with human-readable names.

### Changes
- Extract estimation procedure IDs from server error message
- Map IDs to names using `_get_estimation_procedure_list()`
- Display readable format instead of numeric IDs

### Before
acceptable inputs: [7, 8, 9]

### After
acceptable inputs:
7: 10-fold Crossvalidation  
8: 5 times 2-fold Crossvalidation  

### Notes
This improves usability by making error messages more understandable for users.

