### PR TITLE
[MNT] Remove temporary dummy CI jobs from test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,12 +210,3 @@ jobs:
             echo "Not all generated files have been deleted!"
             exit 1
         fi
-
-  dummy_windows_py_sk024:
-    name: (windows-latest, Py, sk0.24.*, sk-only:false)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dummy step
-        run: |
-          echo "This is a temporary dummy job."
-          echo "Always succeeds."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,21 +219,3 @@ jobs:
         run: |
           echo "This is a temporary dummy job."
           echo "Always succeeds."
-
-  dummy_windows_py_sk023:
-    name: (ubuntu-latest, Py3.8, sk0.23.1, sk-only:false)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dummy step
-        run: |
-          echo "This is a temporary dummy job."
-          echo "Always succeeds."
-
-  dummy_docker:
-    name: docker
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dummy step
-        run: |
-          echo "This is a temporary dummy docker job."
-          echo "Always succeeds."


### PR DESCRIPTION
Removes the 3 temporary dummy CI jobs added in #1572 as a workaround  when branch protection rules still required jobs that no longer existed:

- dummy_windows_py_sk024
- dummy_windows_py_sk023  
- dummy_docker

The prerequisite — removing these from branch protection settings — was 
completed by @PGijsbers on Mar 4, 2026 (see #1688). 

This is a clean re-attempt after the previous PR was closed due to 
unresolved merge conflicts.

Fixes #1573