### PR TITLE
Add attach_runs/detach_runs to OpenMLStudy and attach_tasks/detach_tasks to OpenMLBenchmarkSuite

### DIFF
--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -296,7 +296,7 @@ class OpenMLStudy(BaseStudy):
             raise ValueError(
                 "Cannot attach runs to an unpublished study. Please publish the study first.",
             )
-        result = openml.study.functions.attach_to_study(self.id, run_ids)
+        result = openml.study.attach_to_study(self.id, run_ids)
         self.runs = (self.runs or []) + list(run_ids)
         return result
 
@@ -322,9 +322,9 @@ class OpenMLStudy(BaseStudy):
             raise ValueError(
                 "Cannot detach runs from an unpublished study. Please publish the study first.",
             )
-        result = openml.study.functions.detach_from_study(self.id, run_ids)
+        result = openml.study.detach_from_study(self.id, run_ids)
         if self.runs is not None:
-            self.runs = [run_id for run_id in self.runs if run_id not in run_ids]
+            self.runs = [run_id for run_id in self.runs if run_id not in set(run_ids)]
         return result
 
 
@@ -419,7 +419,7 @@ class OpenMLBenchmarkSuite(BaseStudy):
             raise ValueError(
                 "Cannot attach tasks to an unpublished suite. Please publish the suite first.",
             )
-        result = openml.study.functions.attach_to_suite(self.id, task_ids)
+        result = openml.study.attach_to_suite(self.id, task_ids)
         self.tasks = (self.tasks or []) + list(task_ids)
         return result
 
@@ -445,7 +445,7 @@ class OpenMLBenchmarkSuite(BaseStudy):
             raise ValueError(
                 "Cannot detach tasks from an unpublished suite. Please publish the suite first.",
             )
-        result = openml.study.functions.detach_from_suite(self.id, task_ids)
+        result = openml.study.detach_from_suite(self.id, task_ids)
         if self.tasks is not None:
-            self.tasks = [task_id for task_id in self.tasks if task_id not in task_ids]
+            self.tasks = [task_id for task_id in self.tasks if task_id not in set(task_ids)]
         return result

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -274,6 +274,61 @@ class OpenMLStudy(BaseStudy):
             setups=setups,
         )
 
+    def attach_runs(self, run_ids: list[int]) -> int:
+        """Attach runs to this study.
+
+        Parameters
+        ----------
+        run_ids : list[int]
+            List of run ids to attach to this study.
+
+        Returns
+        -------
+        int
+            The new number of linked entities in the study.
+
+        Raises
+        ------
+        ValueError
+            If the study has not been published yet.
+        """
+        if self.id is None:
+            raise ValueError(
+                "Cannot attach runs to an unpublished study. "
+                "Please publish the study first.",
+            )
+        result = openml.study.functions.attach_to_study(self.id, run_ids)
+        self.runs = (self.runs or []) + list(run_ids)
+        return result
+
+    def detach_runs(self, run_ids: list[int]) -> int:
+        """Detach runs from this study.
+
+        Parameters
+        ----------
+        run_ids : list[int]
+            List of run ids to detach from this study.
+
+        Returns
+        -------
+        int
+            The new number of linked entities in the study.
+
+        Raises
+        ------
+        ValueError
+            If the study has not been published yet.
+        """
+        if self.id is None:
+            raise ValueError(
+                "Cannot detach runs from an unpublished study. "
+                "Please publish the study first.",
+            )
+        result = openml.study.functions.detach_from_study(self.id, run_ids)
+        if self.runs is not None:
+            self.runs = [run_id for run_id in self.runs if run_id not in run_ids]
+        return result
+
 
 class OpenMLBenchmarkSuite(BaseStudy):
     """
@@ -343,3 +398,58 @@ class OpenMLBenchmarkSuite(BaseStudy):
             runs=None,
             setups=None,
         )
+
+    def attach_tasks(self, task_ids: list[int]) -> int:
+        """Attach tasks to this benchmark suite.
+
+        Parameters
+        ----------
+        task_ids : list[int]
+            List of task ids to attach to this suite.
+
+        Returns
+        -------
+        int
+            The new number of linked entities in the suite.
+
+        Raises
+        ------
+        ValueError
+            If the suite has not been published yet.
+        """
+        if self.id is None:
+            raise ValueError(
+                "Cannot attach tasks to an unpublished suite. "
+                "Please publish the suite first.",
+            )
+        result = openml.study.functions.attach_to_suite(self.id, task_ids)
+        self.tasks = (self.tasks or []) + list(task_ids)
+        return result
+
+    def detach_tasks(self, task_ids: list[int]) -> int:
+        """Detach tasks from this benchmark suite.
+
+        Parameters
+        ----------
+        task_ids : list[int]
+            List of task ids to detach from this suite.
+
+        Returns
+        -------
+        int
+            The new number of linked entities in the suite.
+
+        Raises
+        ------
+        ValueError
+            If the suite has not been published yet.
+        """
+        if self.id is None:
+            raise ValueError(
+                "Cannot detach tasks from an unpublished suite. "
+                "Please publish the suite first.",
+            )
+        result = openml.study.functions.detach_from_suite(self.id, task_ids)
+        if self.tasks is not None:
+            self.tasks = [task_id for task_id in self.tasks if task_id not in task_ids]
+        return result

--- a/openml/study/study.py
+++ b/openml/study/study.py
@@ -294,8 +294,7 @@ class OpenMLStudy(BaseStudy):
         """
         if self.id is None:
             raise ValueError(
-                "Cannot attach runs to an unpublished study. "
-                "Please publish the study first.",
+                "Cannot attach runs to an unpublished study. Please publish the study first.",
             )
         result = openml.study.functions.attach_to_study(self.id, run_ids)
         self.runs = (self.runs or []) + list(run_ids)
