### PR TITLE
[FIX] Show malformed XML response details

### DIFF
--- a/openml/_api/clients/http.py
+++ b/openml/_api/clients/http.py
@@ -453,14 +453,17 @@ class HTTPClient:
             code, message = self._parse_exception_response(response)
 
         except (requests.exceptions.JSONDecodeError, xml.parsers.expat.ExpatError) as e:
-            if method != "GET":
-                extra = f"Status code: {response.status_code}\n{response.text}"
-                raise OpenMLServerError(
-                    f"Unexpected server error when calling {url}. Please contact the "
-                    f"developers!\n{extra}"
-                ) from e
+            extra = f"Status code: {response.status_code}\n{response.text}"
+            parse_error = OpenMLServerError(
+                f"Unexpected server error when calling {url}. Please contact the "
+                f"developers!\n{extra}"
+            )
 
-            exception = e
+            if method != "GET":
+                raise parse_error from e
+
+            parse_error.__cause__ = e
+            exception = parse_error
 
         except Exception as e:
             # If we failed to parse it out,

--- a/tests/test_api/test_http.py
+++ b/tests/test_api/test_http.py
@@ -6,7 +6,7 @@ import hashlib
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
 from openml.enums import APIVersion
-from openml.exceptions import OpenMLAuthenticationError
+from openml.exceptions import OpenMLAuthenticationError, OpenMLServerError
 from openml._api import HTTPClient, HTTPCache
 import openml
 
@@ -160,8 +160,29 @@ def test_get_with_api_key(http_client, sample_path, test_apikey_v1):
 
 @pytest.mark.test_server()
 def test_get_without_api_key_raises(http_client):
-    with openml.config.overwrite_config_context({"apikey": None}), pytest.raises(OpenMLAuthenticationError):
+    with openml.config.overwrite_config_context({"apikey": None}), pytest.raises(
+        OpenMLAuthenticationError
+    ):
         http_client.get("task/1", use_api_key=True)
+
+
+def test_get_with_invalid_error_xml_shows_response(http_client, sample_url_v1):
+    response = Response()
+    response.status_code = 500
+    response._content = b"<invalid"
+    response.headers = {"Content-Type": "text/xml", "Content-Encoding": "gzip"}
+
+    with (
+        openml.config.overwrite_config_context({"connection_n_retries": 1}),
+        patch.object(Session, "request", return_value=response),
+        pytest.raises(OpenMLServerError) as exc_info,
+    ):
+        http_client.get("task/1")
+
+    assert str(exc_info.value) == (
+        f"Unexpected server error when calling {sample_url_v1}. Please contact the developers!\n"
+        "Status code: 500\n<invalid"
+    )
 
 
 @pytest.mark.test_server()


### PR DESCRIPTION
#### Metadata
* Reference Issue: Fixes #986
* New Tests Added: Yes
* Documentation Updated: No
* Change Log Entry: "Show the response status and body when server error XML is malformed"


#### Details 

**What does this PR implement/fix?**

When an unsuccessful GET response contains malformed XML, the HTTP client now preserves its existing retry behavior and ultimately raises `OpenMLServerError` with the request URL, HTTP status, and unparsed response body. The original XML parser exception remains attached as the exception cause.

A deterministic regression test mocks a malformed XML response and verifies the complete user-facing error.

**Root cause**

`HTTPClient._validate_response()` returned the raw `ExpatError` for malformed GET responses. After retries were exhausted, `_request()` raised that parser error directly, so the response details needed to diagnose a server-side failure were lost. Non-GET requests already produced a useful `OpenMLServerError`.

**Testing**

* `.venv/bin/pytest -q tests/test_api/test_http.py` — 13 passed
* `.venv/bin/pytest -q tests/test_api/test_http.py -m 'not test_server'` — 4 passed, 9 deselected
* `.venv/bin/pre-commit run --files openml/_api/clients/http.py tests/test_api/test_http.py` — all configured hooks passed (Ruff, Ruff format, mypy, and repository checks)
* `git diff --check` — passed

**Documentation and compatibility**

No documentation change is required because this does not alter the public API. Successful responses and valid server error responses are unchanged. Malformed GET error responses continue to be retried, but now fail with the existing OpenML exception type and useful diagnostic context.

**Limitations**

The raw response body is included only for malformed error responses, matching the existing non-GET behavior. This change does not alter retry policy or attempt to repair invalid server XML.
