### PR TITLE
test: assert holdout task in run function tests

### DIFF
--- a/tests/test_runs/test_run_functions.py
+++ b/tests/test_runs/test_run_functions.py
@@ -224,7 +224,7 @@ class TestRun(TestBase):
     def _rerun_model_and_compare_predictions(self, run_id, model_prime, seed, create_task_obj):
         run = openml.runs.get_run(run_id)
 
-        # TODO: assert holdout task
+        assert run.task.estimation_procedure == "holdout"
 
         # downloads the predictions of the old task
         file_id = run.output_files["predictions"]


### PR DESCRIPTION
## What does this PR do?

Adds an assertion to verify that the run's task uses the holdout estimation procedure.

## Why?

The test helper previously contained a TODO for validating the holdout task.

## Testing

- `python -m pytest tests/test_runs/test_run_functions.py::TestRun::test_run_regression_on_classif_task -x`
- Result: 1 passed