@@ -321,8 +320,7 @@ class OpenMLStudy(BaseStudy):
         """
         if self.id is None:
             raise ValueError(
-                "Cannot detach runs from an unpublished study. "
-                "Please publish the study first.",
+                "Cannot detach runs from an unpublished study. Please publish the study first.",
             )
         result = openml.study.functions.detach_from_study(self.id, run_ids)
         if self.runs is not None:
@@ -419,8 +417,7 @@ class OpenMLBenchmarkSuite(BaseStudy):
         """
         if self.id is None:
             raise ValueError(
-                "Cannot attach tasks to an unpublished suite. "
-                "Please publish the suite first.",
+                "Cannot attach tasks to an unpublished suite. Please publish the suite first.",
             )
         result = openml.study.functions.attach_to_suite(self.id, task_ids)
         self.tasks = (self.tasks or []) + list(task_ids)
@@ -446,8 +443,7 @@ class OpenMLBenchmarkSuite(BaseStudy):
         """
         if self.id is None:
             raise ValueError(
-                "Cannot detach tasks from an unpublished suite. "
-                "Please publish the suite first.",
+                "Cannot detach tasks from an unpublished suite. Please publish the suite first.",
             )
         result = openml.study.functions.detach_from_suite(self.id, task_ids)
         if self.tasks is not None:

--- a/tests/test_study/test_study_functions.py
+++ b/tests/test_study/test_study_functions.py
@@ -262,3 +262,129 @@ class TestStudyFunctions(TestBase):
         study_list = openml.study.list_studies(status="in_preparation")
         # might fail if server is recently reset
         assert len(study_list) >= 2
+
+    @pytest.mark.test_server()
+    def test_study_attach_runs_object_method(self):
+        run_list = openml.runs.list_runs(size=5)
+        assert len(run_list) == 5
+        run_ids = list(run_list["run_id"])
+
+        study = openml.study.create_study(
+            alias=None,
+            benchmark_suite=None,
+            name="unit tested study attach runs",
+            description="test attach_runs",
+            run_ids=run_ids,
+        )
+        study.publish()
+        TestBase._mark_entity_for_removal("study", study.id)
+        TestBase.logger.info(f"collected from {__file__.split('/')[-1]}: {study.id}")
+
+        study_downloaded = openml.study.get_study(study.id)
+        self.assertSetEqual(set(study_downloaded.runs), set(run_ids))
+
+        # attach more runs using the object method
+        run_list_additional = openml.runs.list_runs(size=3, offset=5)
+        run_list_additional_ids = list(run_list_additional["run_id"])
+        attached_count = study.attach_runs(run_list_additional_ids)
+        assert attached_count == len(run_ids) + len(run_list_additional_ids)
+
+        # verify local state updated
+        self.assertSetEqual(set(study.runs), set(run_ids) | set(run_list_additional_ids))
+
+        study_downloaded = openml.study.get_study(study.id)
+        self.assertSetEqual(set(study_downloaded.runs), set(run_ids) | set(run_list_additional_ids))
+
+        # detach runs using the object method
+        detached_count = study.detach_runs(run_ids)
+        assert detached_count == len(run_list_additional_ids)
+
+        # verify local state updated
+        self.assertSetEqual(set(study.runs), set(run_list_additional_ids))
+
+        study_downloaded = openml.study.get_study(study.id)
+        self.assertSetEqual(set(study_downloaded.runs), set(run_list_additional_ids))
+
+    @pytest.mark.test_server()
+    def test_study_attach_runs_unpublished_raises(self):
+        study = openml.study.create_study(
+            alias=None,
+            benchmark_suite=None,
+            name="unpublished study",
+            description="none",
+            run_ids=None,
+        )
+        with pytest.raises(ValueError, match="Cannot attach runs to an unpublished study"):
+            study.attach_runs([1])
+
+    @pytest.mark.test_server()
+    def test_study_detach_runs_unpublished_raises(self):
+        study = openml.study.create_study(
+            alias=None,
+            benchmark_suite=None,
+            name="unpublished study",
+            description="none",
+            run_ids=None,
+        )
+        with pytest.raises(ValueError, match="Cannot detach runs from an unpublished study"):
+            study.detach_runs([1])
+
+    @pytest.mark.test_server()
+    def test_suite_attach_tasks_object_method(self):
+        fixture_task_ids = [1, 2, 3]
+
+        suite = openml.study.create_benchmark_suite(
+            alias=None,
+            name="unit tested suite attach tasks",
+            description="test attach_tasks",
+            task_ids=fixture_task_ids,
+        )
+        suite.publish()
+        TestBase._mark_entity_for_removal("study", suite.id)
+        TestBase.logger.info(f"collected from {__file__.split('/')[-1]}: {suite.id}")
+
+        suite_downloaded = openml.study.get_suite(suite.id)
+        self.assertSetEqual(set(suite_downloaded.tasks), set(fixture_task_ids))
+
+        # attach more tasks using the object method
+        tasks_additional = [4, 5, 6]
+        attached_count = suite.attach_tasks(tasks_additional)
+        assert attached_count == len(fixture_task_ids) + len(tasks_additional)
+
+        # verify local state updated
+        self.assertSetEqual(set(suite.tasks), set(fixture_task_ids + tasks_additional))
+
+        suite_downloaded = openml.study.get_suite(suite.id)
+        self.assertSetEqual(set(suite_downloaded.tasks), set(fixture_task_ids + tasks_additional))
+
+        # detach tasks using the object method
+        detached_count = suite.detach_tasks(fixture_task_ids)
+        assert detached_count == len(tasks_additional)
+
+        # verify local state updated
+        self.assertSetEqual(set(suite.tasks), set(tasks_additional))
+
+        suite_downloaded = openml.study.get_suite(suite.id)
+        self.assertSetEqual(set(suite_downloaded.tasks), set(tasks_additional))
+
+    @pytest.mark.test_server()
+    def test_suite_attach_tasks_unpublished_raises(self):
+        suite = openml.study.create_benchmark_suite(
+            alias=None,
+            name="unpublished suite",
+            description="none",
+            task_ids=[1],
+        )
+        with pytest.raises(ValueError, match="Cannot attach tasks to an unpublished suite"):
+            suite.attach_tasks([2])
+
+    @pytest.mark.test_server()
+    def test_suite_detach_tasks_unpublished_raises(self):
+        suite = openml.study.create_benchmark_suite(
+            alias=None,
+            name="unpublished suite",
+            description="none",
+            task_ids=[1],
+        )
+        with pytest.raises(ValueError, match="Cannot detach tasks from an unpublished suite"):
+            suite.detach_tasks([1])


### PR DESCRIPTION

<!--
Thanks for contributing a pull request to the OpenML python connector! Please ensure you have taken a look at
the contribution guidelines: https://github.com/openml/openml-python/blob/main/CONTRIBUTING.md#Contributing-Pull-Requests

Please make sure that:

* the title of the pull request is descriptive
* this pull requests is against the `main` branch
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
    * collect files uploaded to test server using _mark_entity_for_removal()
* add the BSD 3-Clause license to any new file created
-->

#### Metadata
* Reference Issue: Fixes #1109 <!-- Example: Fixes #1234 or NA-->
* New Tests Added: Yes <!-- Yes/No/NA -->
* Documentation Updated: No <!-- Yes/No/NA -->
* Change Log Entry: Add attach_runs/detach_runs to OpenMLStudy and attach_tasks/detach_tasks to OpenMLBenchmarkSuite
 <!-- Short String, example: "Add new function `foo()` to module `bar`"; or "Fixes a bug with `bar`" -->


#### Details 
<!--
if necessary, please share the following:

* What does this PR implement/fix? Explain your changes.
* Why is this change necessary? What is the problem it solves?
* How can I reproduce the issue this PR is solving and its solution?
* Any other comments?
-->

- **What does this PR implement/fix?** Adds instance methods `attach_runs(run_ids)` and `detach_runs(run_ids)` to `OpenMLStudy`, and `attach_tasks(task_ids)` and `detach_tasks(task_ids)` to `OpenMLBenchmarkSuite`. These methods delegate to the existing public module-level functions (`openml.study.attach_to_study`, `openml.study.detach_from_study`, `openml.study.attach_to_suite`, `openml.study.detach_from_suite`), update local object state, and raise `ValueError` if the object has not been published yet.

- **Why is this change necessary?** The current API requires passing the study/suite ID back into a module-level function even when the object is already in hand. This is inconsistent with the object-oriented design of the rest of the SDK and makes iterative workflows (e.g., adding runs to a study as they complete on a cluster) unnecessarily verbose.

- **How can I reproduce the issue this PR is solving and its solution?**
  -  Before:
  ```
       openml.study.attach_to_study(study.id, [1, 2, 3])
  ```
  - After:
  ```
    study.attach_runs([1, 2, 3])
  ```
    The object methods behave identically to the module-level functions but operate on the instance directly.

- **Any other comments?** Existing module-level functions are preserved for backward compatibility. New tests cover both successful attach/detach operations against the test server and ValueError guards for unpublished objects. All uploaded test entities are collected for removal using TestBase._mark_entity_for_removal().