### PR TITLE
Lower the limit of the list calls to match new server maximum

### DIFF
--- a/openml/evaluations/functions.py
+++ b/openml/evaluations/functions.py
@@ -79,8 +79,9 @@ def list_evaluations(
         the evaluation function. e.g., predictive_accuracy
     offset : int, optional
         the number of runs to skip, starting from the first
-    size : int, default 10000
+    size : int, default 1000
         The maximum number of runs to show.
+        Maximum allowed is 1000.
         If set to ``None``, it returns all the results.
 
     tasks : list[int,str], optional

--- a/openml/utils/_openml.py
+++ b/openml/utils/_openml.py
@@ -249,7 +249,7 @@ def _list_all(  # noqa: C901
     *,
     limit: int | None = None,
     offset: int | None = None,
-    batch_size: int | None = 10_000,
+    batch_size: int | None = 1000,
 ) -> list[_SizedT]:
     """Helper to handle paged listing requests.
 
@@ -279,7 +279,7 @@ def _list_all(  # noqa: C901
     results: list[_SizedT] = []
 
     offset = offset if offset is not None else 0
-    batch_size = batch_size if batch_size is not None else 10_000
+    batch_size = batch_size if batch_size is not None else 1000
 
     LIMIT = limit
     BATCH_SIZE_ORIG = batch_size


### PR DESCRIPTION
The PHP REST API 1.2.6 lowered the maximum limit for setups, runs, and evaluations to 1000. ([ref](https://github.com/openml/OpenML/releases/tag/v1.2.6))
These changes make the default compatible with the new maximum.