### PR TITLE
[DOC] Update documentation for running tests with local services

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,54 @@ pytest tests
 ```
 For Windows systems, you may need to add `pytest` to PATH before executing the command.
 
+#### Running Tests Against Local Services
+
+The test suite can use a local OpenML service stack instead of the remote test server.
+This requires Docker Desktop and the [`openml/services`](https://github.com/openml/services)
+repository.
+
+From the directory where you want to clone the services repository, run:
+
+```bash
+git clone --depth 1 https://github.com/openml/services.git
+cd services
+chmod -R a+rw ./data
+chmod -R a+rw ./logs
+docker compose --profile rest-api --profile minio --profile evaluation-engine up -d
+```
+
+The permission commands allow the containers to write their local data and logs.
+Wait until the `openml-php-rest-api` container reports a healthy status before running
+the tests. You can also verify the service gateway with:
+
+```bash
+curl -sSfL http://localhost:8000/api/v1/xml/data/1
+```
+
+In a second terminal, from the `openml-python` repository, enable local services and
+run the tests:
+
+```bash
+# Linux/macOS
+export OPENML_USE_LOCAL_SERVICES=true
+pytest -n 4 --durations=20 --dist load -sv -m "not production_server"
+```
+
+On Windows PowerShell, use:
+
+```powershell
+$env:OPENML_USE_LOCAL_SERVICES = "true"
+pytest -sv -m "not production_server"
+```
+
+The `OPENML_USE_LOCAL_SERVICES` variable must be set in the same terminal session
+where pytest is started. To stop the local services after testing, run this from the
+`services` repository:
+
+```bash
+docker compose --profile rest-api --profile minio --profile evaluation-engine down
+```
+
 Executing a specific unit test can be done by specifying the module, test case, and test.
 You may then run a specific module, test case, or unit test respectively:
 ```bash

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -31,26 +31,22 @@ cd services
 
 #### 2. Configure File Permissions
 
-To ensure the containerized PHP service can write to the local filesystem, initialize the data directory permissions.
-
-From the repository root:
-
-```bash
-chown -R www-data:www-data data/php
-```
-
-If the `www-data` user does not exist on the host system, grant full permissions as a fallback:
+To ensure the containers can write to the local filesystem, initialize the data and
+log directory permissions from the services repository root:
 
 ```bash
-chmod -R 777 data/php
+chmod -R a+rw ./data
+chmod -R a+rw ./logs
 ```
+
+These permissions are required before starting the Docker services.
 
 #### 3. Launch Services
 
 Initialize the container stack:
 
 ```bash
-docker compose --profile all up -d
+docker compose --profile rest-api --profile minio --profile evaluation-engine up -d
 ```
 
 #### Warning: Container Conflicts
@@ -58,8 +54,8 @@ docker compose --profile all up -d
 If API v2 (Python backend) containers are present on the system, name conflicts may occur. To resolve this, stop and remove existing containers before launching API v1:
 
 ```bash
-docker compose --profile all down
-docker compose --profile all up -d
+docker compose --profile rest-api --profile minio --profile evaluation-engine down
+docker compose --profile rest-api --profile minio --profile evaluation-engine up -d
 ```
 
 #### 4. Verification


### PR DESCRIPTION
## Metadata

- Reference Issue: Fixes #1708
- New Tests Added: No
- Documentation Updated: Yes
- Change Log Entry: Document running tests with local services

## Details

This pull request updates the contributor documentation for running tests against local OpenML services.

Changes:
- Document the required permissions for the local `data` and `logs` directories.
- Document the Docker Compose profiles required to start the local services.
- Document the `OPENML_USE_LOCAL_SERVICES` environment variable.
- Add pytest commands for Linux/macOS and Windows PowerShell.
- Add local service verification and cleanup instructions.

This addresses the documentation gap introduced by the switch to Docker-based local services in #1697.