### PR TITLE
[TEST] Re-add sparse dataset row ID and ignore attributes

### DIFF
--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -380,22 +380,29 @@ class OpenMLDatasetTestSparse(TestBase):
         assert rval.shape == (600, 20001)
 
     def test_get_sparse_dataset_rowid_and_ignore_and_target(self):
-        # TODO: re-add row_id and ignore attributes
         self.sparse_dataset.ignore_attribute = ["V256"]
         self.sparse_dataset.row_id_attribute = ["V512"]
-        X, y, categorical, _ = self.sparse_dataset.get_data(
-            target="class",
-            include_row_id=False,
-            include_ignore_attribute=False,
-        )
-        assert all(dtype == pd.SparseDtype(np.float32, fill_value=0.0) for dtype in X.dtypes)
-        # array format returned dense, but now we only return sparse and let the user handle it.
-        assert isinstance(y.dtypes, pd.SparseDtype)
-        assert X.shape == (600, 19998)
 
-        assert len(categorical) == 19998
-        self.assertListEqual(categorical, [False] * 19998)
+        X, y, categorical, attribute_names = self.sparse_dataset.get_data(
+            target="class",
+            include_row_id=True,
+            include_ignore_attribute=True,
+        )
+
+        assert all(
+            dtype == pd.SparseDtype(np.float32, fill_value=0.0)
+            for dtype in X.dtypes
+        )
+        assert isinstance(y.dtypes, pd.SparseDtype)
+        assert X.shape == (600, 20000)
         assert y.shape == (600,)
+
+        assert "V256" in X.columns
+        assert "V512" in X.columns
+        assert "V256" in attribute_names
+        assert "V512" in attribute_names
+
+        self.assertListEqual(categorical, [False] * 20000)
 
     def test_get_sparse_categorical_data_id_395(self):
         dataset = openml.datasets.get_dataset(395, download_data=True)


### PR DESCRIPTION
## Description

Re-adds coverage for row ID and ignored attributes in the sparse dataset test.

## Changes

- Enable `include_row_id=True` and `include_ignore_attribute=True`.
- Verify that the row ID (`V512`) and ignored attribute (`V256`) are returned.
- Verify sparse dtypes and expected output shapes.
- Verify `attribute_names` and categorical metadata.

## Testing

- Targeted sparse dataset test: 1 passed
- Full `tests/test_datasets/test_dataset.py`: 22 passed, 4 skipped
- `git diff --check`: passed

Closes #1644